### PR TITLE
allow comparing run specs side by side

### DIFF
--- a/src/benchmark/adapter.py
+++ b/src/benchmark/adapter.py
@@ -299,6 +299,10 @@ class Adapter:
                 # Create request_states
                 for eval_index, eval_instance in enumerate(eval_instances):
                     prompt: str = self.construct_prompt(train_instances, eval_instance)
+                    hlog(
+                        f"trial {train_trial_index}: construct_prompt {eval_index} (total {len(eval_instances)}): "
+                        f"len(prompt) = {len(prompt)}"
+                    )
 
                     # Just print one prompt (useful for debugging)
                     if train_trial_index == 0 and eval_index == 0:

--- a/src/benchmark/metric.py
+++ b/src/benchmark/metric.py
@@ -4,6 +4,7 @@ from typing import List, Dict
 from math import log, e
 from collections import defaultdict
 
+from common.hierarchical_logger import hlog
 from common.statistic import Stat, merge_stat
 from common.object_spec import ObjectSpec, create_object
 from common.general import singleton
@@ -51,8 +52,9 @@ class Metric(ABC):
             trial_stats: Dict[MetricName, Stat] = {}  # Statistics just for this trial
             # TODO: incorporate disparities (compute difference between average over instances with some tag)
             #       https://github.com/stanford-crfm/benchmarking/issues/48
-            for instance in scenario_state.instances:
+            for instance_index, instance in enumerate(scenario_state.instances):
                 instance_stats = []
+                hlog(f"trial {train_trial_index}: evaluate {instance_index} (total {len(scenario_state.instances)})")
 
                 # Evaluate generated request_state
                 request_state = singleton(scenario_state.get_request_states(train_trial_index, instance, None))

--- a/src/benchmark/presentation/present.py
+++ b/src/benchmark/presentation/present.py
@@ -87,7 +87,7 @@ class AllRunner:
             # Use `dry_run` flag if set, else use what's in the file.
             dry_run = self.dry_run if self.dry_run is not None else status == WIP_STATUS
 
-            run_benchmarking(
+            new_run_specs = run_benchmarking(
                 run_spec_descriptions=[run_spec_description],
                 auth=self.auth,
                 url=self.url,
@@ -97,23 +97,24 @@ class AllRunner:
                 skip_instances=self.skip_instances,
                 max_eval_instances=self.max_eval_instances,
             )
+            run_specs.extend(new_run_specs)
 
-            with open(os.path.join(runs_dir, run_spec_description, "run_spec.json")) as f:
-                run_spec = json.load(f)
-                run_specs.append(run_spec)
-
-            # Get the metric output, so we can display it on the status page
-            metrics_text: str = Path(os.path.join(runs_dir, run_spec_description, "metrics.txt")).read_text()
-            if status == READY_STATUS:
-                ready_content.append(f"{run_spec} - \n{metrics_text}\n")
-            else:
-                wip_content.append(f"{run_spec} - {metrics_text}")
+            for run_spec in new_run_specs:
+                # Get the metric output, so we can display it on the status page
+                metrics_text: str = Path(os.path.join(runs_dir, run_spec.name, "metrics.txt")).read_text()
+                if status == READY_STATUS:
+                    ready_content.append(f"{run_spec} - \n{metrics_text}\n")
+                else:
+                    wip_content.append(f"{run_spec} - {metrics_text}")
 
         # Write out the status page with the WIP RunSpecs first
         status = "\n".join(wip_content + ["", "-" * 150, ""] + ready_content)
         write(os.path.join(self.output_path, "status.txt"), status)
 
-        write(os.path.join(self.output_path, "run_specs.json"), json.dumps(run_specs, indent=2))
+        write(
+            os.path.join(self.output_path, "run_specs.json"),
+            json.dumps(list(map(dataclasses.asdict, run_specs)), indent=2),
+        )
 
         all_models = [dataclasses.asdict(model) for model in ALL_MODELS]
         write(os.path.join(self.output_path, "models.json"), json.dumps(all_models, indent=2))

--- a/src/benchmark/run.py
+++ b/src/benchmark/run.py
@@ -21,7 +21,7 @@ def run_benchmarking(
     dry_run: bool,
     skip_instances: bool,
     max_eval_instances: Optional[int],
-):
+) -> List[RunSpec]:
     """Runs RunSpecs given a list of RunSpec descriptions."""
     execution_spec = ExecutionSpec(auth=auth, url=url, parallelism=num_threads, dry_run=dry_run)
 
