### PR TITLE
Add tokens check

### DIFF
--- a/src/benchmark/multiple_request_metrics.py
+++ b/src/benchmark/multiple_request_metrics.py
@@ -325,7 +325,11 @@ class InformationRetrievalMetric(MultipleRequestMetrics):
             oid = instance.request_id
             if oid:
                 text, logprob = self.MISSING_RESULT_TEXT, 0.0
-                if request_state.result and request_state.result.completions:
+                if (
+                    request_state.result
+                    and request_state.result.completions
+                    and request_state.result.completions[0].tokens
+                ):
                     token = request_state.result.completions[0].tokens[0]
                     text, logprob = token.text, token.logprob
                 triples.append((oid, self.standardize(text), logprob))


### PR DESCRIPTION
We can get completions with 0 tokens in them. This check ensures that we account for this case.