### PR TITLE
Remove .gz in file names for HumanEval; fixes #657

### DIFF
--- a/src/benchmark/code_scenario.py
+++ b/src/benchmark/code_scenario.py
@@ -103,7 +103,7 @@ def _read_and_preprocess_human_eval(
     return instances
 
 
-def _read_human_eval(evalset_file: str = "HumanEval.jsonl.gz") -> Dict[str, Dict]:
+def _read_human_eval(evalset_file: str = "HumanEval.jsonl") -> Dict[str, Dict]:
     return {task["task_id"]: task for task in _stream_jsonl(evalset_file)}
 
 
@@ -267,7 +267,7 @@ class CodeScenario(Scenario):
     def get_instances(self) -> Sequence[CodeInstance]:
         # By construction, self.output_path == 'benchmark_output/scenarios/code'.
         if self.dataset == "HumanEval":
-            target_path = os.path.join(self.output_path, "HumanEval.jsonl.gz")
+            target_path = os.path.join(self.output_path, "HumanEval.jsonl")
             ensure_file_downloaded(
                 source_url="https://github.com/openai/human-eval/raw/master/data/HumanEval.jsonl.gz",
                 target_path=target_path,


### PR DESCRIPTION
The problem in #657 clearly is a bug, but it is a minor one and doesn't seem to affect correctness of outputs in some cases (it ran on my local machine w/o any issue). 

The main issue is that the target file name for HumanEval (which is meant to be for the decompressed file) contained the suffix `.gz`. The suffix should be reserved only for files that are compressed under gzip. 

I don't have the full logs, so I can't deduce the exact reason why the run failed. My guess is that the read file function got confused and thought the decompressed file is actually gzip compressed.

Note `byte 0x8b in position 1` usually signals that the data stream is gzipped (see the top answer of [this thread](https://stackoverflow.com/questions/11072705/twitter-trends-api-unicodedecodeerror-utf8-codec-cant-decode-byte-0x8b-in-po)). 

The scenario runs smoothly on my local machine. 