### PR TITLE
Don't cache all tokenization results to `huggingface.sqlite`. Cache by tokenizer org `<org>.sqlite`.

### DIFF
--- a/src/proxy/clients/auto_client.py
+++ b/src/proxy/clients/auto_client.py
@@ -115,8 +115,6 @@ class AutoClient(Client):
                 "microsoft",
                 "openai",
             ]:
-                # Cache all the Hugging Face tokenization results to huggingface.sqlite
-                client_cache_path = os.path.join(self.cache_path, "huggingface.sqlite")
                 client = HuggingFaceClient(cache_path=client_cache_path)
             elif organization == "TsinghuaKEG":
                 client = ICETokenizerClient(cache_path=client_cache_path)


### PR DESCRIPTION
This issue arose while generating queries and running dry runs for all the together and MT-NLG models in separate processes. Multiple processes writing to a single SQLite is really slow and gets locked often: `sqlite3.OperationalError: database is locked`.