### PR TITLE
Fix loading NaturalQA instances

### DIFF
--- a/src/benchmark/scenarios/natural_qa_scenario.py
+++ b/src/benchmark/scenarios/natural_qa_scenario.py
@@ -1,3 +1,4 @@
+import gzip
 import json
 import os
 import re
@@ -213,7 +214,7 @@ class NaturalQAScenario(Scenario):
         all_samples: List[dict] = []
 
         with htrack_block(f"Reading {target_file}"):
-            with open(target_file) as fp:
+            with gzip.open(target_file) as fp:
                 for line in fp:
                     raw = json.loads(line)
                     # Only keep dataset samples with at least one short answer
@@ -249,7 +250,7 @@ class NaturalQAScenario(Scenario):
         splits = {"train": TRAIN_SPLIT, "val": VALID_SPLIT}
         for file in file_list:
             source_url: str = f"{base_url}/{file}"
-            target_path: str = os.path.join(data_path, file.rstrip(".gz"))
+            target_path: str = os.path.join(data_path, file)
             ensure_file_downloaded(source_url=source_url, target_path=target_path)
 
             instances.extend(self.get_file_instances(target_path, splits=splits))

--- a/src/common/general.py
+++ b/src/common/general.py
@@ -95,7 +95,8 @@ def ensure_file_downloaded(source_url: str, target_path: str, unpack: bool = Fal
             shell(["mv", tmp2_path, target_path])
         os.unlink(tmp_path)
     else:
-        if source_url.endswith(".gz"):
+        # Don't decompress if desired `target_path` ends with `.gz`.
+        if source_url.endswith(".gz") and not target_path.endswith(".gz"):
             gzip_path = f"{target_path}.gz"
             shell(["mv", tmp_path, gzip_path])
             # gzip writes its output to a file named the same as the input file, omitting the .gz extension


### PR DESCRIPTION
I ran into the same error even with a fresh download. `ensure_file_downloaded` already ensures the file is downloaded and decompressed. 