### PR TITLE
Fix AI21 caching

### DIFF
--- a/src/proxy/ai21_client.py
+++ b/src/proxy/ai21_client.py
@@ -21,9 +21,10 @@ class AI21Client(Client):
         self.cache = Cache(cache_path)
 
     def make_request(self, request: Request) -> RequestResult:
-        model = request.model
+        model: str = request.model
         if model not in ["ai21/j1-large", "ai21/j1-jumbo"]:
             raise Exception("Invalid model")
+
         raw_request = {
             "prompt": request.prompt,
             "temperature": request.temperature,
@@ -47,7 +48,8 @@ class AI21Client(Client):
             return response
 
         try:
-            cache_key = Client.make_cache_key(raw_request, request)
+            # We need to include the engine's name to differentiate among requests made for different model engines
+            cache_key = Client.make_cache_key({"engine": request.model_engine, **raw_request}, request)
             response, cached = self.cache.get(cache_key, wrap_request_time(do_it))
         except AI21RequestError as e:
             return RequestResult(success=False, cached=False, error=str(e), completions=[])


### PR DESCRIPTION
The Efficiency team discovered this issue. Since we don't specify the engine name in `raw_request` and instead use different URLs for AI21, we don't differentiate between requests for j1-large vs. j1-jumbo when caching. After this fix is merged, we need to redeploy and, unfortunately, blow away the existing AI21 cache used in production.

Before the fix (notice the responses and request times are the same) :

![before](https://user-images.githubusercontent.com/16793796/153538602-c1aa8c4b-5bbf-4dd0-a4e2-1f9a21144782.png)

After the fix:

![after](https://user-images.githubusercontent.com/16793796/153538615-a0fc4b1b-ba30-487c-9010-3e9e66bfe72b.png)