### PR TITLE
Fix for CNN/DM issue with cache.

### DIFF
--- a/src/benchmark/run_specs.py
+++ b/src/benchmark/run_specs.py
@@ -1048,7 +1048,7 @@ def get_xsum_summarization_spec() -> RunSpec:
 def get_cnndm_summarization_spec() -> RunSpec:
     scenario = ScenarioSpec(
         class_name="benchmark.summarization_scenario.SummarizationScenario",
-        args={"dataset_name": "cnn-dm", "sampling_min_length": 50, "sampling_max_length": 64, "doc_max_length": 512,},
+        args={"dataset_name": "cnn-dm", "sampling_min_length": 50, "sampling_max_length": 150, "doc_max_length": 512,},
     )
 
     adapter_spec = AdapterSpec(

--- a/src/benchmark/summarization_scenario.py
+++ b/src/benchmark/summarization_scenario.py
@@ -73,7 +73,7 @@ class SummarizationScenario(Scenario):
             article_key = "document"
             summary_key = "summary"
         elif dataset_name == "cnn-dm":
-            dataset = load_dataset("cnn_dailymail", "3.0.0")
+            dataset = load_dataset("ccdv/cnn_dailymail", "3.0.0")
             article_key = "article"
             summary_key = "highlights"
         else:


### PR DESCRIPTION
The original HuggingFace datasets link was trying to access a google drive folder where the quota had exceeded, which led to caching issues. Using the alternate copy here:
https://huggingface.co/datasets/ccdv/cnn_dailymail

This one works without any issues.

Also using this commit to change the max_length for sampling training examples to 150 (from 64). 