### PR TITLE
Refactor BBQMetric to implement evaluate_instances

### DIFF
--- a/src/benchmark/bbq_metrics.py
+++ b/src/benchmark/bbq_metrics.py
@@ -46,8 +46,7 @@ class BBQMetric(Metric):
     For more details, see the equation on page 6 of https://arxiv.org/pdf/2110.08193.pdf
     """
 
-    @staticmethod
-    def evaluate_instances(request_states: List[RequestState]) -> List[Stat]:
+    def evaluate_instances(self, request_states: List[RequestState]) -> List[Stat]:
 
         amb_non_unknown = 0  # keep track of the number of non-unknowns
         disamb_non_unknown = 0  # keep track of the number of non-unknowns


### PR DESCRIPTION
## Purpose

This PR refactors the `BBQMetric` to implement `evaluate_instances` (rather than `evaluate`). Should be merged after #680.

Relevant to @rishibommasani @percyliang @dtsip.

## Updates

### 2022/08/10

After merging #680, running `BBQMetric` on `ai21/j1-large` produces the following stats:
```
      MetricName(name='bbq_accuracy', k=None, split='test', sub_split=None, perturbation=None)[min=0.394, mean=0.394, max=0.394, sum=0.394 (1)]
      MetricName(name='bbq_metric_ambiguous_bias', k=None, split='test', sub_split=None, perturbation=None)[min=-0.111, mean=-0.111, max=-0.111, sum=-0.111 (1)]
      MetricName(name='bbq_metric_unambiguous_bias', k=None, split='test', sub_split=None, perturbation=None)[min=-0.247, mean=-0.247, max=-0.247, sum=-0.247 (1)]
```

Previous stats can be seen [here](https://crfm-models.stanford.edu/static/benchmarking.html?runSpec=bbq%3Asubject%3Dall%2Cmodel%3Dai21_j1-large) (the values in the link may change with new runs) on the website and they are:
```
  | accuracy                                                                            | 0.37
  | BBQMetric: bias score across ambiguous examples     | -0.037
  | BBQMetric: bias score across unambiguous examples | -0.173
```
Note that this set of stats may have been computed while not respecting the `split`, `k`, and `perturbation` fields.
