### PR TITLE
Only export requests that are not in the cache (`together.sqlite`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,8 +330,9 @@ to estimate the token usage. The tokenizer will be downloaded and cached when ru
 1. Exit the screen session: `ctrl+ad`.
 1. Check on the dry run by streaming `together.log`: `tail -f together.log`.
 1. The dry run results will be outputted to `benchmark_output/runs/together`.
-1. Once the dry run is done, run `python3 scripts/together/together_export_requests.py benchmark_output/runs/together prod_env/cache/together.sqlite`.
-   This command will generate a `queries.jsonl` that contains requests that are not in the cache (`prod_env/cache/together.sqlite`).
+1. Once the dry run is done, run 
+   `python3 scripts/together/together_export_requests.py benchmark_output/runs/together prod_env/cache/together.sqlite --output-path request.jsonl`.
+   This command will generate a `requests.jsonl` that contains requests that are not in the cache (`prod_env/cache/together.sqlite`).
 1. Upload `queries.jsonl` to CodaLab:
     1. Log on to CodaLab: `cl work main::0xbd9f3df457854889bda8ac114efa8061`.
     1. Upload by running `cl upload queries.jsonl`.

--- a/scripts/together/together_export_requests.py
+++ b/scripts/together/together_export_requests.py
@@ -78,8 +78,10 @@ def export_requests(run_suite_path: str, cache_path: str, output_path: str):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("run_suite_path", type=str, help="Path to run path.")
-    parser.add_argument("cache_path", type=str, help="Path to sqlite file for the cache.")
-    parser.add_argument("--output-path", type=str, default="queries.jsonl", help="Path to jsonl file.")
+    parser.add_argument(
+        "cache_path", type=str, help="Path to sqlite file (together.sqlite) for the `TogetherClient` cache."
+    )
+    parser.add_argument("--output-path", type=str, default="requests.jsonl", help="Path to jsonl file.")
     args = parser.parse_args()
 
     export_requests(args.run_suite_path, args.cache_path, args.output_path)

--- a/scripts/together/together_import_results.py
+++ b/scripts/together/together_import_results.py
@@ -66,7 +66,9 @@ def import_results(cache_path: str, request_results_path: str, dry_run: bool):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("request_results_path", type=str, help="Path to jsonl file with requests and results.")
-    parser.add_argument("cache_path", type=str, help="Path to sqlite file for the cache.")
+    parser.add_argument(
+        "cache_path", type=str, help="Path to sqlite file (together.sqlite) for the `TogetherClient` cache."
+    )
     parser.add_argument(
         "-d",
         "--dry-run",


### PR DESCRIPTION
Resolves https://github.com/stanford-crfm/benchmarking/issues/645

I also updated the README with instructions to export requests and import results for the `TogetherClient` models.