### PR TITLE
Correcting serialization to improve performance

### DIFF
--- a/src/benchmark/entity_data_imputation_scenario.py
+++ b/src/benchmark/entity_data_imputation_scenario.py
@@ -106,7 +106,7 @@ class EntityDataImputationScenario(Scenario):
         res = []
         for c in columns:
             res.append(f"{c}: {row[c]}".strip())
-        return " | ".join(res)
+        return ". ".join(res)
 
     def get_instances(self) -> List[Instance]:
         data_path = Path(self.output_path) / "data" / self.dataset
@@ -132,7 +132,7 @@ class EntityDataImputationScenario(Scenario):
             hlog(f"Processing {split} with {example_df.shape[0]} rows")
             for _, row in example_df.iterrows():
                 res = self.serialize_row(row, columns_for_serialize)
-                input = f"{res} | {col_to_impute}:"
+                input = f"{res}. {col_to_impute}?"
                 label = row[col_to_impute]
 
                 instance = Instance(input=input, references=[Reference(output=label, tags=[CORRECT_TAG])], split=split,)

--- a/src/benchmark/entity_matching_scenario.py
+++ b/src/benchmark/entity_matching_scenario.py
@@ -94,7 +94,7 @@ class EntityMatchingScenario(Scenario):
         res = []
         for c_og, c_map in column_map.items():
             res.append(f"{c_map}: {row[c_og]}".strip())
-        return " | ".join(res)
+        return ". ".join(res)
 
     def get_instances(self) -> List[Instance]:
         data_path = Path(self.output_path) / "data" / self.dataset
@@ -126,7 +126,7 @@ class EntityMatchingScenario(Scenario):
             for _, pair in example_df.iterrows():
                 resA = self.serialize_row(pair, column_mapA)
                 resB = self.serialize_row(pair, column_mapB)
-                input = f"Row A: {resA} ; Row B: {resB} ?"
+                input = f"Product A is {resA}. Product B is {resB}. Are A and B the same?"
                 label = "Yes" if pair["label"] else "No"
 
                 instance = Instance(input=input, references=[Reference(output=label, tags=[CORRECT_TAG])], split=split,)

--- a/src/benchmark/run_specs.py
+++ b/src/benchmark/run_specs.py
@@ -1172,9 +1172,9 @@ def get_entity_matching_spec(dataset: str) -> RunSpec:
 
     adapter_spec = AdapterSpec(
         method=ADAPT_GENERATION,
-        instructions="Are Row A and Row B the same? Yes or No?",
+        instructions="Are Product A and Product B the same? Yes or No?",
         input_prefix="",
-        output_prefix="\n ",
+        output_prefix=" ",
         num_train_trials=1,
         max_train_instances=5,
         model="openai/davinci",
@@ -1199,9 +1199,9 @@ def get_entity_data_imputation_spec(dataset: str) -> RunSpec:
 
     adapter_spec = AdapterSpec(
         method=ADAPT_GENERATION,
-        instructions="Generate the missing value in the row.",
+        instructions="What is the missing value?",
         input_prefix="",
-        output_prefix="\n ",
+        output_prefix=" ",
         num_train_trials=1,
         max_train_instances=5,
         model="openai/davinci",


### PR DESCRIPTION
Found a few serialization tricks to improve performance. Expected around 20-30 point lift on Beer with serializing rows with "." rather than "|".