### PR TITLE
augmentation expander naming fix

### DIFF
--- a/src/benchmark/run_expander.py
+++ b/src/benchmark/run_expander.py
@@ -139,7 +139,7 @@ class DataAugmentationRunExpander(RunExpander):
     def expand(self, run_spec: RunSpec) -> List[RunSpec]:
         """Return `run_spec` with data augmentations."""
 
-        def create_run_spec(run_name: str, perturbation_specs: List[PerturbationSpec]) -> RunSpec:
+        def create_run_spec(aug_name: str, perturbation_specs: List[PerturbationSpec]) -> RunSpec:
             data_augmenter_spec: DataAugmenterSpec = DataAugmenterSpec(
                 perturbation_specs=perturbation_specs,
                 should_perturb_references=False,
@@ -152,12 +152,12 @@ class DataAugmentationRunExpander(RunExpander):
             )
             return replace(
                 run_spec,
-                name=f"{run_name},{DataAugmentationRunExpander.name}={self.value}",
+                name=f"{run_spec.name},{DataAugmentationRunExpander.name}={aug_name}",
                 data_augmenter_spec=data_augmenter_spec,
             )
 
         return [
-            create_run_spec(f"{run_spec.name}:{aug_name}", perturbation_specs)
+            create_run_spec(aug_name, perturbation_specs)
             for aug_name, perturbation_specs in PERTURBATION_SPECS_DICT[self.value].items()
         ]
 


### PR DESCRIPTION
Add the original run_spec name so that we write in `boolq:misspelling0.2,data_augmentation=misspelling_sweep` instead of just `misspelling0.2,data_augmentation=misspelling_sweep`.