### PR TITLE
Make calibration more general.

### DIFF
--- a/src/benchmark/metrics/basic_metrics.py
+++ b/src/benchmark/metrics/basic_metrics.py
@@ -19,7 +19,6 @@ from rouge_score import rouge_scorer
 from common.hierarchical_logger import hlog
 from common.request import Token, Sequence
 from benchmark.adapter import (
-    ADAPT_MULTIPLE_CHOICE_JOINT,
     ADAPT_MULTIPLE_CHOICE_SEPARATE_ORIGINAL,
     ADAPT_MULTIPLE_CHOICE_SEPARATE_CALIBRATED,
     AdapterSpec,


### PR DESCRIPTION
Compute max-probs for all generation datasets. We compute calibration if max prob and exact_match were computed.

If the generation involves multiple tokens, we take the product of the probabilities. I tested this on boolq and raft:subset=ade_corpus_v2 (and the older datasets I tested on, mmlu, blimp, wikitext). It seems to work fine, it produces calibration metrics for boolq, raft, mmlu, bimp, and does not produce them for wikitext as desired.

 I still need to find a test case where there are multiple tokens being generated. It seemed like raft:subset=ade_corpus_v2 has some such examples (Rishi found some) but I ran with "-m 100" and didn't come across those - and a bit afraid to use up too many tokens.