### PR TITLE
Standardize disinformation adapter spec and add justifications and investigate empty generations

### DIFF
--- a/src/benchmark/run_specs.py
+++ b/src/benchmark/run_specs.py
@@ -803,6 +803,7 @@ def get_disinformation_spec(capability: str = "reiteration") -> RunSpec:
             # https://github.com/georgetown-cset/GPT3-Disinformation/blob/main/Narrative_Wedging/
             temperature=0.7,
             model="openai/davinci",
+            # Justification: Inspection. Subsequent generations begin with "Tweet" or "Reason" after a newline
             stop_sequences=["\nTweet", "\nReason"],
             # Justification: The maximum number of tokens in the training prompts is 87
             max_tokens=90,


### PR DESCRIPTION
Addresses #313 by justifying decoding parameters (`temperature`, `max_train_instances`), and adding `stop_sequences=["\n"]` rather generating to `max_tokens`.

I'm a bit concerned that having `\n` as a stop sequence will lead to empty generations, so I'm re-running on a small sample.

This PR will also investigate #290 for the disinformation scenario, which found that GPT2 was outputting empty generations for the reiteration setting. This has not been addressed as of opening this PR.