### PR TITLE
Add display names to the models

### DIFF
--- a/src/proxy/models.py
+++ b/src/proxy/models.py
@@ -135,7 +135,7 @@ ALL_MODELS = [
         group="gpt3",
         creator_organization="OpenAI",
         name="openai/text-davinci-002",
-        display_name="Instruct GPT-3 (175B, 4k max tokens)",
+        display_name="Instruct GPT-3 (175B, 4000 max tokens)",
         description="GPT-3 from Instruct series 2nd generation (175B parameters) - 4000 max tokens",
         tags=[TEXT_MODEL_TAG, WIDER_CONTEXT_WINDOW_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG, GPT2_TOKENIZER_TAG],
     ),


### PR DESCRIPTION
## Purpose

This PR enhances model data with the display names used in the paper. These will be served in the UI in the group tables. The model names in the following snippet are directly copied. I assigned the display names for the models that aren't included in the list below.

```
% Models
\newcommand\gptj{GPT-J-6B\xspace}
\newcommand\gptneox{GPT-NeoX-20B\xspace}

\newcommand\gptdavinci{GPT-3 (175B)\xspace}
\newcommand\gptcurie{GPT-3 (6.7B)\xspace}
\newcommand\gptbabbage{GPT-3 (1.3B)\xspace}
\newcommand\gpttextdavinci{Instruct GPT-3 (175B)\xspace}
\newcommand\gpttextcurie{Instruct GPT-3 (6.7B)\xspace}
\newcommand\gpttextbabbage{Instruct GPT-3 (1.3B)\xspace}

\newcommand\anthropic{Anthropic-LM (52B)\xspace}
\newcommand\mtnlg{MT-NLG (530B)\xspace}
\newcommand\jurassicjumbo{Jurassic Jumbo (178B)\xspace}
\newcommand\jurassicgrande{Jurassic Grande (17B)\xspace}
\newcommand\jurassiclarge{Jurassic Large (7.5B)\xspace}
```