### PR TITLE
Check `topTokens` for AI21

### DIFF
--- a/src/proxy/ai21_client.py
+++ b/src/proxy/ai21_client.py
@@ -80,8 +80,8 @@ class AI21Client(Client):
             text_length: int = raw["textRange"]["end"] - raw["textRange"]["start"]
             # "topTokens" can be None when sending a request with topKReturn=0
             top_logprobs: Dict[str, float] = dict(
-                (fix_text(x["token"], first), x["logprob"]) for x in raw["topTokens"]
-            ) if raw["topTokens"] else dict()
+                (fix_text(x["token"], first), x["logprob"]) for x in raw["topTokens"] or []
+            )
 
             return Token(
                 # Text should not be longer than text_length. Since "▁" is always inserted


### PR DESCRIPTION
"topTokens" can be None when sending a request with topKReturn=0

To fix https://crfm-models.stanford.edu/static/index.html?prompt=%22Previously%20on%20%22Wayward%20Pines%22...%22%20%22This%20fake%20little%20town%20is%20all%20that%27s%20left.%22%20%22There%27s%20a%20faction.%22%20%22They%27re%20gonna%20take%20down%20the%20fence.%22%20%22Surrender%20your%20arms%20and%20explosives%20by%20tomorrow%20morning%20and%20everything%20stays%20between%20us.%22&settings=echo_prompt%3A%20true%20%20%23%20Analyze%20the%20prompt%0Amax_tokens%3A%200%20%20%23%20Don%27t%20generate%20any%20more%0Atop_k_per_token%3A%200%20%20%23%20Show%20alternatives%20for%20each%20position%0Amodel%3A%20ai21%2Fj1-jumbo&environments=