### PR TITLE
to address issue 42, sort predictions

### DIFF
--- a/src/benchmark/metrics/basic_metrics.py
+++ b/src/benchmark/metrics/basic_metrics.py
@@ -446,7 +446,7 @@ class BasicMetric(Metric):
         assert request_state.result is not None
         # TODO: Sort the predictions, or take them from the top tokens of the first completion
         #       https://github.com/stanford-crfm/benchmarking/issues/42
-        preds = sorted([completion for completion in request_state.result.completions], key=lambda x: -x.logprob)
+        preds = sorted(request_state.result.completions, key=lambda x: -x.logprob)
         preds = [completion.text.strip() for completion in preds]
 
         # Apply mapping if exists (e.g., for multiple-choice questions A -> Boston, B -> New York)


### PR DESCRIPTION
To address https://github.com/stanford-crfm/benchmarking/issues/42, I added a line to sort the predictions by the log probability.