### PR TITLE
Fix shuffling of eval instances

### DIFF
--- a/src/benchmark/adapter.py
+++ b/src/benchmark/adapter.py
@@ -154,12 +154,13 @@ class ScenarioState:
         # the `Metric` later to access them.  Two things are produced:
         self.request_state_map: Dict[Tuple[int, Instance, Optional[int]], List[RequestState]] = defaultdict(list)
 
-        instances_set = set()
+        # Python doesn't support an ordered set, so use an OrderedDict instead to maintain insertion order
+        instances_set: Dict[Instance, None] = OrderedDict()
         for request_state in self.request_states:
-            instances_set.add(request_state.instance)
+            instances_set[request_state.instance] = None
             key = (request_state.train_trial_index, request_state.instance, request_state.reference_index)
             self.request_state_map[key].append(request_state)
-        self.instances: List[Instance] = list(instances_set)
+        self.instances: List[Instance] = list(instances_set.keys())
 
     def get_request_states(
         self, train_trial_index: int, instance: Instance, reference_index: Optional[int]

--- a/src/proxy/static/benchmarking.js
+++ b/src/proxy/static/benchmarking.js
@@ -301,7 +301,6 @@ $(function () {
       );
 
       scenarios.forEach((scenario) => {
-        scenario.instances.sort((a, b) => a.id.localeCompare(b.id));
         scenario.instances.forEach((instance, instanceIndex) => {
           const key = instanceKey(instance);
           if (key in instanceToDiv) {


### PR DESCRIPTION
## Description

Pull request addressing #282.

## Diagnostics

The frontend processes the instances in the order present in the respective `scenario.json` files for a given run. For a given scenario, this order is different for each run.

## Possible Solutions

### 1. Fixing the Order in `scenario.json`

One way to address this issue is to ensure that instances are written in the same order to `scenario.json`, which would automatically address the issue on the frontend. As an example, the order of the instances in `scenario_state.json` is uniform across different runs of the same scenario.

### 2. Re-ordering the Instances in the Frontend

We could re-order the instances in the frontend, which is the solution I selected. I'm using the `id` field of the instances to order them.

## Future Notes

I think it would be better if the order in the `scenario.json` files matched for different runs of the same scenario. What do the reviewers think?