### PR TITLE
NarrativeQA: one question per doc

### DIFF
--- a/src/benchmark/narrativeqa_scenario.py
+++ b/src/benchmark/narrativeqa_scenario.py
@@ -88,7 +88,7 @@ class NarrativeQAScenario(Scenario):
                     continue
                 split_summaries[row["document_id"]] = row
 
-        doc_id_to_question_rows: Dict[str, List[dict]] = {}
+        doc_id_to_question_rows: Dict[str, List[Dict[str, str]]] = {}
         with open(qaps_file, encoding="utf-8") as f:
             reader = csv.DictReader(f)
             for row in reader:


### PR DESCRIPTION
Use each document only for one question. We have too many questions (~14k in dev+test) to test all of them and we have enough documents (470 in dev+test) to give us significance even with one question each. (We could imagine testing all the questions for each document but this feels off the critical path).

Resolves #263 