### PR TITLE
Disable `msmarco` for now

### DIFF
--- a/src/benchmark/presentation/run_specs.conf
+++ b/src/benchmark/presentation/run_specs.conf
@@ -106,10 +106,11 @@
 
 # TODO: rename scenario to msmarco, track to msmarco - Issue 527
 # TODO: Update valid_topk=30 based on AI21 results
-"msmarco:task=passage,model=full_functionality_text,track=regular,use_qrels_passages=True,use_topk_passages=True,valid_topk=30,num_valid_queries=200": {status: "READY", priority: 2}
-"msmarco:task=passage,model=full_functionality_text,track=trec,use_qrels_passages=True,use_topk_passages=True,valid_topk=30": {status: "READY", priority: 1}
-"msmarco:task=passage,model=full_functionality_text,track=regular,use_qrels_passages=False,use_topk_passages=True,valid_topk=30,num_valid_queries=200": {status: "READY", priority: 2}
-"msmarco:task=passage,model=full_functionality_text,track=trec,use_qrels_passages=False,use_topk_passages=True,valid_topk=30": {status: "READY", priority: 1}
+# TODO: reenable after MultipleInstance refactor
+# "msmarco:task=passage,model=full_functionality_text,track=regular,use_qrels_passages=True,use_topk_passages=True,valid_topk=30,num_valid_queries=200": {status: "READY", priority: 2}
+# "msmarco:task=passage,model=full_functionality_text,track=trec,use_qrels_passages=True,use_topk_passages=True,valid_topk=30": {status: "READY", priority: 1}
+# "msmarco:task=passage,model=full_functionality_text,track=regular,use_qrels_passages=False,use_topk_passages=True,valid_topk=30,num_valid_queries=200": {status: "READY", priority: 2}
+# "msmarco:task=passage,model=full_functionality_text,track=trec,use_qrels_passages=False,use_topk_passages=True,valid_topk=30": {status: "READY", priority: 1}
 
 
 ##### Summarization #####


### PR DESCRIPTION
Currently failing with:

```
  Error when running msmarco:task=passage,model=full_functionality_text,track=trec,use_qrels_passages=False,use_topk_passages=True,valid_topk=30:
Traceback (most recent call last):
  File "/juice/scr/nlp/crfm/benchmarking/benchmarking/src/benchmark/presentation/present.py", line 98, in run
    new_run_specs = run_benchmarking(
  File "/juice/scr/nlp/crfm/benchmarking/benchmarking/src/benchmark/run.py", line 63, in run_benchmarking
    runner.run_all()
  File "/juice/scr/nlp/crfm/benchmarking/benchmarking/src/benchmark/runner.py", line 92, in run_all
    self.run_one(run_spec)
  File "/juice/scr/nlp/crfm/benchmarking/benchmarking/src/benchmark/runner.py", line 136, in run_one
    [] if self.dry_run else [create_metric(metric_spec) for metric_spec in run_spec.metric_specs]
  File "/juice/scr/nlp/crfm/benchmarking/benchmarking/src/benchmark/runner.py", line 136, in <listcomp>
    [] if self.dry_run else [create_metric(metric_spec) for metric_spec in run_spec.metric_specs]
  File "/juice/scr/nlp/crfm/benchmarking/benchmarking/src/benchmark/metrics/metric.py", line 356, in create_metric
    return create_object(metric_spec)
  File "/juice/scr/nlp/crfm/benchmarking/benchmarking/src/common/object_spec.py", line 22, in create_object
    module = getattr(module, component)
AttributeError: module 'benchmark.metrics.multiple_request_metrics' has no attribute 'InformationRetrievalMetric'
```