### PR TITLE
remove CANNOTANSWER from end of QuAC passage

### DIFF
--- a/src/benchmark/quac_scenario.py
+++ b/src/benchmark/quac_scenario.py
@@ -110,7 +110,11 @@ class QuACScenario(Scenario):
 
         prompt += f"Section: {sample['section_title']}\n"
         dialogue = sample["paragraphs"][0]
-        prompt += f"Context: {dialogue['context']}\n\n"
+
+        context = dialogue["context"]
+        assert context[-13:] == " CANNOTANSWER"
+        context = context[:-13]
+        prompt += f"Passage: {context}\n\n"
 
         qas = dialogue["qas"]
         num_qas = len(qas)


### PR DESCRIPTION
Since QuAC was originally created as a span selection dataset, it included "CANNOTANSWER" at the end of each passage. This is arguably an artifact and not really part of the scenario, so we might as well just remove it.

Note that this will invalidate any caching we have already done and should not really affect model performance, so I don't have strong opinions about merging. But someone did notice it during the bug bash so I thought I would bring it up.