### PR TITLE
Rename `num_tokens` to `num_perplexity_tokens`

### DIFF
--- a/src/benchmark/basic_metrics.py
+++ b/src/benchmark/basic_metrics.py
@@ -488,7 +488,7 @@ class BasicMetric(Metric):
         else:
             tokens = sequence.tokens
         pred_tokens = tokens[request_state.num_conditioning_tokens :]
-        logprob, num_tokens, num_bytes = (
+        logprob, num_perplexity_tokens, num_bytes = (
             sum(token.logprob for token in pred_tokens),
             len(pred_tokens),
             get_num_bytes(pred_tokens),
@@ -496,7 +496,7 @@ class BasicMetric(Metric):
 
         return [
             Stat(MetricName("logprob")).add(logprob),
-            Stat(MetricName("num_tokens")).add(num_tokens),
+            Stat(MetricName("num_perplexity_tokens")).add(num_perplexity_tokens),
             Stat(MetricName("num_bytes")).add(num_bytes),
         ]
 

--- a/src/benchmark/metric.py
+++ b/src/benchmark/metric.py
@@ -122,13 +122,13 @@ class Metric(ABC):
             for split in EVAL_SPLITS:
                 if (
                     MetricName("logprob", split=split) in trial_stats
-                    and MetricName("num_tokens", split=split) in trial_stats
+                    and MetricName("num_perplexity_tokens", split=split) in trial_stats
                     and MetricName("num_bytes", split=split) in trial_stats
                 ):
                     # TODO: find out the root cause and undo this change
                     #       https://github.com/stanford-crfm/benchmarking/issues/350
                     if (
-                        trial_stats[MetricName("num_tokens", split=split)].sum == 0
+                        trial_stats[MetricName("num_perplexity_tokens", split=split)].sum == 0
                         or trial_stats[MetricName("num_bytes", split=split)].sum == 0
                     ):
                         continue
@@ -139,7 +139,7 @@ class Metric(ABC):
                             e
                             ** (
                                 -trial_stats[MetricName("logprob", split=split)].sum
-                                / trial_stats[MetricName("num_tokens", split=split)].sum
+                                / trial_stats[MetricName("num_perplexity_tokens", split=split)].sum
                             )
                         ),
                     )
@@ -200,8 +200,8 @@ class Metric(ABC):
         # Aggregate the corpus-level metrics
         if (
             MetricName("logprob", split=split) in trial_stats
-            and MetricName("num_tokens", split=split) in trial_stats
-            and trial_stats[MetricName("num_tokens", split=split)].sum != 0
+            and MetricName("num_perplexity_tokens", split=split) in trial_stats
+            and trial_stats[MetricName("num_perplexity_tokens", split=split)].sum != 0
         ):
             merge_stat(
                 trial_stats,
@@ -209,7 +209,7 @@ class Metric(ABC):
                     e
                     ** (
                         -trial_stats[MetricName("logprob", split=split)].sum
-                        / trial_stats[MetricName("num_tokens", split=split)].sum
+                        / trial_stats[MetricName("num_perplexity_tokens", split=split)].sum
                     )
                 ),
             )

--- a/src/proxy/static/schema.yaml
+++ b/src/proxy/static/schema.yaml
@@ -38,7 +38,7 @@ metrics:
   description: Whether the predicted output matches one of the correct references up to lightweight processing.
 - name: logprob
   description: Log-probability of the predicted output (for language modeling, the input too).
-- name: num_tokens
+- name: num_perplexity_tokens
   description: Number of tokens in the output (for language modeling, the input too).
 - name: num_bytes
   description: Number of bytes in the output (for language modeling, the input too).


### PR DESCRIPTION
Related Issue: https://github.com/stanford-crfm/benchmarking/issues/407

Rename `num_tokens` to `num_perplexity_tokens` to avoid confusion.

## Test
Ran `venv/bin/benchmark-run -r wikitext_103 -m 20` and reproduced the results.