### PR TITLE
MT-NLG: Check `choices` is in response

### DIFF
--- a/src/proxy/microsoft_client.py
+++ b/src/proxy/microsoft_client.py
@@ -115,8 +115,9 @@ class MicrosoftClient(Client):
                         # Validate the responses, so we don't cache malformed responses with null `logprobs` and `text`
                         if (
                             "choices" not in response
-                            or response["choices"][0]["text"] is None
-                            or response["choices"][0]["logprobs"] is None
+                            or len(response["choices"]) == 0
+                            or response["choices"][0].get("text") is None
+                            or response["choices"][0].get("logprobs") is None
                         ):
                             raise turing.error.OpenAIError(
                                 f"For request: {raw_request}, invalid response from the MT-NLG server: {response}."


### PR DESCRIPTION
Most MT-NLG runs have failed because we're not getting back `choices` in the response. This PR just improves the check, so we can get a better error message than `KeyError: 'choices'`.