### PR TITLE
Adding tex format for group tables

### DIFF
--- a/src/benchmark/presentation/summarize.py
+++ b/src/benchmark/presentation/summarize.py
@@ -270,22 +270,27 @@ class Summarizer:
             json.dumps(list(map(asdict_without_nones, self.runs)), indent=2),
         )
 
-    def write_tables_to_tex(self, tables: List[Table], save_path: str, skip_blank_columns=True):
+    def write_tables_to_latex(self, tables: List[Table], save_path: str, skip_blank_columns=True):
         ensure_directory_exists(save_path)
         for table in tables:
+            table_name = table.title.replace(" ", "_").replace("/", "_")
             columns_shown = list(range(len(table.header)))
             # TODO: should we skip blank columns even earlier?
             if skip_blank_columns:
                 columns_shown = [i for i in columns_shown if not all(row[i].value is None for row in table.rows)]
-            tex = "\\begin{tabular}{l" + "r" * (len(columns_shown) - 1) + "}\n"
-            tex += "\\toprule\n"
-            tex += " & ".join(str(cell.value) for i, cell in enumerate(table.header) if i in columns_shown) + " \\\\\n"
-            tex += "\\midrule\n"
+            latex = "\\begin{table}[htp]\n"
+            latex += "\\begin{tabular}{l" + "r" * (len(columns_shown) - 1) + "}\n"
+            latex += "\\toprule\n"
+            latex += " & ".join(str(table.header[i].value) for i in columns_shown) + " \\\\\n"
+            latex += "\\midrule\n"
             for row in table.rows:
-                tex += " & ".join(str(cell.value or "") for i, cell in enumerate(row) if i in columns_shown) + " \\\\\n"
-            tex += "\\bottomrule\n"
-            tex += "\\end{tabular}\n"
-            write(os.path.join(save_path, table.title.replace(" ", "_").replace("/", "_") + ".tex"), tex)
+                latex += " & ".join(str(row[i].display_value or row[i].value or "") for i in columns_shown) + " \\\\\n"
+            latex += "\\bottomrule\n"
+            latex += "\\end{tabular}\n"
+            latex += "\\caption{Results for group " + table.title + "}\n"
+            latex += "\\label{fig:" + table_name + "}\n"
+            latex += "\\end{table}\n"
+            write(os.path.join(save_path, f"{table_name}.tex"), latex.replace("%", "\\%"))
 
     def create_index_table(self) -> Table:
         header = [
@@ -326,10 +331,9 @@ class Summarizer:
         if aggregate_stat is None:
             return Cell(None)
         value = aggregate_stat.mean
-        if value:
-            value = round(value, 3)
+        display_value = round(value, 3) if value else value
         description = aggregate_stat.bare_str()  # Show more information
-        return Cell(value=value, display_value=value, description=description)
+        return Cell(value=value, display_value=display_value, description=description)
 
     def create_group_table(
         self, title: str, scenario_group: ScenarioGroup, model_to_runs: Dict[str, List[Run]], link_to_runs: bool
@@ -444,7 +448,7 @@ class Summarizer:
             write(
                 os.path.join(groups_path, group.name + ".json"), json.dumps(list(map(asdict_without_nones, tables))),
             )
-            self.write_tables_to_tex(tables, os.path.join(groups_path, "tex"))
+            self.write_tables_to_latex(tables, os.path.join(groups_path, "latex"))
 
 
 @htrack(None)

--- a/src/proxy/static/benchmarking.css
+++ b/src/proxy/static/benchmarking.css
@@ -33,7 +33,7 @@ tr {
   background-color: #f9f9f9;
 }
 
-.tex {
+.latex {
   white-space: pre-wrap;
   font-family: monospace;
   background-color: #f9f9f9

--- a/src/proxy/static/benchmarking/benchmarking.js
+++ b/src/proxy/static/benchmarking/benchmarking.js
@@ -337,7 +337,7 @@ $(function () {
       $table.append($row);
     });
     $output.append($table);
-    $output.append($('<a>', {href: '?tex=' + table.title.replaceAll(" ", "_").replace("/", "_")}).append('tex'));
+    $output.append($('<a>', {href: '?latex=' + table.title.replaceAll(" ", "_").replace("/", "_")}).append('latex'));
     return $output;
   }
 
@@ -349,8 +349,8 @@ $(function () {
     return $output;
   }
 
-  function renderTex(tex) {
-    const $output = $('<div>', {class: 'tex'}).append(tex);
+  function renderLatex(latex) {
+    const $output = $('<div>', {class: 'latex'}).append(latex);
     return $output;
   }
 
@@ -403,11 +403,11 @@ $(function () {
         console.log('group', tables);
         $main.append(renderTables(tables));
       });
-    } else if (urlParams.tex) {
+    } else if (urlParams.latex) {
       // Tex corresponding to a group
-      $.get(`benchmark_output/runs/${suite}/groups/tex/${urlParams.tex}.tex`, {}, (tex) => {
-        console.log('tex', tex);
-        $main.append(renderTex(tex));
+      $.get(`benchmark_output/runs/${suite}/groups/latex/${urlParams.latex}.tex`, {}, (latex) => {
+        console.log('latex', latex);
+        $main.append(renderLatex(latex));
       });
     } else {
       $main.append(renderLandingPage());


### PR DESCRIPTION
To facilitate copying the results to the paper this PR is adding the tex format of each table:
- `summarize.py` saves a `.tex` file for each table it generates
- added a link from each `?group=` webpage to a corresponding `?tex=` page that contains the tex code

Happy to discuss alternative implementations!

(added a few fixes to `MetricNameMatcher` to make it compatible with our current metric structure, but let me know if I should do something else for backwards compatibility)