### PR TITLE
Added filetering for XSum; added sampled_xsum

### DIFF
--- a/src/benchmark/presentation/run_specs.conf
+++ b/src/benchmark/presentation/run_specs.conf
@@ -57,11 +57,9 @@
 "raft:model=anthropic/stanford-online-helpful-v4-s3,subset=tweet_eval_hate": {status: "READY"}
 "raft:model=anthropic/stanford-online-helpful-v4-s3,subset=twitter_complaints": {status: "READY"}
 
-# TODO: @Faisal @Esin - Look at results to decide on the temp setting.
-"summarization_cnndm:model=default,temperature=0": {status: "READY"}
 "summarization_cnndm:model=default,temperature=0.3": {status: "READY"}
-"summarization_xsum:model=default,temperature=0": {status: "READY"}
 "summarization_xsum:model=default,temperature=0.3": {status: "READY"}
+"summarization_xsum_sampled:model=default,temperature=0.3": {status: "READY"}
 
 ##### Information Retrieval #####
 

--- a/src/benchmark/run_specs.py
+++ b/src/benchmark/run_specs.py
@@ -1098,7 +1098,7 @@ def get_xsum_summarization_spec(temperature: float = 0.3) -> RunSpec:
     # TODO: @Faisal remove this parameter once testing is done.
     scenario = ScenarioSpec(
         class_name="benchmark.summarization_scenario.SummarizationScenario",
-        args={"dataset_name": "xsum", "sampling_min_length": 50, "sampling_max_length": 64, "doc_max_length": 512,},
+        args={"dataset_name": "xsum", "sampling_min_length": 50, "sampling_max_length": 150, "doc_max_length": 512,},
     )
 
     adapter_spec = AdapterSpec(
@@ -1111,7 +1111,42 @@ def get_xsum_summarization_spec(temperature: float = 0.3) -> RunSpec:
         model="openai/davinci",
         max_eval_instances=None,
         num_outputs=1,
-        max_tokens=60,  # From Lewis et al. 2019 (https://arxiv.org/pdf/1910.13461.pdf)
+        max_tokens=64,  # From Zhang et al. 2020 (https://arxiv.org/pdf/1912.08777.pdf)
+        temperature=temperature,  # Temporary change for testing.
+        stop_sequences=["}"],  # Summary is enclosed in curly braces. Worked more reliably than newline.
+    )
+
+    return RunSpec(
+        name=f"summarization_xsum:temperature={temperature}",
+        scenario=scenario,
+        adapter_spec=adapter_spec,
+        metrics=get_basic_metrics({"names": ["rouge-1", "rouge-2", "rouge-l"]}),  # TODO: Add faithfulness metrics later
+    )
+
+
+def get_xsum_sampled_summarization_spec(temperature: float = 0.3) -> RunSpec:
+    # TODO: @Faisal remove this parameter once testing is done.
+    scenario = ScenarioSpec(
+        class_name="benchmark.summarization_scenario.SummarizationScenario",
+        args={
+            "dataset_name": "xsum-sampled",
+            "sampling_min_length": 50,
+            "sampling_max_length": 150,
+            "doc_max_length": 512,
+        },
+    )
+
+    adapter_spec = AdapterSpec(
+        method=ADAPT_GENERATION,
+        instructions="Summarize the given documents.",
+        input_prefix="Document: ",
+        output_prefix="\nSummary: {",
+        num_train_trials=1,
+        max_train_instances=5,
+        model="openai/davinci",
+        max_eval_instances=None,
+        num_outputs=1,
+        max_tokens=64,  # From Zhang et al. 2020 (https://arxiv.org/pdf/1912.08777.pdf)
         temperature=temperature,  # Temporary change for testing.
         stop_sequences=["}"],  # Summary is enclosed in curly braces. Worked more reliably than newline.
     )
@@ -1303,6 +1338,7 @@ CANONICAL_RUN_SPEC_FUNCS: Dict[str, Callable[..., RunSpec]] = {
     "babi_qa": get_babi_qa_spec,
     "real_toxicity_prompts": get_real_toxicity_prompts_spec,
     "summarization_xsum": get_xsum_summarization_spec,
+    "summarization_xsum_sampled": get_xsum_sampled_summarization_spec,
     "summarization_cnndm": get_cnndm_summarization_spec,
     "truthful_qa": get_truthful_qa_spec,
     "twitter_aae": get_twitter_aae_spec,

--- a/src/benchmark/summarization_scenario.py
+++ b/src/benchmark/summarization_scenario.py
@@ -58,7 +58,7 @@ class SummarizationScenario(Scenario):
                                 truncated to doc_max_length tokens.
                                 NOTE: Currently uses whitespace tokenization.
         """
-        if dataset_name not in ["xsum", "cnn-dm"]:
+        if dataset_name not in ["xsum", "xsum-sampled", "cnn-dm"]:
             raise Exception(f"Uknown dataset_name: {dataset_name}")
         self.dataset_name = dataset_name
         self.sampling_min_length = sampling_min_length
@@ -68,6 +68,24 @@ class SummarizationScenario(Scenario):
     def _clean_and_truncate(self, text: str, max_length: Optional[int] = None):
         text = text.replace("\n", " ")
         return " ".join(text.split()[:max_length])
+
+    def _xsum_filter(self, article: str, summary: str):
+        art_len = len(article.split())
+        summ_len = len(summary.split())
+
+        if "Media playback is unsupported on your device" in article:
+            return True
+
+        if "Last updated at" in article:
+            return True
+
+        if summ_len <= 10:
+            return True
+
+        if summ_len / art_len > 0.2:
+            return True
+
+        return False
 
     def _download_dataset(self, url, tag):
         data_dir = os.path.join(self.output_path, "data")
@@ -83,6 +101,11 @@ class SummarizationScenario(Scenario):
         if dataset_name == "xsum":
             url = "https://worksheets.codalab.org/rest/bundles/0xac5607f21bf945939edc56ea945496d5/contents/blob/"
             dataset = self._download_dataset(url, "xsum")
+            article_key = "document"
+            summary_key = "summary"
+        elif dataset_name == "xsum-sampled":
+            url = "https://worksheets.codalab.org/rest/bundles/0xcfbb0ef1226040f78e58060c9e4d13cf/contents/blob/"
+            dataset = self._download_dataset(url, "xsum-sampled")
             article_key = "document"
             summary_key = "summary"
         elif dataset_name == "cnn-dm":
@@ -113,6 +136,9 @@ class SummarizationScenario(Scenario):
                         continue
                     if self.sampling_min_length and art_len < self.sampling_min_length:
                         continue
+                    if self.dataset_name == "xsum":
+                        if self._xsum_filter(article, summary):
+                            continue
 
                 instances.append(
                     Instance(


### PR DESCRIPTION
Here are the changes:
Removed temp 0 setting, since temp 0.3 seemed to be a bit better.
Added additional filtering for XSum to reduce probability of sampling noisy examples. 
Added sampled-xsum scenario consisting of manually whitelisted examples that are not noisy.