### PR TITLE
Update schema.yaml: use denoised runtime as default inference efficiency metric

### DIFF
--- a/src/proxy/static/schema.yaml
+++ b/src/proxy/static/schema.yaml
@@ -394,8 +394,7 @@ metric_groups:
 
   - name: efficiency
     metrics:
-    - name: inference_idealized_runtime
-      # TODO: should we use inference_denoised_runtime instead?
+    - name: inference_denoised_runtime
       split: ${main_split}
 
   - name: efficiency_detailed


### PR DESCRIPTION
I looked at the runtime vs. denoised runtime graph, and average runtime >= average denoised runtime for ~99% of scenarios, so I am happy to make this the default.

![image](https://user-images.githubusercontent.com/2724038/189723302-d13e6e91-8098-4cfb-a948-3e378fb094d2.png)
