### PR TITLE
Switch Cache to using diskcache instead of sqlitedict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ Mako==1.1.5
 pyhocon==0.3.58
 pyOpenSSL==21.0.0
 sqlitedict==1.7.0
+diskcache==5.4.0
 sentencepiece==0.1.96   # Necessary for some of the HuggingFace tokenizers
 torch==1.12.1+cu113
 torchvision==0.13.1+cu113

--- a/src/common/test_cache.py
+++ b/src/common/test_cache.py
@@ -1,30 +1,30 @@
-import os
 import tempfile
+import threading
 
 from common.cache import Cache, cache_stats
 
 
 class TestCache:
     def setup_method(self, method):
-        cache_file = tempfile.NamedTemporaryFile(delete=False)
-        self.cache_path = cache_file.name
-        self.cache = Cache(self.cache_path)
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.cache_path = self.temp_dir.name
         cache_stats.reset()
 
     def teardown_method(self, method):
-        os.remove(self.cache_path)
+        self.temp_dir.cleanup()
 
     def test_get(self):
+        cache = Cache(self.cache_path)
         request = {"name": "request1"}
         compute = lambda: {"response1"}
 
         # The request should not be cached the first time
-        response, cached = self.cache.get(request, compute)
+        response, cached = cache.get(request, compute)
         assert response == {"response1"}
         assert not cached
 
         # The same request should now be cached
-        response, cached = self.cache.get(request, compute)
+        response, cached = cache.get(request, compute)
         assert response == {"response1"}
         assert cached
 
@@ -34,3 +34,52 @@ class TestCache:
         cache_stats.reset()
         assert cache_stats.num_queries[self.cache_path] == 0
         assert cache_stats.num_computes[self.cache_path] == 0
+
+    def test_many_requests(self):
+        cache = Cache(self.cache_path)
+        num_items = 100
+        num_iterations = 20
+        requests = [{"name": "request%d" % i} for i in range(num_items)]
+        responses = ["response%d" % i for i in range(num_items)]
+        for iteration in range(num_iterations):
+            for i in range(num_items):
+                response, cached = cache.get(requests[i], lambda: {responses[i]})
+                assert response == {responses[i]}
+                assert cached == (iteration > 0)
+        assert cache_stats.num_queries[self.cache_path] == num_items * num_iterations
+        assert cache_stats.num_computes[self.cache_path] == num_items
+
+    def test_many_caches(self):
+        num_items = 100
+        num_caches = 20
+        requests = [{"name": "request%d" % i} for i in range(num_items)]
+        responses = ["response%d" % i for i in range(num_items)]
+        for cache_index in range(num_caches):
+            cache = Cache(self.cache_path)
+            for i in range(num_items):
+                response, cached = cache.get(requests[i], lambda: {responses[i]})
+                assert response == {responses[i]}
+                assert cached == (cache_index > 0)
+        assert cache_stats.num_queries[self.cache_path] == num_items * num_caches
+        assert cache_stats.num_computes[self.cache_path] == num_items
+
+    def test_many_threads(self):
+        cache = Cache(self.cache_path)
+        num_items = 100
+        num_threads = 20
+        requests = [{"name": "request%d" % i} for i in range(num_items)]
+        responses = ["response%d" % i for i in range(num_items)]
+
+        def run():
+            for i in range(num_items):
+                response, _ = cache.get(requests[i], lambda: {responses[i]})
+                assert response == {responses[i]}
+
+        threads = [threading.Thread(target=run) for _ in range(num_threads)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=5)
+        assert cache_stats.num_queries[self.cache_path] == num_items * num_threads
+        assert cache_stats.num_computes[self.cache_path] >= num_items
+        assert cache_stats.num_computes[self.cache_path] <= num_items * num_threads

--- a/src/proxy/clients/auto_client.py
+++ b/src/proxy/clients/auto_client.py
@@ -34,7 +34,7 @@ class AutoClient(Client):
         self.credentials = credentials
         self.cache_path = cache_path
         self.clients: Dict[str, Client] = {}
-        self.huggingface_client = HuggingFaceClient(cache_path=os.path.join(self.cache_path, "huggingface.sqlite"))
+        self.huggingface_client = HuggingFaceClient(cache_path=os.path.join(self.cache_path, "huggingface"))
         hlog(f"AutoClient: cache_path = {cache_path}")
 
     def get_client(self, organization: str) -> Client:
@@ -43,7 +43,7 @@ class AutoClient(Client):
 
         if client is None:
             org_id: Optional[str]
-            client_cache_path: str = os.path.join(self.cache_path, f"{organization}.sqlite")
+            client_cache_path: str = os.path.join(self.cache_path, organization)
 
             if organization == "openai":
                 org_id = self.credentials.get("openaiOrgId", None)
