### PR TITLE
Fix ICE Gender Filtering

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,8 @@ pyhocon==0.3.58
 pyOpenSSL==21.0.0
 sqlitedict==1.7.0
 sentencepiece==0.1.96   # Necessary for some of the HuggingFace tokenizers
-# torch==1.12.1+cu113
-# torchvision==0.13.1+cu113
+torch==1.12.1+cu113
+torchvision==0.13.1+cu113
 transformers==4.20.1
 zstandard==0.17.0
 jsonlines==3.0.0


### PR DESCRIPTION
The gender filtering for ICE wasn't working with a) subsets that use HDR files for metadata (IND, USA) and runs with multiple subsets (e.g. subset=all). This PR fixes those two issues so the runs specified in our current configuration will run as expected.