### PR TITLE
Speed up initializing AI21Tokenizer and metric calculation

### DIFF
--- a/src/proxy/tokenizer/ai21_tokenizer.py
+++ b/src/proxy/tokenizer/ai21_tokenizer.py
@@ -1,7 +1,6 @@
 import re
 
 from typing import List, Optional, Tuple
-from transformers import GPT2TokenizerFast
 from urllib.parse import unquote
 
 from common.tokenization_request import TokenizationRequest, TokenizationRequestResult, TokenizationToken, TextRange
@@ -35,12 +34,12 @@ class AI21Tokenizer(Tokenizer):
         "AI21 only gave API access to their tokenizer, so this method is not supported."
     )
 
-    def __init__(self, model: str, service: TokenizerService):
+    def __init__(self, model: str, service: TokenizerService, gpt2_tokenizer: GPT2Tokenizer):
         self.model: str = model
         # We need the `TokenizerService` to make requests to the server.
         self.service: TokenizerService = service
-        # As explained above, we need a gpt2 tokenizer to help tokenize long text sequences.
-        self.gpt2_tokenizer = GPT2Tokenizer(GPT2TokenizerFast.from_pretrained("gpt2"))
+        # As explained above, we need a GPT-2 tokenizer to help tokenize long text sequences.
+        self.gpt2_tokenizer = gpt2_tokenizer
 
     @property
     def max_sequence_length(self) -> int:

--- a/src/proxy/tokenizer/tokenizer_factory.py
+++ b/src/proxy/tokenizer/tokenizer_factory.py
@@ -55,8 +55,11 @@ class TokenizerFactory:
             if not service:
                 raise ValueError("Need to pass in a TokenizerService to get the tokenizer for the AI21 models.")
 
-            # Don't need to cache since AI21Tokenizer is just a wrapper.
-            tokenizer = AI21Tokenizer(model=model_name, service=service)
+            tokenizer = AI21Tokenizer(
+                model=model_name,
+                service=service,
+                gpt2_tokenizer=GPT2Tokenizer(tokenizer=TokenizerFactory.get_gpt2_tokenizer_fast()),
+            )
         else:
             raise ValueError(f"Invalid model name or organization: {model_name_or_organization}")
 


### PR DESCRIPTION
Calculating metrics has become really slow. It turns out we're creating a fresh GPT-2 tokenizer every we use the factory to fetch the AI21 tokenizer. We should pass in the cached GPT-2 tokenizer instead.