### PR TITLE
Display stop_sequences as a JSON

### DIFF
--- a/src/proxy/static/benchmarking.js
+++ b/src/proxy/static/benchmarking.js
@@ -53,8 +53,15 @@ $(function () {
     return result;
   }
 
+  function renderStopSequence(value) {
+    return JSON.stringify(value);
+  }
+
   function renderFieldValue(field, value) {
     if (!field.values) {
+      if (field.name === 'stop_sequences') {
+        return renderStopSequence(value);
+      }
       return value;
     }
     const valueField = field.values.find(valueField => valueField.name === value);


### PR DESCRIPTION
## Purpose

UI fix to display stop sequences properly. Resolves #395.

## Diagnostics

In the current version, the `stop_sequences` array is displayed by concatenating the string representation of all of its elements (e.g. `['1', '2']` would be mapped to `12`). Because most of the stop sequences are new line characters, this field usually appears as empty.

## Proposed Solution

I considered mapping stop sequences to tokens such as <new_line>, <space>, etc. but decided that this would make this field more complicated. I settled on rendering the array as if rendering a `JSON`. Included below is a screenshot showing the current version.

<img width="701" alt="Screen Shot 2022-05-16 at 9 34 18 PM" src="https://user-images.githubusercontent.com/21346670/168730360-eefb6f34-63c0-4c4c-9e6e-330a19b86efa.png">


Edit: Looks like we can no longer request multiple reviewers, apologies for the extra notifications.

