### PR TITLE
Anthropic: Switch to `stanford-online-all-v4-s3`

### DIFF
--- a/src/proxy/anthropic_client.py
+++ b/src/proxy/anthropic_client.py
@@ -19,18 +19,20 @@ class AnthropicRequestError(Exception):
 
 class AnthropicClient(Client):
     """
-    Anthropic models. Documentation and paper coming soon. They use their own version of the GPT-2 tokenizer.
+    Client for the Anthropic models (https://arxiv.org/abs/2204.05862).
+    They used their own version of the GPT-2 tokenizer.
 
-    The Anthropic API currently does not support:
+    The Anthropic API is not production-ready and currently does not support:
     - Top k per token
     - Multiple completions
     - Echo prompt
     - Log probabilities
     """
 
-    # Note: we can currently only request for a maximum of 700 tokens in the completion.
-    # TODO: increase this later when Anthropic supports it.
-    MAX_COMPLETION_LENGTH: int = 700
+    # Note: The model has a maximum context size of 8192, but the Anthropic API
+    #       can currently only support a maximum of ~3000 tokens in the completion.
+    # TODO: increase this later when Anthropic supports more.
+    MAX_COMPLETION_LENGTH: int = 3000
 
     def __init__(self, api_key: str, cache_path: str):
         self.api_key = api_key
@@ -40,7 +42,7 @@ class AnthropicClient(Client):
 
     def make_request(self, request: Request) -> RequestResult:
         # Validate the fields of `Request`
-        if request.model != "anthropic/stanford-online-helpful-v4-s3":
+        if request.model != "anthropic/stanford-online-all-v4-s3":
             raise ValueError(f"Invalid model: {request.model}")
         # `Request` field values that Anthropic currently does not support
         if request.echo_prompt:
@@ -71,10 +73,6 @@ class AnthropicClient(Client):
             # Meta tokens are non-text tokens Anthropic sometimes injects into the text to identify the dataset
             "meta": True,  # meta=True skips sampling meta tokens. Keep it true.
             "is_replicated": True,  # Always set to True
-            # Setting `use_sample_v1` to false enables batching to increase throughput.
-            # However, if false, the API will break when users send multiple requests with different hyperparameters.
-            # Therefore, default to True for now.
-            "use_sample_v1": True,
         }
 
         def do_it():

--- a/src/proxy/models.py
+++ b/src/proxy/models.py
@@ -200,11 +200,11 @@ ALL_MODELS = [
         tags=[TEXT_MODEL_TAG],
     ),
     # Anthropic
-    # TODO: The API for the Anthropic LM is not production-ready. Update with the official name and description.
+    # TODO: The API for the Anthropic LM is not production-ready. Update with the official name.
     Model(
         group="anthropic",
         creator_organization="Anthropic",
-        name="anthropic/stanford-online-helpful-v4-s3",
+        name="anthropic/stanford-online-all-v4-s3",
         description="Anthropic model (52B parameters)",
         tags=[LIMITED_FUNCTIONALITY_MODEL_TAG, TEXT_MODEL_TAG],  # The Anthropic model has limited functionality
     ),


### PR DESCRIPTION
Resolves #503 

Paper: https://arxiv.org/abs/2204.05862

Performance on MMLU (on `global_facts`):


```
MetricName(name='exact_match', k=None, split='test', sub_split=None, perturbation=None)[min=0.290, mean=0.290, max=0.290, sum=0.290 (1)]
MetricName(name='exact_match', k=1, split='test', sub_split=None, perturbation=None)[min=0.290, mean=0.290, max=0.290, sum=0.290 (1)]
MetricName(name='exact_match', k=None, split='valid', sub_split=None, perturbation=None)[min=0.500, mean=0.500, max=0.500, sum=0.500 (1)]
MetricName(name='exact_match', k=1, split='valid', sub_split=None, perturbation=None)[min=0.500, mean=0.500, max=0.500, sum=0.500 (1)]
```

vs. OpenAI's Davinci (175B parameters): 

```
MetricName(name='exact_match', k=None, split='test', sub_split=None, perturbation=None)[min=0.360, mean=0.360, max=0.360, sum=0.360 (1)]
MetricName(name='exact_match', k=1, split='test', sub_split=None, perturbation=None)[min=0.360, mean=0.360, max=0.360, sum=0.360 (1)]
MetricName(name='exact_match', k=None, split='valid', sub_split=None, perturbation=None)[min=0.300, mean=0.300, max=0.300, sum=0.300 (1)]
MetricName(name='exact_match', k=1, split='valid', sub_split=None, perturbation=None)[min=0.300, mean=0.300, max=0.300, sum=0.300 (1)]
```