### PR TITLE
Fix raw token text for MT-NLG models

### DIFF
--- a/src/proxy/microsoft_client.py
+++ b/src/proxy/microsoft_client.py
@@ -62,7 +62,7 @@ class MicrosoftClient(Client):
         Log probabilities are also currently not supported.
         """
 
-        def fix_token_text(text: str) -> str:
+        def fix_text(text: str) -> str:
             return text.replace("Ġ", " ")
 
         # Only a single "stop" value (str) or None is currently supported.
@@ -110,7 +110,7 @@ class MicrosoftClient(Client):
             # Since the log probs and tokens are not available to us just tokenize the completion using the tokenizer
             completion_text: str = raw_completion["text"]
             tokens: List[Token] = [
-                Token(text=fix_token_text(text), logprob=0, top_logprobs={})
+                Token(text=fix_text(text), logprob=0, top_logprobs={})
                 for text in self.tokenizer.tokenize(completion_text)
             ]
             completion = Sequence(text=completion_text, logprob=0, tokens=tokens)


### PR DESCRIPTION
Resolves #381 

Before:

<img width="563" alt="before" src="https://user-images.githubusercontent.com/16793796/167950670-8f9e1c5e-e02c-4f15-b0c8-539f69ff104c.png">

After:

<img width="526" alt="after" src="https://user-images.githubusercontent.com/16793796/167950701-c978b129-1b5d-42a6-b491-47521dad8d3f.png">