### PR TITLE
make synonyms threadsafe

### DIFF
--- a/src/benchmark/augmentations/synonym_perturbation.py
+++ b/src/benchmark/augmentations/synonym_perturbation.py
@@ -54,13 +54,14 @@ class SynonymPerturbation(Perturbation):
         try:
             self.spacy_model = spacy.load("en_core_web_sm")
         except OSError:
-            # no idea why this keeps failing, tested multiple times
             spacy.cli.download("en_core_web_sm")  # type: ignore
             self.spacy_model = spacy.load("en_core_web_sm")
 
         output_dir = os.path.join("benchmark_output", "perturbations", self.name)
         Path(output_dir).mkdir(parents=True, exist_ok=True)
         try:
+            # We cannot use wordnet.synsets directly since it's not thread-safe. So we copy the synsets to
+            # wordnet_synonyms.json and use that in combination with _morphy (as done in the original wordnet.synsets).
             _ = wordnet._morphy("test", "n")
         except LookupError:
             nltk.data.path.append(output_dir)


### PR DESCRIPTION
Replaced the wordnet.synsets (which was throwing errors when parallelized; see https://github.com/stanford-crfm/benchmarking/issues/770) with a dict + some additional logic.

It's a bit tricky since synsets does not just look up a dictionary but actually takes the base form of a word (e.g., largest -> large) before that. (This is done via the _morphy method which can apparently differ from the morphy method...) I tried to make sure that the synonyms we get are the same (made sure that boolq:data_augmentation=canonical -m 100 is the same before and after), but we might get some cache misses due to corner-cases.