### PR TITLE
Fix prompts for `wikifact`

### DIFF
--- a/src/benchmark/adapter.py
+++ b/src/benchmark/adapter.py
@@ -602,12 +602,7 @@ class Adapter:
             if self.window_service.fits_within_context_window(
                 text=prompt, expected_completion_token_length=self.adapter_spec.max_tokens,
             ):
-                # Most models cannot handle spaces at the end of prompts. For example, when
-                # given the prompt "1 2 3 4", GPT-J will output "5 6 7...", but when given
-                # "1 2 3 4 " (white space at the end) will output a bunch of white spaces.
-                # This is an issue even with larger models like OpenAI's Davinci. When fed
-                # "1 2 3 4 ", it outputs "下一页 尾页 页码：1/4<|endoftext|>".
-                return Prompt(prompt.rstrip(), num_in_context_examples=len(train_instances), input_truncated=False)
+                return Prompt(prompt, num_in_context_examples=len(train_instances), input_truncated=False)
 
             train_instances = train_instances[:-1]
             prompt = construct_prompt_helper(train_instances)
@@ -624,7 +619,7 @@ class Adapter:
         original_length = len(prompt)
         prompt = self.window_service.truncate_from_right(prompt, self.adapter_spec.max_tokens)
         input_truncated = len(prompt) < original_length
-        return Prompt(prompt.rstrip(), num_in_context_examples=len(train_instances), input_truncated=input_truncated)
+        return Prompt(prompt, num_in_context_examples=len(train_instances), input_truncated=input_truncated)
 
     def construct_example_prompt(self, instance: Instance, include_output: bool, reference_index: Optional[int]) -> str:
         """Return a list of lines corresponding to this example (part of the prompt)."""

--- a/src/benchmark/run_specs.py
+++ b/src/benchmark/run_specs.py
@@ -374,7 +374,7 @@ def get_wikifact_spec(k: str, subject: str) -> RunSpec:
     adapter_spec = AdapterSpec(
         method=ADAPT_GENERATION,
         input_prefix="",
-        output_prefix="",
+        output_prefix=" ",  # Separate subject and predicate by a space
         num_train_trials=1,
         max_train_instances=5,
         max_eval_instances=SIMPLE_METRIC_MAX_EVAL_INSTANCES,

--- a/src/benchmark/scenarios/wikifact_scenario.py
+++ b/src/benchmark/scenarios/wikifact_scenario.py
@@ -142,7 +142,8 @@ class WIKIFactScenario(Scenario):
                 raw_data = json.loads(line)
                 if raw_data["property"] != self.subject:
                     continue
-                question = raw_data["template"] + " "
+
+                question = raw_data["template"]
                 answers = flatten_list(raw_data["result_names"])
 
                 def answer_to_reference(answer):


### PR DESCRIPTION
Closes https://github.com/stanford-crfm/benchmarking/issues/629

Most models (including Together models) cannot handle prompts with whitespace at the end (see below). This fix is to remove the extra whitespace at the end of prompts just for `wikifact` for now.

![space_at_end_demo](https://user-images.githubusercontent.com/16793796/185466645-34391648-b2a6-422a-a34b-197ecdf7db27.png)


Undid fix in here: https://github.com/stanford-crfm/benchmarking/pull/267