### PR TITLE
Fix per-instance stats bug for estimated_num_tokens

### DIFF
--- a/src/benchmark/metric.py
+++ b/src/benchmark/metric.py
@@ -4,7 +4,6 @@ from typing import List, Dict, Tuple
 from math import log, e
 from collections import defaultdict
 
-from common.hierarchical_logger import hlog
 from common.statistic import Stat, merge_stat
 from common.object_spec import ObjectSpec, create_object
 from common.general import singleton
@@ -72,7 +71,6 @@ class Metric(ABC):
             #       https://github.com/stanford-crfm/benchmarking/issues/48
             for instance_index, instance in enumerate(scenario_state.instances):
                 instance_stats = []
-                hlog(f"trial {train_trial_index}: evaluate {instance_index} (total {len(scenario_state.instances)})")
 
                 # Evaluate generated request_state
                 request_state = singleton(scenario_state.get_request_states(train_trial_index, instance, None))

--- a/src/benchmark/tokens_metric.py
+++ b/src/benchmark/tokens_metric.py
@@ -1,4 +1,3 @@
-from tqdm import tqdm
 from typing import List, Dict, Tuple
 
 from common.request import Request
@@ -26,11 +25,13 @@ class TokensMetric(Metric):
         per_instance_stats: Dict[Tuple[Instance, int], List[Stat]] = {}
         stats: Dict[MetricName, Stat] = {}
 
-        for request_state in tqdm(scenario_state.request_states):
+        for request_state in scenario_state.request_states:
             request: Request = request_state.request
             num_tokens: int = self.token_counter.estimate_tokens(request)
             stat = Stat(MetricName("estimated_number_of_tokens")).add(num_tokens)
             merge_stat(stats, stat)
-            per_instance_stats[(request_state.instance, 0)] = [stat]
+            # Call take_mean to make a copy of the stat above so that merge_stat updates do
+            # not change what is in per_instance_stats.
+            per_instance_stats[(request_state.instance, 0)] = [stat.take_mean()]
 
         return MetricResult([stat.take_mean() for stat in stats.values()], per_instance_stats)


### PR DESCRIPTION
`estimated_number_of_tokens` in first instance of per_instance_metrics has statistics for multiple instances: https://crfm-models.stanford.edu/static/benchmark_output/runs/narrative_qa,model=openai_davinci/per_instance_metrics.json.

This PR fixes this issue, and also removes needless logging to stdout.