@@ -44,6 +44,7 @@ def run_benchmarking(
 
     runner = Runner(execution_spec, output_path, run_specs, skip_instances)
     runner.run_all()
+    return run_specs
 
 
 def add_run_args(parser: argparse.ArgumentParser):

--- a/src/benchmark/run_expander.py
+++ b/src/benchmark/run_expander.py
@@ -73,6 +73,7 @@ class ModelRunExpander(ReplaceValueRunExpander):
     name = "model"
     values_dict = {
         "default": ["openai/davinci"],
+        "jurassic": ["ai21/j1-jumbo"],
         "all": [model.name for model in ALL_MODELS],
         "code": ["openai/code-davinci-001", "openai/code-cushman-001"],
     }

--- a/src/benchmark/runner.py
+++ b/src/benchmark/runner.py
@@ -92,10 +92,11 @@ class Runner:
         metrics: List[Metric] = (
             [TokensMetric()] if self.dry_run else [create_metric(metric) for metric in run_spec.metrics]
         )
-        hlog(f"{len(metrics)} metrics")
         stats: List[Stat] = []
-        for metric in metrics:
-            stats.extend(metric.evaluate(scenario_state, self.metric_service))
+        with htrack_block(f"{len(metrics)} metrics"):
+            for metric in metrics:
+                with htrack_block(metric):
+                    stats.extend(metric.evaluate(scenario_state, self.metric_service))
 
         # Print out stats
         with htrack_block("Stats"):

--- a/src/proxy/static/benchmarking.css
+++ b/src/proxy/static/benchmarking.css
@@ -1,0 +1,13 @@
+.correct {
+  background-color: #dfffdf;
+}
+
+.scenario-info {
+  margin-top: 30px;
+  margin-bottom: 30px;
+}
+
+td {
+  padding-left: 15px;
+  padding-right: 15px;
+}

--- a/src/proxy/static/benchmarking.html
+++ b/src/proxy/static/benchmarking.html
@@ -5,7 +5,7 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
-		<link rel="stylesheet" type="text/css" href="index.css">
+		<link rel="stylesheet" type="text/css" href="benchmarking.css">
 	</head>
 
 	<body>

--- a/src/proxy/static/benchmarking.js
+++ b/src/proxy/static/benchmarking.js
@@ -17,20 +17,20 @@ $(function () {
     return $table;
   }
 
-  function renderRuns(runSpecs) {
+  function renderRunsOverview(runSpecs) {
     const $table = $('<table>', {class: 'query-table'});
     const $header = $('<tr>')
         .append($('<td>').append($('<b>').append('Run')))
-        .append($('<td style="padding-left:30px;">').append($('<b>').append('Model')))
-        .append($('<td style="padding-left:30px;">').append($('<b>').append('Adaptation method')));
+        .append($('<td>').append($('<b>').append('Model')))
+        .append($('<td>').append($('<b>').append('Adaptation method')));
     $table.append($header);
 
     runSpecs.forEach((runSpec) => {
       const href = encodeUrlParams(Object.assign(urlParams, {runSpec: runSpec.name}));
       const $row = $('<tr>')
         .append($('<td>').append($('<a>', {href}).append(runSpec.name)))
-        .append($('<td style="padding-left:30px;">').append(runSpec.adapter_spec.model))
-        .append($('<td style="padding-left:30px;">').append(runSpec.adapter_spec.method))
+        .append($('<td>').append(runSpec.adapter_spec.model))
+        .append($('<td>').append(runSpec.adapter_spec.method))
       $table.append($row);
     });
     return $table;
@@ -54,95 +54,188 @@ $(function () {
     return result;
   }
 
-  function renderRun(runSpec) {
+  function getJSONList(paths, callback) {
+    // Fetch the JSON files `paths`, and pass the list of results into `callback`.
+    const responses = {};
+    $.when(
+      ...paths.map((path) => $.getJSON(path, {}, (response) => { responses[path] = response; })),
+    ).then(() => {
+      callback(paths.map((path) => responses[path]));
+    });
+  }
+
+  function canonicalizeList(lists) {
+    // Takes as input a list of lists, and returns the list of unique elements (preserving order).
+    // Example: [1, 2, 3], [2, 3, 4] => [1, 2, 3, 4]
+    const result = [];
+    lists.forEach((list) => {
+      list.forEach((elem) => {
+        if (result.indexOf(elem) === -1) {
+          result.push(elem);
+        }
+      });
+    });
+    return result;
+  }
+
+  function dict(entries) {
+    // Make a dictionary (object) out of the key/value `entries`
+    const obj = {};
+    entries.forEach(([key, value]) => {
+      obj[key] = value;
+    });
+    return obj;
+  }
+
+  function findDiff(items) {
+    // `items` is a list of dictionaries.
+    // Return a corresponding list of dictionaries where all the common keys have been removed.
+    const commonKeys = Object.keys(items[0]).filter((key) => items.every((item) => JSON.stringify(item[key]) === JSON.stringify(items[0][key])));
+    return items.map((item) => {
+      return dict(Object.entries(item).filter((entry) => commonKeys.indexOf(entry[0]) === -1));
+    });
+  }
+
+  function renderRunsDetailed(runSpecs) {
+    // Render all the `runSpecs`:
+    // - Adapter specifictaion
+    // - Metric
+    // - Instances + predictions
+    // For each block, we show a table and each `runSpec` is a column.
     const CORRECT_TAG = 'correct';
 
+    // Used to hash instances.
     function instanceKey(instance) {
       return JSON.stringify(instance);
     }
 
-    const instanceToDiv = {};
+    function renderDict(obj) {
+      return Object.entries(obj).map(([key, value]) => `${key}=${value}`).join(',');
+    }
 
+    // Figure out short names for the runs based on where they differ
+    const runDisplayNames = findDiff(runSpecs.map((runSpec) => runSpec.adapter_spec)).map(renderDict);
+
+    // Setup the basic HTML elements
     const $root = $('<div>');
-    $.getJSON(`benchmark_output/runs/${runSpec.name}/scenario.json`, {}, (scenario) => {
-      console.log('scenario', scenario);
+    const $scenarioInfo = $('<div>', {class: 'scenario-info'});
+    $root.append($scenarioInfo);
 
-      $root.append($('<h4>').append(scenario.name));
-      $root.append($('<div>').append($('<i>').append(scenario.description)));
+    $root.append($('<h5>').append('Adapter specification'));
+    const $adapterSpec = $('<table>', {class: 'table'});
+    if (runSpecs.length > 1) {
+      $adapterSpec.append($('<tr>').append($('<td>')).append(runDisplayNames.map((name) => $('<td>').append(name))));
+    }
+    $root.append($adapterSpec);
 
-      // Render adapter spec
-      const $adapterSpec = $('<table>', {class: 'table'});
-      for (let key in runSpec.adapter_spec) {
-        $adapterSpec.append($('<tr>').append($('<td>').append(key)).append($('<td>').append(runSpec.adapter_spec[key])));
-      }
-      $root.append($('<h5>').append('Adapter specification'));
-      $root.append($adapterSpec);
+    $root.append($('<h5>').append('Metrics'));
+    const $metrics = $('<table>', {class: 'table'});
+    if (runSpecs.length > 1) {
+      $metrics.append($('<tr>').append($('<td>')).append(runDisplayNames.map((name) => $('<td>').append(name))));
+    }
+    $root.append($metrics);
 
-      // Render metrics
-      const $metrics = $('<table>', {class: 'table'});
-      $.getJSON(`benchmark_output/runs/${runSpec.name}/metrics.json`, {}, (metrics) => {
-        console.log('metrics', metrics);
-        metrics.forEach((metric) => {
-          const name = renderMetricName(metric.name);
-          $metrics.append($('<tr>').append($('<td>').append(name)).append($('<td>').append(round(metric.mean, 3))));
-        });
+    $root.append($('<h5>').append('Instances'));
+    const $instances = $('<div>');
+    $root.append($instances);
+
+    // Render adapter specs
+    const keys = canonicalizeList(runSpecs.map((runSpec) => Object.keys(runSpec.adapter_spec)));
+    keys.forEach((key) => {
+      const $row = $('<tr>').append($('<td>').append(key));
+      runSpecs.forEach((runSpec) => {
+        $row.append($('<td>').append(runSpec.adapter_spec[key]));
       });
-      $root.append($('<h5>').append('Metrics'));
-      $root.append($metrics);
+      $adapterSpec.append($row);
+    });
 
-      $root.append($('<h5>').append('Instances'));
-      const $instances = $('<div>');
-      $root.append($instances);
-      scenario.instances.forEach((instance, i) => {
-        $instances.append($('<hr>'));
-        const $instance = $('<div>');
-        $instance.append($('<b>').append(`Input ${i}`));
-        $instance.append(': ');
-        $instance.append(multilineHtml(instance.input));
-        const $references = $('<ul>');
-        instance.references.forEach((reference) => {
-          const isCorrect = reference.tags.includes(CORRECT_TAG);
-          $references.append($('<li>').append($('<span>', {class: isCorrect ? 'correct' : ''}).append(reference.output)));
+    // Render metrics
+    getJSONList(runSpecs.map((runSpec) => `benchmark_output/runs/${runSpec.name}/metrics.json`), (metricsList) => {
+      console.log('metrics', metricsList);
+      const displayNames = canonicalizeList(metricsList.map((metrics) => metrics.map((metric) => renderMetricName(metric.name))));
+
+      displayNames.forEach((displayName) => {
+        const $row = $('<tr>').append($('<td>').append(displayName));
+        metricsList.forEach((metrics) => {
+          const metric = metrics.find((metric) => renderMetricName(metric.name) === displayName);
+          $row.append($('<td>').append(metric ? round(metric.mean, 3) : '?'));
         });
-        $instance.append($references);
-        $instances.append($instance);
-        instanceToDiv[instanceKey(instance)] = $instance;
+        $metrics.append($row);
       });
+    });
 
-      // Get the model predictions
-      $.getJSON(`benchmark_output/runs/${runSpec.name}/scenario_state.json`, {}, (scenarioState) => {
-        console.log('scenarioState', scenarioState);
-        scenarioState.request_states.forEach((requestState) => {
-          const $instance = instanceToDiv[instanceKey(requestState.instance)];
-          if (!$instance) {
-            console.log('Not found: ' + instanceKey(requestState.instance));
+    // Render scenario instances
+    const instanceToDiv = {};
+    getJSONList(runSpecs.map((runSpec) => `benchmark_output/runs/${runSpec.name}/scenario.json`), (scenarios) => {
+      console.log('scenarios', scenarios);
+
+      $scenarioInfo.append($('<h4>').append(scenarios[0].name));
+      $scenarioInfo.append($('<div>').append($('<i>').append(scenarios[0].description)));
+
+      scenarios.forEach((scenario) => {
+        scenario.instances.forEach((instance, i) => {
+          const key = instanceKey(instance);
+          if (key in instanceToDiv) {
             return;
           }
 
-          // Create a link for the request made to the server
-          const request = Object.assign({}, requestState.request);
-          const prompt = request.prompt;
-          delete request.prompt;
-          const query = {
-            prompt,
-            settings: JSON.stringify(request),
-            environments: '',
-          };
-          const href = '/static/index.html' + encodeUrlParams(query);
+          // Render instance
+          $instances.append($('<hr>'));
+          const $instance = $('<div>');
+          $instance.append($('<b>').append(`Input ${i}`));
+          $instance.append(': ');
+          $instance.append(multilineHtml(instance.input));
+          const $references = $('<ul>');
+          instance.references.forEach((reference) => {
+            const isCorrect = reference.tags.includes(CORRECT_TAG);
+            $references.append($('<li>').append($('<span>', {class: isCorrect ? 'correct' : ''}).append(reference.output)));
+          });
+          $instance.append($references);
+          $instances.append($instance);
+          instanceToDiv[key] = $instance;
+        });
+      });
 
-          // Render the prediction
-          let prediction = $('<i>').append('(empty)');
-          if (requestState.result) {
-            prediction = requestState.result.completions[0].text.trim();
-            if (requestState.output_mapping) {
-              prediction = requestState.output_mapping[prediction];
+      // Render the model predictions
+      getJSONList(runSpecs.map((runSpec) => `benchmark_output/runs/${runSpec.name}/scenario_state.json`), (scenarioStates) => {
+        console.log('scenarioStates', scenarioStates);
+        scenarioStates.forEach((scenarioState, index) => {
+          scenarioState.request_states.forEach((requestState) => {
+            const $instance = instanceToDiv[instanceKey(requestState.instance)];
+            if (!$instance) {
+              console.log('Not found: ' + instanceKey(requestState.instance));
+              return;
             }
-          }
-          const isCorrect = requestState.instance.references.some((reference) => reference.tags.includes(CORRECT_TAG) && reference.output === prediction);
-          $instance.append($('<a>', {href}).append($('<b>').append('Prediction'))).append(': ').append($('<span>', {class: isCorrect ? 'correct' : ''}).append(prediction));
+
+            // Create a link for the request made to the server
+            const request = Object.assign({}, requestState.request);
+            const prompt = request.prompt;
+            delete request.prompt;
+            const query = {
+              prompt,
+              settings: JSON.stringify(request),
+              environments: '',
+            };
+            const href = '/static/index.html' + encodeUrlParams(query);
+
+            // Render the prediction
+            let prediction = $('<i>').append('(empty)');
+            if (requestState.result) {
+              prediction = requestState.result.completions[0].text.trim();
+              if (requestState.output_mapping) {
+                prediction = requestState.output_mapping[prediction];
+              }
+            }
+            const isCorrect = requestState.instance.references.some((reference) => reference.tags.includes(CORRECT_TAG) && reference.output === prediction);
+            $instance.append($('<div>')
+              .append($('<a>', {href}).append($('<b>').append(runSpecs.length > 1 ? `Prediction (${runDisplayNames[index]})` : 'Prediction')))
+              .append(': ')
+              .append($('<span>', {class: isCorrect ? 'correct' : ''}).append(prediction)));
+          });
         });
       });
     });
+
     return $root;
   }
 
@@ -163,16 +256,14 @@ $(function () {
       $main.append(renderHeader('Models', renderModels(models)));
     }
     if (urlParams.runSpec) {
-      const matchedRunSpecs = runSpecs.filter((runSpec) => runSpec.name === urlParams.runSpec);
+      const matchedRunSpecs = runSpecs.filter((runSpec) => new RegExp('^' + urlParams.runSpec + '$').test(runSpec.name));
       if (matchedRunSpecs.length === 0) {
         $main.append(renderError('No matching runs'));
       } else {
-        matchedRunSpecs.forEach((runSpec) => {
-          $main.append(renderRun(runSpec));
-        });
+        $main.append(renderRunsDetailed(matchedRunSpecs));
       }
     } else {
-      $main.append(renderHeader('Runs', renderRuns(runSpecs)));
+      $main.append(renderHeader('Runs', renderRunsOverview(runSpecs)));
     }
   });
 });

--- a/src/proxy/static/index.css
+++ b/src/proxy/static/index.css
@@ -49,7 +49,3 @@ td {
   margin-left: 3px;
   margin-right: 3px;
 }
-
-.correct {
-  background-color: #dfffdf;
-}


### PR DESCRIPTION
Main change is allowing us to show two runs side-by-side.

For example, if we run we have a `a.conf` file:
```
"mmlu:subject=philosophy": {status: READY}
"mmlu:subject=philosophy,model=jurassic": {status: READY}
```
and run `benchmark-present -c a.conf`.

Then the web interface (`http://localhost:1959/static/benchmarking.html?runSpec=mmlu%3Asubject%3Dphilosophy.*`) should compare the GPT-3 and Jurassic model side by side.

Drive-by changes: improve logging to show status (since the AI21 tokenizer takes a while to run).