### PR TITLE
move num_instances to BasicMetric

### DIFF
--- a/src/benchmark/metrics/basic_metrics.py
+++ b/src/benchmark/metrics/basic_metrics.py
@@ -735,6 +735,7 @@ class BasicMetric(Metric):
         """Derive calibration metrics if applicable. We don't worry about splits and perturbations here."""
         derived_stats: List[Stat] = []
         derived_stats.extend(compute_calibration_metrics(per_instance_stats))
+        derived_stats.append(Stat(MetricName("num_instances")).add(len(per_instance_stats)))
         return derived_stats
 
 

--- a/src/benchmark/metrics/metric.py
+++ b/src/benchmark/metrics/metric.py
@@ -178,12 +178,6 @@ class Metric(ABC):
                 for stat in self.derive_per_instance_stats(instance_dict):
                     merge_stat(trial_stats, add_context(stat, context))
 
-                # keep track of how many instances are in each subset
-                # TODO: `num_instances` will be computed multiple times if there are more than
-                #       one child Metric class that inherits this method.
-                num_instances_stat = Stat(MetricName("num_instances")).add(len(instance_dict))
-                merge_stat(trial_stats, add_context(num_instances_stat, context))
-
             # aggregate request states and call evaluate_instances in case the metric needs it
             grouped_request_states: Dict[MetricContext, List[RequestState]] = defaultdict(list)
             for instance in scenario_state.instances:


### PR DESCRIPTION
This ensures that the metric is not computed multiple times when `Metric` is inherited.