@@ -108,7 +108,7 @@ class AutoClient(Client):
         client: Optional[Client] = self.clients.get(organization)
 
         if client is None:
-            client_cache_path: str = os.path.join(self.cache_path, f"{organization}.sqlite")
+            client_cache_path: str = os.path.join(self.cache_path, organization)
             if organization in [
                 "anthropic",
                 "bigscience",

--- a/src/proxy/clients/perspective_api_client.py
+++ b/src/proxy/clients/perspective_api_client.py
@@ -55,7 +55,7 @@ class PerspectiveAPIClient:
         self.client: Optional[discovery.Resource] = None
 
         # Cache requests and responses from Perspective API
-        self.cache = Cache(os.path.join(cache_path, "perspectiveapi.sqlite"))
+        self.cache = Cache(os.path.join(cache_path, "perspectiveapi"))
 
         # httplib2 is not thread-safe. Acquire this lock when sending requests to PerspectiveAPI
         self.request_lock: Optional[threading.RLock] = threading.RLock()

--- a/src/proxy/clients/test_huggingface_client.py
+++ b/src/proxy/clients/test_huggingface_client.py
@@ -1,5 +1,4 @@
 import pytest
-import os
 import tempfile
 
 from common.request import Request, RequestResult
@@ -14,12 +13,12 @@ from .huggingface_client import HuggingFaceClient
 
 class TestHuggingFaceClient:
     def setup_method(self, method):
-        cache_file = tempfile.NamedTemporaryFile(delete=False)
-        self.cache_path: str = cache_file.name
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.cache_path = self.temp_dir.name
         self.client = HuggingFaceClient(cache_path=self.cache_path)
 
     def teardown_method(self, method):
-        os.remove(self.cache_path)
+        self.temp_dir.cleanup()
 
     def test_tokenize(self):
         request = TokenizationRequest(text="I am a computer scientist.")

--- a/src/proxy/clients/test_ice_tokenizer_client.py
+++ b/src/proxy/clients/test_ice_tokenizer_client.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 from typing import List
 
@@ -13,8 +12,8 @@ from .ice_tokenizer_client import ICETokenizerClient
 
 class TestICETokenizerClient:
     def setup_method(self, method):
-        cache_file = tempfile.NamedTemporaryFile(delete=False)
-        self.cache_path: str = cache_file.name
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.cache_path = self.temp_dir.name
         self.client = ICETokenizerClient(cache_path=self.cache_path)
 
         # The test cases were created using the examples from https://github.com/THUDM/icetk#tokenization
@@ -22,7 +21,7 @@ class TestICETokenizerClient:
         self.encoded_test_prompt: List[int] = [39316, 20932, 20035, 20115, 20344, 22881, 35955, 20007]
 
     def teardown_method(self, method):
-        os.remove(self.cache_path)
+        self.temp_dir.cleanup()
 
     def test_tokenize(self):
         request = TokenizationRequest(text=self.test_prompt)

--- a/src/proxy/clients/test_yalm_tokenizer_client.py
+++ b/src/proxy/clients/test_yalm_tokenizer_client.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 from typing import List
 
@@ -13,15 +12,15 @@ from .yalm_tokenizer_client import YaLMTokenizerClient
 
 class TestYaLMTokenizerClient:
     def setup_method(self, method):
-        cache_file = tempfile.NamedTemporaryFile(delete=False)
-        self.cache_path: str = cache_file.name
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.cache_path = self.temp_dir.name
         self.client = YaLMTokenizerClient(cache_path=self.cache_path)
 
         self.test_prompt: str = "The model leverages 100 billion parameters."
         self.encoded_test_prompt: List[int] = [496, 3326, 30128, 1602, 1830, 8529, 8071, 127581]
 
     def teardown_method(self, method):
-        os.remove(self.cache_path)
+        self.temp_dir.cleanup()
 
     def test_tokenize(self):
         request = TokenizationRequest(text=self.test_prompt)

--- a/src/proxy/token_counters/test_openai_token_counter.py
+++ b/src/proxy/token_counters/test_openai_token_counter.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 from typing import List
 
@@ -19,11 +18,12 @@ class TestOpenAITokenCounter:
     )
 
     def setup_method(self, method):
-        self.cache_path: str = tempfile.NamedTemporaryFile(delete=False).name
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.cache_path = self.temp_dir.name
         self.token_counter = OpenAITokenCounter(HuggingFaceClient(self.cache_path))
 
     def teardown_method(self, method):
-        os.remove(self.cache_path)
+        self.temp_dir.cleanup()
 
     def test_count_tokens(self):
         request = Request(prompt=TestOpenAITokenCounter.TEST_PROMPT)


### PR DESCRIPTION
Addresses #944. Significantly speeds up Cache performance: `TestCache` takes less than a second to run, rather than several minutes. Note that diskcache expects a directory rather than a file as the cache path.