### PR TITLE
Add medium contamination level

### DIFF
--- a/src/benchmark/presentation/contamination.py
+++ b/src/benchmark/presentation/contamination.py
@@ -11,16 +11,19 @@ CONTAMINATION_YAML_PATH: str = "src/proxy/static/contamination.yaml"
 
 # Contamination levels
 CONTAMINATION_LEVEL_WEAK = "weak"
+CONTAMINATION_LEVEL_MEDIUM = "medium"
 CONTAMINATION_LEVEL_STRONG = "strong"
 
 CONTAMINATION_SYMBOLS = {
     CONTAMINATION_LEVEL_WEAK: "⚠",
+    CONTAMINATION_LEVEL_MEDIUM: "💀",
     CONTAMINATION_LEVEL_STRONG: "☠",
 }
 
 # These are CSS styles applied to cells that have the type of contamination.
 CONTAMINATION_STYLES = {
-    CONTAMINATION_LEVEL_WEAK: {"color": "gray"},
+    CONTAMINATION_LEVEL_WEAK: {"color": "darkgray"},
+    CONTAMINATION_LEVEL_MEDIUM: {"color": "gray"},
     CONTAMINATION_LEVEL_STRONG: {"color": "lightgray"},
 }
 
@@ -38,7 +41,7 @@ class ContaminationPoint:
 
     scenario_groups: List[str]
 
-    # How contaminated (strong or weak)
+    # How contaminated (strong, medium, or weak)
     level: str
 
     # Explanation of how we know

--- a/src/proxy/static/contamination.yaml
+++ b/src/proxy/static/contamination.yaml
@@ -7,7 +7,7 @@ points:
     - together/bloom
     scenario_groups:
     - the_pile
-    level: strong
+    level: medium
     description: BLOOM is explicitly trained on the Pile, i.e. data from the same distribution as the test set. See https://huggingface.co/spaces/bigscience/BigScienceCorpus.
 
   - models:
@@ -15,7 +15,7 @@ points:
     - gooseai/gpt-j-6b
     scenario_groups:
     - the_pile
-    level: strong
+    level: medium
     description: GPT-J is explicitly trained on the Pile, i.e. data from the same distribution as the test set. See https://arankomatsuzaki.wordpress.com/2021/06/04/gpt-j/.
 
   - models:
@@ -23,7 +23,7 @@ points:
     - gooseai/gpt-neox-20b
     scenario_groups:
     - the_pile
-    level: strong
+    level: medium
     description: GPT-NeoX is explicitly trained on the Pile, i.e. data from the same distribution as the test set. See https://arxiv.org/abs/2204.06745.
 
   - models:
@@ -31,7 +31,7 @@ points:
     - together/opt-175b
     scenario_groups:
     - the_pile
-    level: strong
+    level: medium
     description: OPT is explicitly trained on the Pile, i.e. data from the same distribution as the test set. See https://arxiv.org/abs/2205.01068.
 
   - models:
@@ -39,21 +39,21 @@ points:
     - microsoft/TNLGv2_530B
     scenario_groups:
     - the_pile
-    level: strong
+    level: medium
     description: MT-NLG is explicitly trained on the Pile, i.e. data from the same distribution as the test set. See https://arxiv.org/abs/2201.11990.
 
   - models:
     - anthropic/stanford-online-all-v4-s3
     scenario_groups:
     - the_pile
-    level: strong
+    level: medium
     description: Anthropic is explicitly trained on the Pile, i.e. data from the same distribution as the test set. See https://arxiv.org/abs/2112.00861.
 
   - models:
     - together/yalm
     scenario_groups:
     - the_pile
-    level: strong
+    level: medium
     description: YaLM is explicitly trained on the Pile, i.e. data from the same distribution as the test set. See https://github.com/yandex/YaLM-100B.
 
 # Models explicitly trained on specific downstream scenarios
@@ -66,7 +66,7 @@ points:
     - summarization_xsum
     - summarization_cnndm
     - imdb
-    level: strong
+    level: medium
     description: T0++ is explicitly trained on these datasets, i.e. data from the same distribution as the test set. See Table 5 on page 24 of https://arxiv.org/pdf/2110.08207.pdf.
 
 # Models with contamination analyses.


### PR DESCRIPTION
**Summary of changes.** This closes #859. 
1. Added medium contamination level in `contamination.py`: I modified the gray-colors for contamination levels and used skull as the emoji after looking for a bit on https://emojipedia.org/. The only other things I saw that made saw were specific terms with other semantics (e.g. radioactive, biohazard) or too visually subtle (coffin, headstone). Not sure it is obvious whether skull or skull w/ bones is more dangerous (currently it is caution < skull < skull w/ bones).
2. I modified the annotations (also in the spreadsheet) to include the Pile-training for models (e.g. OPT, GPT-NeoX) akin to T0++ in our medium category. The descriptions also are fairly clear what is going on. 

Some interesting subtleties:
a. Previously, when I/we assumed text-davinci/etc. was InstructGPT, the models inherited the analysis from Brown et al. from GPT-3 as derivatives of GPT-3. However, now that we don't know this, they don't inherit this analysis (which may or may not be accurate). In fact, not sure if this point should extend to Codex's. 
b. Afaik MT-NLG 7B (esp. v2, whatever that means) is not explicitly mentioned in the MT-NLG 530B paper. So we could confirm with the folks it is trained on the Pile: if one wanted to be perfectly precise, we actually don't know MT-NLG 7B is trained on the Pile (happy to remove the annotation if we want as a result). 

Note that I didn't test the changes.