### PR TITLE
Revert adapter changes

### DIFF
--- a/src/benchmark/adapter.py
+++ b/src/benchmark/adapter.py
@@ -1,7 +1,7 @@
 import random
 from dataclasses import dataclass, field, replace
 from itertools import cycle
-from typing import List, Dict, Tuple, Optional, Callable
+from typing import List, Dict, Tuple, Optional
 from collections import defaultdict, OrderedDict
 
 import numpy as np
@@ -10,7 +10,7 @@ from common.general import serialize, indent_lines, format_text_lines, parallel_
 from common.hierarchical_logger import hlog, htrack, htrack_block
 from common.request import Request, RequestResult
 from common.tokenization_request import TokenizationToken
-from .scenarios.scenario import Instance, TRAIN_SPLIT, EVAL_SPLITS, CORRECT_TAG
+from .scenarios.scenario import Instance, TRAIN_SPLIT, EVAL_SPLITS
 from .window_services.window_service import WindowService, EncodeResult
 from .window_services.window_service_factory import WindowServiceFactory
 from .window_services.tokenizer_service import TokenizerService

--- a/src/benchmark/metrics/ranking_metrics.py
+++ b/src/benchmark/metrics/ranking_metrics.py
@@ -9,8 +9,8 @@ from .metric import Metric
 from .metric_name import MetricName
 from .metric_service import MetricService
 from .statistic import Stat
-from ..adapter import AdapterSpec, RequestState, CORRECT_TAG, ADAPT_RANKING_BINARY
-from ..scenarios.scenario import unpack_tag
+from ..adapter import AdapterSpec, RequestState, ADAPT_RANKING_BINARY
+from ..scenarios.scenario import unpack_tag, CORRECT_TAG
 
 
 @dataclass


### PR DESCRIPTION
@teetone reported that the adapter changes caused cache misses. Reverting the adapter changes to isolate the issue. Alternative to #952, won't be needed if #952 gets merged / good.