### PR TITLE
Populate the robustness deep dive with perturbations

### DIFF
--- a/src/benchmark/run_expander.py
+++ b/src/benchmark/run_expander.py
@@ -499,6 +499,17 @@ PERTURBATION_SPECS_DICT: Dict[str, Dict[str, List[PerturbationSpec]]] = {
     "robustness": {"robustness": ROBUSTNESS_PERTURBATION_SPECS},
     "fairness": {"fairness": FAIRNESS_PERTURBATION_SPECS},
     "canonical": {"canonical": ROBUSTNESS_PERTURBATION_SPECS + FAIRNESS_PERTURBATION_SPECS},
+    "robustness_all": {
+        "robustness_all": [
+            *contract_and_expand(),
+            filler(0.1),
+            lower(),
+            misspelling(prob=0.1),
+            space(max_spaces=3),
+            synonym(prob=0.1),
+            typo(prob=0.01),
+        ]
+    },
 }
 
 


### PR DESCRIPTION
Adding the list of perturbations that we want for the robustness deep dive (not sure why this did not make it into the previous PR).

It contains the perturbations from the "robustness mix" separated, plus a few others. These are still relatively mild perturbations, but we could introduce more aggressive ones and see how performance degrades across models. (cc @percyliang)

I visualized 20 examples here: [IMDB](http://john17.stanford.edu:8000/imdb.html), [natural_qa](http://john17.stanford.edu:8000/natural_qa.html), [MMLU](http://john17.stanford.edu:8000/mmlu.html).

The run_specs_robustness.conf file is based on the discussion we had with @rishibommasani a while ago, but I'm happy to go with whatever set of "representative" scenarios and/or run these on fewer instances.