### PR TITLE
Fix bbq metric

### DIFF
--- a/src/benchmark/bbq_metrics.py
+++ b/src/benchmark/bbq_metrics.py
@@ -1,7 +1,8 @@
 from typing import List
 
 from common.general import singleton
-from .adapter import ScenarioState
+from common.request import RequestResult
+from .adapter import ScenarioState, RequestState
 from .metric import Metric, MetricResult
 from .metric_name import MetricName
 from .metric_service import MetricService
@@ -69,17 +70,19 @@ class BBQMetric(Metric):
 
         for train_trial_index in range(adapter_spec.num_train_trials):
             for instance in scenario_state.instances:
-                request_state = singleton(scenario_state.get_request_states(train_trial_index, instance, None))
+                request_state: RequestState = singleton(
+                    scenario_state.get_request_states(train_trial_index, instance, None)
+                )
                 references = request_state.instance.references
 
                 reference = references[0]
                 is_negative = NEGATIVE_TAG in reference.tags
                 is_ambiguous = AMBIGUOUS_TAG in reference.tags
 
-                request_result = request_state.result
+                request_result: RequestResult = request_state.result
                 # Filter out empty completions
                 completions: List[str] = [
-                    completion.value.strip() for completion in request_result.completions if completion.value
+                    completion.text.strip() for completion in request_result.completions if completion.text
                 ]
 
                 for completion in completions:


### PR DESCRIPTION
BBQ was failing with

```
 bbq:model=text,subject=all:
Traceback (most recent call last):
  File "/juice/scr/nlp/crfm/benchmarking/benchmarking/src/benchmark/presentation/present.py", line 126, in run
    new_run_specs = run_benchmarking(
  File "/juice/scr/nlp/crfm/benchmarking/benchmarking/src/benchmark/run.py", line 73, in run_benchmarking
    runner.run_all()
  File "/juice/scr/nlp/crfm/benchmarking/benchmarking/src/benchmark/runner.py", line 79, in run_all
    self.run_one(run_spec)
  File "/juice/scr/nlp/crfm/benchmarking/benchmarking/src/benchmark/runner.py", line 116, in run_one
    metric_result: MetricResult = metric.evaluate(
  File "/juice/scr/nlp/crfm/benchmarking/benchmarking/src/benchmark/bbq_metrics.py", line 81, in evaluate
    completions: List[str] = [
  File "/juice/scr/nlp/crfm/benchmarking/benchmarking/src/benchmark/bbq_metrics.py", line 82, in <listcomp>
    completion.value.strip() for completion in request_result.completions if completion.value
AttributeError: 'Sequence' object has no attribute 'value'
```

This PR fixes it by using `completion.text` instead of `completion.value`.