### PR TITLE
remove blimp todo

### DIFF
--- a/src/proxy/static/schema.yaml
+++ b/src/proxy/static/schema.yaml
@@ -431,7 +431,7 @@ scenario_groups:
       - accuracy
       - efficiency
     environment:
-      main_name: exact_match # TODO: This seems incorrect; we need to add the BLiMP metric
+      main_name: exact_match
       main_split: test
 
   - name: bold


### PR DESCRIPTION
removes todo, closes #793.  

The `double-exact-match` has the alternative, which splits the metrics. 