### PR TITLE
Per perturbation worst

### DIFF
--- a/src/benchmark/metric.py
+++ b/src/benchmark/metric.py
@@ -145,7 +145,7 @@ class Metric(ABC):
                         if perturbation.fairness:
                             fairness_stat.merge(stat)
                         assert perturbation not in individual_perturbation_stats
-                        individual_perturbation_stats[perturbation] = stat
+                        individual_perturbation_stats[perturbation] = Stat(stat.name).merge(stat)  # copy
 
                 for stat in [robustness_stat, fairness_stat, *individual_perturbation_stats.values()]:
                     perturbation = stat.name.perturbation


### PR DESCRIPTION
Implemented a metric that tracks the worst performance across perturbations for each input.

We are computing two main things:
- For each individual perturbation, compute the worst performance between the perturbed input and the original input (if that exists). This allows us to see if the model is actually invariant to the perturbation.
- For each perturbation family (fairness, robustness) compute the worst case performance across all perturbations in the family (including the identity perturbation if it exists).

Resolves #543 .