### PR TITLE
Make NaturalQuestions load faster by caching

### DIFF
--- a/src/benchmark/scenarios/natural_qa_scenario.py
+++ b/src/benchmark/scenarios/natural_qa_scenario.py
@@ -189,11 +189,7 @@ class NaturalQAScenario(Scenario):
                 long_answers.append(long_ans)
 
         return RawInstance(
-            title=title,
-            document=document,
-            question=question,
-            long_answers=long_answers,
-            short_answers=short_answers,
+            title=title, document=document, question=question, long_answers=long_answers, short_answers=short_answers,
         )
 
     def create_instance(self, instance: RawInstance, split: str) -> Instance:


### PR DESCRIPTION
Reduced time from 2 minutes to 5 seconds, which is useful for debugging.

Cache the intermediate computation (`RawInstance`), which should be relatively stable.