### PR TITLE
Add inference runtime / normalized runtime as a metric

### DIFF
--- a/src/benchmark/basic_metrics.py
+++ b/src/benchmark/basic_metrics.py
@@ -72,18 +72,14 @@ class BasicMetric(Metric):
     def compute_runtime_metrics(
         self, adapter_spec: AdapterSpec, request_state: RequestState, metric_service: MetricService
     ) -> List[Stat]:
-        """Record runtime"""
+        """Compute per-token normalized runtime"""
         assert request_state.result is not None
 
-        runtime_stat = Stat("runtime")
-        normalized_runtime_stat = Stat("normalized_runtime")
-        for sequence in request_state.result.completions:
-            num_tokens = len(sequence.tokens)
-            runtime = request_state.result.request_time
+        runtime = request_state.result.request_time
+        # Compute total number of tokens across completions
+        num_tokens: int = sum([len(sequence.tokens) for sequence in request_state.result.completions])
 
-            runtime_stat.add(runtime)
-            normalized_runtime_stat.add(runtime / num_tokens)
-        return [runtime_stat, normalized_runtime_stat]
+        return [Stat("runtime").add(runtime), Stat("normalized_runtime").add(runtime / num_tokens)]
 
     def compute_language_modeling_metrics(
         self, adapter_spec: AdapterSpec, request_state: RequestState, metric_service: MetricService


### PR DESCRIPTION
Sample output:

```
...
    343/345: [[test]] "Craig says an actually infinite number of things _____." => "cannot exist", predicted "is possible" [WRONG]
    344/345: [[test]] "Descartes believed that interaction between body and mind took place in _____." => "the pineal gland", predicted "the pineal gland" [CORRECT]
    345/345: [[test]] "Which of the following is a form of harm that might be suffered by research participants?" => "All of the above", predicted "All of the above" [CORRECT]
    Processed 345 requests
  } [21.576s]
  1 metrics
  Stats {
    test.exact_match[min=0.511, mean=0.511, max=0.511, sum=0.511, (1)]
    test.exact_match@10[min=0.511, mean=0.511, max=0.511, sum=0.511, (1)]
    test.logprob[min=-0.681, mean=-0.681, max=-0.681, sum=-0.681, (1)]
    test.num_tokens[min=1.000, mean=1.000, max=1.000, sum=1.000, (1)]
    test.num_bytes[min=2.000, mean=2.000, max=2.000, sum=2.000, (1)]
    test.runtime[min=0.361, mean=0.361, max=0.361, sum=0.361, (1)]
    test.normalized_runtime[min=0.361, mean=0.361, max=0.361, sum=0.361, (1)]
    valid.exact_match[min=0.500, mean=0.500, max=0.500, sum=0.500, (1)]
    valid.exact_match@10[min=0.500, mean=0.500, max=0.500, sum=0.500, (1)]
    valid.logprob[min=-0.574, mean=-0.574, max=-0.574, sum=-0.574, (1)]
    valid.num_tokens[min=1.000, mean=1.000, max=1.000, sum=1.000, (1)]
    valid.num_bytes[min=2.000, mean=2.000, max=2.000, sum=2.000, (1)]
    valid.runtime[min=0.466, mean=0.466, max=0.466, sum=0.466, (1)]
    valid.normalized_runtime[min=0.466, mean=0.466, max=0.466, sum=0.466, (1)]
    valid.perplexity[min=1.489, mean=1.489, max=1.489, sum=1.489, (1)]
    valid.bits_per_byte[min=0.414, mean=0.414, max=0.414, sum=0.414, (1)]
    test.perplexity[min=1.604, mean=1.604, max=1.604, sum=1.604, (1)]
    test.bits_per_byte[min=0.492, mean=0.492, max=0.492, sum=0.492, (1)]
  } [0.0s]

Done.
} [21.826s]
```