### PR TITLE
Remove stop_sequences for all LM scenarios

### DIFF
--- a/src/benchmark/run_specs.py
+++ b/src/benchmark/run_specs.py
@@ -341,7 +341,6 @@ def get_commonsense_qa_spec(dataset: str, method: str) -> RunSpec:
             num_train_trials=1,
             model="openai/davinci",
             temperature=0.0,
-            stop_sequences=["\n"],
         )
         run_spec = RunSpec(
             name=f"commonsense_qa:dataset={dataset},method={method}",
@@ -445,7 +444,6 @@ def get_twitter_aae_spec(demographic: str) -> RunSpec:
         num_train_trials=1,
         model="openai/davinci",
         temperature=0.0,
-        stop_sequences=["\n"],
         max_tokens=0,
     )
 
@@ -901,7 +899,6 @@ def get_the_pile_spec(subset: str) -> RunSpec:
         model="openai/davinci",
         temperature=0.0,
         max_tokens=0,
-        stop_sequences=["\n"],
     )
 
     return RunSpec(
@@ -927,7 +924,6 @@ def get_ice_spec(**kwargs) -> RunSpec:
         model="openai/davinci",
         temperature=0.0,
         max_tokens=0,
-        stop_sequences=["\n"],
     )
 
     return RunSpec(
@@ -1004,7 +1000,6 @@ def get_wikitext_103_spec() -> RunSpec:
         model="openai/davinci",
         temperature=0.0,
         max_tokens=0,
-        stop_sequences=["\n"],
     )
 
     return RunSpec(
@@ -1027,7 +1022,6 @@ def get_blimp_spec(phenomenon: str) -> RunSpec:
         model="openai/davinci",
         temperature=0.0,
         max_tokens=0,
-        stop_sequences=["\n"],
     )
 
     return RunSpec(


### PR DESCRIPTION
This PR solves the problem described in issue [#277](https://github.com/stanford-crfm/benchmarking/issues/277)

Tested on the complete Wikitext-103 test set (60 instances), did not trigger the assertion error.

Tested on 20 instances of ice-CAN, did not trigger the assertion error. Did not test it on the whole test set due to quota limitations.
