### PR TITLE
Set MT-NLG Window Service's prefix_token value.

### DIFF
--- a/src/benchmark/window_services/mt_nlg_window_service.py
+++ b/src/benchmark/window_services/mt_nlg_window_service.py
@@ -9,14 +9,19 @@ class MTNLGWindowService(GPT2WindowService):
     @property
     def max_sequence_length(self) -> int:
         """
-        The max length of the model input. The max sequence length for the MT-NLG models is 2048.
+        The max length of the model input. MT-NLG does not predict the logprob of the first
+        input token so max_sequence_length is one token shorter than max_request_length.
+        """
+        return self.max_request_length - 1
+
+    @property
+    def max_request_length(self) -> int:
+        """
+        The max request length for the MT-NLG models is 2048.
         Source: https://github.com/microsoft/turing-academic-TNLG
         """
         return 2048
 
     @property
-    def max_request_length(self) -> int:
-        """
-        The max request length for the MT-NLG models is also 2048.
-        """
-        return self.max_sequence_length
+    def prefix_token(self) -> str:
+        return "<<"


### PR DESCRIPTION
Set MT-NLG window service's `prefix_token` to `<<` following Christian's advice. Changed `max_sequence_length` to 2047 now that we have a non-empty prefix token.