### PR TITLE
Create run_specs_ir.conf

### DIFF
--- a/src/benchmark/presentation/run_specs_ir.conf
+++ b/src/benchmark/presentation/run_specs_ir.conf
@@ -1,0 +1,2 @@
+"msmarco:task=passage,model=full_functionality_text,track=regular,use_qrels_passages=True,use_topk_passages=True,valid_topk=30,num_valid_queries=200": {status: "READY", priority: 2}
+"msmarco:task=passage,model=full_functionality_text,track=trec,use_qrels_passages=True,use_topk_passages=True,valid_topk=30": {status: "READY", priority: 1}


### PR DESCRIPTION
Adding a small `conf` file for the IR tasks.

There are two more configurations we would like to run, but all the instances to be created by them is already contained in the configurations we already have. Sharing them here just in case:
```
"msmarco:task=passage,model=full_functionality_text,track=regular,use_qrels_passages=False,use_topk_passages=True,valid_topk=30,num_valid_queries=200": {status: "READY", priority: 2}
"msmarco:task=passage,model=full_functionality_text,track=trec,use_qrels_passages=False,use_topk_passages=True,valid_topk=30": {status: "READY", priority: 1}
```

