### PR TITLE
Updating summarization prompt format to reduce number of incomplete generations.

### DIFF
--- a/src/benchmark/run_specs.py
+++ b/src/benchmark/run_specs.py
@@ -235,7 +235,7 @@ def get_summarization_adapter_spec(num_sents: int, **kwargs) -> AdapterSpec:
     return AdapterSpec(
         method=ADAPT_GENERATION,
         instructions="",
-        input_prefix="###\nArticle:",
+        input_prefix="###\nArticle: ",
         input_suffix="\n\n",
         output_prefix=out_pref,
         output_suffix="\n",


### PR DESCRIPTION
New prompt format is:

```
###
Article: [article text]

Summarize the above article in 3 sentences.
[summary text]

###
Article: [article text]

Summarize the above article in 3 sentences.
[summary text]

###
```
