### PR TITLE
Add group information to runs

### DIFF
--- a/src/benchmark/presentation/run_specs.conf
+++ b/src/benchmark/presentation/run_specs.conf
@@ -116,7 +116,6 @@
 
 "imdb:model=text,data_augmentation=canonical": {status: "READY", priority: 1, groups: ["IMDB"]}
 
-# TODO: include all of them?
 "raft:subset=ade_corpus_v2,model=text,data_augmentation=canonical": {status: "READY", priority: 2, groups: ["RAFT"]}
 "raft:subset=banking_77,model=text,data_augmentation=canonical": {status: "READY", priority: 2, groups: ["RAFT"]}
 "raft:subset=neurips_impact_statement_risks,model=text,data_augmentation=canonical": {status: "READY", priority: 2, groups: ["RAFT"]}
@@ -211,8 +210,8 @@
 "the_pile:model=full_functionality_text,subset=Wikipedia (en)": {status: "READY", priority: 2, groups: ["The Pile"]}
 "the_pile:model=full_functionality_text,subset=YoutubeSubtitles": {status: "READY", priority: 3, groups: ["The Pile"]}
 
-"twitter_aae:model=full_functionality_text,demographic=aa": {status: "READY", priority: 1, groups: ["TwitterAAE (AAE)"]}
-"twitter_aae:model=full_functionality_text,demographic=white": {status: "READY", priority: 1, groups: ["TwitterAAE (White)"]}
+"twitter_aae:model=full_functionality_text,demographic=aa": {status: "READY", priority: 1, groups: ["TwitterAAE (AAE)", "TwitterAAE"]}
+"twitter_aae:model=full_functionality_text,demographic=white": {status: "READY", priority: 1, groups: ["TwitterAAE (White)", "TwitterAAE"]}
 
 "ice:model=full_functionality_text,subset=CAN": {status: "READY", priority: 3, groups: ["ICE (Canada)", "ICE"]}
 # TODO: @Nathan - Add East Africa.


### PR DESCRIPTION
In order to visualize runs, we will need to aggregate runs that correspond to the same scenario (e.g. different variants of MMLU) but need to do so correctly/where aggregation is valid (e.g. don't want to aggregate OpenBookQA and HellaSwag despite them sharing the prefix "commonsense") and desirable (e.g. don't want to do for runs exclusively there to track performance disparities like TwitterAAE and ICE, though we do for now for others like CivilComments/BOLD). 