### PR TITLE
Lower the text before checking for exact match

### DIFF
--- a/src/benchmark/basic_metrics.py
+++ b/src/benchmark/basic_metrics.py
@@ -71,7 +71,7 @@ def normalize_text(text: str) -> str:
 
 
 def exact_match(gold: str, pred: str) -> float:
-    return 1 if gold.strip() == pred.strip() else 0
+    return 1 if gold.lower().strip() == pred.lower().strip() else 0
 
 
 def quasi_exact_match(gold: str, pred: str) -> float:


### PR DESCRIPTION
## Purpose

As a follow up to our Slack conversation, lowering the predicted and expected text for the exact match comparison.