### PR TITLE
Update Main Metric to Pass and Fix Display Name for HumanEval

### DIFF
--- a/src/proxy/static/schema.yaml
+++ b/src/proxy/static/schema.yaml
@@ -370,11 +370,6 @@ metric_groups:
       - name: strict_acc
         split: ${main_split}
 
-  - name: humaneval_metrics
-    metrics:
-      - name: pass
-        split: ${main_split}
-
   - name: bbq_metrics
     metrics:
       - name: bbq_metric_ambiguous_bias
@@ -775,8 +770,7 @@ scenario_groups:
     display_name: HumanEval (Code)
     description: The HumanEval benchmark for measuring functional correctness for synthesizing programs from docstrings (Chen et al., 2021).
     metric_groups:
-      # We do not include accuracy as it is subsumed by humaneval
-      - humaneval_metrics
+      - accuracy
       - efficiency
     environment:
       main_name: pass


### PR DESCRIPTION
The main metric for HumanEval is now pass instead of code_eval_acc. Also change the display name of pass to pass@1 for clarity.