### PR TITLE
AI21 tokenizer: Fix double space case

### DIFF
--- a/src/proxy/tokenizer/ai21_tokenizer.py
+++ b/src/proxy/tokenizer/ai21_tokenizer.py
@@ -158,7 +158,14 @@ class AI21Tokenizer(Tokenizer):
         last_text_range: TextRange = tokens[-1].text_range
         start: int = first_text_range.start
         end: int = last_text_range.end
-        return text[start:end]
+
+        truncated_text: str = text[start:end]
+        if truncated_text.endswith("  "):
+            # The AI21 tokenizer API seems inaccurate (token count is off by 1) when the text ends
+            # with double spaces. Replacing the extra spaces with a single space fixes it.
+            truncated_text = truncated_text.rstrip() + " "
+
+        return truncated_text
 
     def _make_tokenization_request(self, text: str) -> TokenizationRequestResult:
         """Sends a request to the server to tokenize the text via the `TokenizerService`."""


### PR DESCRIPTION
Resolves https://github.com/stanford-crfm/benchmarking/issues/349

The token count by the AI21 tokenizer is off by 1 when the text ends with a double space. I think this might be a bug with the AI21 tokenizer API. 