### PR TITLE
unify perturbation logic

### DIFF
--- a/src/benchmark/augmentations/filler_words_perturbation.py
+++ b/src/benchmark/augmentations/filler_words_perturbation.py
@@ -78,18 +78,15 @@ class FillerWordsPerturbation(Perturbation):
             all_fillers.extend(FILL_PHRASE)
 
         insert_count = 0
-        perturbed_lines = []
-        for line in text.split("\n"):
-            perturbed_words = []
-            for word in line.split():
-                if (max_num_insert is None or insert_count < max_num_insert) and random.random() <= insert_prob:
-                    random_filler = random.choice(all_fillers)
-                    perturbed_words.append(random_filler)
-                    insert_count += 1
-                perturbed_words.append(word)
-            perturbed_lines.append(" ".join(perturbed_words))
+        perturbed_words = []
+        for word in text.split(" "):
+            if (max_num_insert is None or insert_count < max_num_insert) and random.random() <= insert_prob:
+                random_filler = random.choice(all_fillers)
+                perturbed_words.append(random_filler)
+                insert_count += 1
+            perturbed_words.append(word)
 
-        perturbed_text = "\n".join(perturbed_lines)
+        perturbed_text = " ".join(perturbed_words)
 
         return perturbed_text
 

--- a/src/benchmark/augmentations/misspelling_perturbation.py
+++ b/src/benchmark/augmentations/misspelling_perturbation.py
@@ -1,12 +1,13 @@
 from dataclasses import dataclass
 import json
 from pathlib import Path
+import re
 from typing import Dict, List
 
-from nltk.tokenize.treebank import TreebankWordDetokenizer, TreebankWordTokenizer
 import numpy as np
 
 from benchmark.scenario import Instance
+from common.general import match_case
 from .perturbation import Perturbation
 from .perturbation_description import PerturbationDescription
 
@@ -38,8 +39,6 @@ class MisspellingPerturbation(Perturbation):
         misspellings_file = Path(__file__).resolve().expanduser().parent / "correct_to_misspelling.json"
         with open(misspellings_file, "r") as f:
             self.correct_to_misspelling: Dict[str, List[str]] = json.load(f)
-        self.detokenizer = TreebankWordDetokenizer()
-        self.tokenizer = TreebankWordTokenizer()
 
     @property
     def description(self) -> PerturbationDescription:
@@ -50,27 +49,15 @@ class MisspellingPerturbation(Perturbation):
         np.random.seed(int(instance.id[2:]))  # set seed based on instance ID
         return super().apply(instance)
 
-    def perturb_word(self, word: str) -> str:
-        # check if word is in dictionary and perturb with probability self.prob
-        suffix = ""
-        if word[-1] == ".":
-            suffix = "."
-            word = word[:-1]
-        if word in self.correct_to_misspelling and np.random.rand() < self.prob:
-            word = str(np.random.choice(self.correct_to_misspelling[word]))
-        word += suffix
-        return word
-
     def perturb(self, text: str) -> str:
-        lines = text.split("\n")
-        new_lines = []
-        for line in lines:
-            words = self.tokenizer.tokenize(line)
-            new_words = []
-            for word in words:
-                word = self.perturb_word(word)
-                new_words.append(word)
-            perturbed_str = str(self.detokenizer.detokenize(new_words))
-            new_lines.append(perturbed_str)
-        perturbed_str = "\n".join(new_lines)
-        return perturbed_str
+        mispelling_pattern = re.compile(
+            r"\b({})\b".format("|".join(self.correct_to_misspelling.keys())), flags=re.IGNORECASE | re.DOTALL,
+        )
+
+        def mispell(match: re.Match) -> str:
+            word = match.group(1)
+            if np.random.rand() < self.prob:
+                mispelled_word = str(np.random.choice(self.correct_to_misspelling[word.lower()]))
+            return match_case(word, mispelled_word)
+
+        return mispelling_pattern.sub(mispell, text)


### PR DESCRIPTION
Remove Treebank tokenizer, apply `match_case` everywhere, and unify line-break processing.