### PR TITLE
Fix reference order in Quac

### DIFF
--- a/src/benchmark/quac_scenario.py
+++ b/src/benchmark/quac_scenario.py
@@ -127,7 +127,8 @@ class QuACScenario(Scenario):
         prompt += f"Question: {qas[k]['question']}"
 
         answers = [ans["text"] for ans in qas[k]["answers"]]
-        answers = list(dict.fromkeys(answers))  # de-duplicate
+        # De-duplicate the list with dict.fromkeys, which preserves the list order
+        answers = list(dict.fromkeys(answers))
 
         if answers == ["CANNOTANSWER"]:
             answers.extend(["Not enough information", "Cannot answer", "Do not know"])


### PR DESCRIPTION
# Purpose

Possible fix for #630, fixing the order of references in `Quac` to keep the selected perturbed words the same from run to run.