### PR TITLE
Import fix to use code outside of repo

### DIFF
--- a/src/common/request.py
+++ b/src/common/request.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from typing import List, Optional, Dict
 
-from proxy.models import Model, get_model
+from src.proxy.models import Model, get_model
 from .general import indent_lines, format_text
 
 


### PR DESCRIPTION
I want to use the authentication scripts outside of the CRFM repo. I was getting import errors for request.py and this fix corrected things.