### PR TITLE
Summarization metrics on website

### DIFF
--- a/src/proxy/static/schema.yaml
+++ b/src/proxy/static/schema.yaml
@@ -358,9 +358,11 @@ metric_groups:
     metrics:
       - name: SummaC
         split: ${main_split}
-      - name: coverage
+      - name: summarization_coverage
         split: ${main_split}
-      - name: compression
+      - name: summarization_density
+        split: ${main_split}
+      - name: summarization_compression
         split: ${main_split}
 
   - name: apps_metrics


### PR DESCRIPTION
We have results for all of coverage/density/compression.
https://crfm-models.stanford.edu/static/benchmarking.html?runs=undefined&runSpec=summarization_cnndm%3Atemperature%3D0.3%2Cdevice%3Dcpu%2Cmodel%3Dai21_j1-jumbo#metrics
For the purposes of the main table, what do we want to visualize @fladhak @esdurmus? 
https://crfm-models.stanford.edu/static/benchmarking.html?group=summarization_cnndm

Right now, it would look like:

Acc, SummAc, (eventually the QA metric), (eventually human?), coverage, density, compression, bias ..., toxicity, efficiency

This feels a bit crowded. But what do you think?

(This PR only just fixes an error that led to the 3 methods from the newsroom paper not showing up. In some sense, the fact we are displaying this is a bit different from other scenarios as all of these are not really top-level metrics (including even faithfulness because it isn't something we measure holistically))