### PR TITLE
reorder scenarios in schema to match paper

### DIFF
--- a/src/proxy/static/schema.yaml
+++ b/src/proxy/static/schema.yaml
@@ -899,4 +899,3 @@ scenario_groups:
       - efficiency_detailed
     environment:
       main_split: test
-      


### PR DESCRIPTION
This PR re-orders the scenarios to go from alphabetical to structural, i.e. aligning with the structure of the paper. 