### PR TITLE
make RunEntry dataclass

### DIFF
--- a/src/benchmark/presentation/run_entry.py
+++ b/src/benchmark/presentation/run_entry.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+from typing import Optional, List
+import dacite
+
+from common.general import parse_hocon
+from common.hierarchical_logger import hlog
+
+
+@dataclass(frozen=True)
+class RunEntry:
+    """Represents something that we want to run."""
+
+    # Gets expanded into a list of `RunSpec`s.
+    description: str
+
+    # Priority for this run spec (1 is highest priority, 5 is lowest priority)
+    priority: int
+
+    # Additional groups to add to the run spec
+    groups: Optional[List[str]]
+
+
+@dataclass(frozen=True)
+class RunEntries:
+    entries: List[RunEntry]
+
+
+def read_run_entries(path: str) -> RunEntries:
+    """Read a HOCON file `path` and return the `RunEntry`s."""
+    with open(path) as f:
+        raw = parse_hocon(f.read())
+    run_entries = dacite.from_dict(RunEntries, raw)
+    hlog(f"Read {len(run_entries.entries)} run entries from {path}")
+    return run_entries

--- a/src/benchmark/presentation/run_specs.conf
+++ b/src/benchmark/presentation/run_specs.conf
@@ -1,985 +1,978 @@
-# List the RunSpecs that we want to display on the website in this file.
-# A RunSpec specifies how to do a single run, which gets a scenario, adapts it, and computes a list of metrics.
-#
-# RunSpecs are unique. Assign them a priority where a RunSpec with a lower priority value gets run
-# before a one with a higher priority value.
-#
-# Place your new RunSpec description under the appropriate section.
-
-# TODO: Set num_train_trials=3 as the default
-
-
-##### Generic #####
-
-##### Question Answering #####
-# Scenarios: BoolQ, NarrativeQA, NewsQA, QuAC
-# Scenarios: NaturalQuestions
-# Scenarios: CommonsenseQA, HellaSwag, OpenBookQA, TruthfulQA
-# Scenarios: MMLU
-
-## Reading comprehension
-
-"boolq:model=text,data_augmentation=canonical": {priority: 1}
-"narrative_qa:model=text,data_augmentation=canonical": {priority: 2}
-"news_qa:model=text,data_augmentation=canonical": {priority: 3}
-"quac:model=text,data_augmentation=canonical": {priority: 1}
-
-## Reading comprehension and closedbook QA variants
-
-"natural_qa:model=text,mode=openbook_longans,data_augmentation=canonical": {priority: 1}
-"natural_qa:model=text,mode=closedbook,data_augmentation=canonical": {priority: 1}
-
-## Closed-book QA with multiple choice
-
-"commonsense:model=text,dataset=commonsenseqa,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-# Adaptation method is set to ADAPT_MULTIPLE_CHOICE_SEPARATE_CALIBRATED and echo=True
-"commonsense:model=full_functionality_text,dataset=hellaswag,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 1}
-"commonsense:model=full_functionality_text,dataset=openbookqa,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 2}
-"truthful_qa:model=text,task=mc_single,data_augmentation=canonical": {priority: 1}
-
-# For MMLU, we sampled the following 10 subjects, which cover diverse topics across humanities, social sciences and STEM.
-"mmlu:model=text,subject=abstract_algebra,data_augmentation=canonical": {priority: 2}
-"mmlu:model=text,subject=anatomy,data_augmentation=canonical": {priority: 3}
-"mmlu:model=text,subject=college_chemistry,data_augmentation=canonical": {priority: 2}
-"mmlu:model=text,subject=computer_security,data_augmentation=canonical": {priority: 2}
-"mmlu:model=text,subject=econometrics,data_augmentation=canonical": {priority: 2}
-"mmlu:model=text,subject=global_facts,data_augmentation=canonical": {priority: 3}
-"mmlu:model=text,subject=jurisprudence,data_augmentation=canonical": {priority: 3}
-"mmlu:model=text,subject=philosophy,data_augmentation=canonical": {priority: 3}
-"mmlu:model=text,subject=professional_medicine,data_augmentation=canonical": {priority: 3}
-"mmlu:model=text,subject=us_foreign_policy,data_augmentation=canonical": {priority: 2}
-"mmlu:model=text,subject=astronomy,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=business_ethics,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=clinical_knowledge,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=college_biology,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=college_computer_science,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=college_mathematics,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=college_medicine,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=college_physics,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=conceptual_physics,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=electrical_engineering,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=elementary_mathematics,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=formal_logic,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=high_school_biology,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=high_school_chemistry,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=high_school_computer_science,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=high_school_european_history,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=high_school_geography,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=high_school_government_and_politics,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=high_school_macroeconomics,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=high_school_mathematics,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=high_school_microeconomics,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=high_school_physics,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=high_school_psychology,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=high_school_statistics,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=high_school_us_history,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=high_school_world_history,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=human_aging,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=human_sexuality,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=international_law,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=logical_fallacies,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=machine_learning,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=management,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=marketing,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=medical_genetics,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=miscellaneous,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=moral_disputes,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=moral_scenarios,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=nutrition,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=prehistory,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=professional_accounting,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=professional_law,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=professional_psychology,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=public_relations,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=security_studies,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=sociology,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=virology,data_augmentation=canonical": {priority: 4}
-"mmlu:model=text,subject=world_religions,data_augmentation=canonical": {priority: 4}
-
-
-##### Information Retrieval #####
-# Scenarios: MS Marco (Regular), MS MARCO (TREC)
-
-# TODO: rename scenario to msmarco, track to msmarco - Issue 527
-# TODO: Update valid_topk=30 based on AI21 results
-# TODO: reenable after MultipleInstance refactor
-# "msmarco:task=passage,model=full_functionality_text,track=regular,use_qrels_passages=True,use_topk_passages=True,valid_topk=30,num_valid_queries=200": {priority: 2}
-# "msmarco:task=passage,model=full_functionality_text,track=trec,use_qrels_passages=True,use_topk_passages=True,valid_topk=30": {priority: 1}
-# "msmarco:task=passage,model=full_functionality_text,track=regular,use_qrels_passages=False,use_topk_passages=True,valid_topk=30,num_valid_queries=200": {priority: 2}
-# "msmarco:task=passage,model=full_functionality_text,track=trec,use_qrels_passages=False,use_topk_passages=True,valid_topk=30": {priority: 1}
-
-
-##### Summarization #####
-# Scenarios: XSUM, CNN/DM
-
-"summarization_cnndm:model=text,temperature=0.3,device=cpu": {priority: 1}
-"summarization_xsum_sampled:model=text,temperature=0.3,device=cpu": {priority: 1}
-
-
-##### Sentiment Analysis #####
-# Scenarios: IMDB
-
-"imdb:model=text,data_augmentation=canonical": {priority: 1}
-
-
-##### (Miscellaneous) Text Classification #####
-# Scenarios: RAFT
-
-"raft:subset=ade_corpus_v2,model=text,data_augmentation=canonical": {priority: 2}
-"raft:subset=banking_77,model=text,data_augmentation=canonical": {priority: 2}
-"raft:subset=neurips_impact_statement_risks,model=text,data_augmentation=canonical": {priority: 2}
-"raft:subset=one_stop_english,model=text,data_augmentation=canonical": {priority: 2}
-"raft:subset=overruling,model=text,data_augmentation=canonical": {priority: 2}
-"raft:subset=semiconductor_org_types,model=text,data_augmentation=canonical": {priority: 2}
-"raft:subset=tweet_eval_hate,model=text,data_augmentation=canonical": {priority: 2}
-"raft:subset=twitter_complaints,model=text,data_augmentation=canonical": {priority: 2}
-"raft:subset=systematic_review_inclusion,model=text,data_augmentation=canonical": {priority: 2}
-"raft:subset=tai_safety_research,model=text,data_augmentation=canonical": {priority: 2}
-"raft:subset=terms_of_service,model=text,data_augmentation=canonical": {priority: 2}
-
-
-##### Toxicity Detection #####
-# Scenarios: CivilComments
-
-"civil_comments:model=text,demographic=all,data_augmentation=canonical": {priority: 1}
-"civil_comments:model=text,demographic=male,data_augmentation=canonical": {priority: 2}
-"civil_comments:model=text,demographic=female,data_augmentation=canonical": {priority: 2}
-"civil_comments:model=text,demographic=LGBTQ,data_augmentation=canonical": {priority: 2}
-"civil_comments:model=text,demographic=christian,data_augmentation=canonical": {priority: 2}
-"civil_comments:model=text,demographic=muslim,data_augmentation=canonical": {priority: 2}
-"civil_comments:model=text,demographic=other_religions,data_augmentation=canonical": {priority: 2}
-"civil_comments:model=text,demographic=black,data_augmentation=canonical": {priority: 2}
-"civil_comments:model=text,demographic=white,data_augmentation=canonical": {priority: 2}
-
-
-##### Component Skills and Risks #####
-
-##### Language #####
-# Scenarios: BLiMP, The Pile, ICE, WikiText-103, TwitterAAE
-
-# We select 4 phenomena to elevate to priority 2, one per linguistic field.
-# The phenomena in BLiMP are annotated belong to one of the following 4 linguistic fields:
-# Morphology, Semantics, Syntax, and Syntax-Semantics
-# Beyond ensuring coverage of these 4 fields, to choose the higher priority representative,
-# we choose the phenomena within the field with the lowest GPT-2 performance reported (Warsadt et al., 2020).
-"blimp:model=full_functionality_text,phenomenon=anaphor_agreement": {priority: 3} # Morphology
-"blimp:model=full_functionality_text,phenomenon=determiner_noun_agreement": {priority: 3} # Morphology
-"blimp:model=full_functionality_text,phenomenon=irregular_forms": {priority: 2} # Morphology
-"blimp:model=full_functionality_text,phenomenon=subject_verb_agreement": {priority: 3} # Morphology
-"blimp:model=full_functionality_text,phenomenon=quantifiers": {priority: 2} # Semantics
-"blimp:model=full_functionality_text,phenomenon=npi_licensing": {priority: 3} # Semantics
-"blimp:model=full_functionality_text,phenomenon=argument_structure": {priority: 3} # Syntax
-"blimp:model=full_functionality_text,phenomenon=ellipsis": {priority: 3} # Syntax
-"blimp:model=full_functionality_text,phenomenon=filler_gap_dependency": {priority: 3} # Syntax
-"blimp:model=full_functionality_text,phenomenon=island_effects": {priority: 2} # Syntax
-"blimp:model=full_functionality_text,phenomenon=binding": {priority: 2} # Syntax-Semantics
-"blimp:model=full_functionality_text,phenomenon=control_raising": {priority: 3} # Syntax-Semantics
-
-## Language modeling
-"wikitext_103:model=full_functionality_text": {status: "READY", priority: 3}
-
-"the_pile:model=full_functionality_text,subset=ArXiv": {status: "READY", priority: 2}
-"the_pile:model=full_functionality_text,subset=BookCorpus2": {status: "READY", priority: 2}
-"the_pile:model=full_functionality_text,subset=Books3": {status: "READY", priority: 3}
-"the_pile:model=full_functionality_text,subset=DM Mathematics": {status: "READY", priority: 3}
-"the_pile:model=full_functionality_text,subset=Enron Emails": {status: "READY", priority: 2}
-"the_pile:model=full_functionality_text,subset=EuroParl": {status: "READY", priority: 3}
-"the_pile:model=full_functionality_text,subset=FreeLaw": {status: "READY", priority: 3}
-"the_pile:model=full_functionality_text,subset=Github": {status: "READY", priority: 2}
-"the_pile:model=full_functionality_text,subset=Gutenberg (PG-19)": {status: "READY", priority: 3}
-"the_pile:model=full_functionality_text,subset=HackerNews": {status: "READY", priority: 3}
-"the_pile:model=full_functionality_text,subset=NIH ExPorter": {status: "READY", priority: 3}
-"the_pile:model=full_functionality_text,subset=OpenSubtitles": {status: "READY", priority: 3}
-"the_pile:model=full_functionality_text,subset=OpenWebText2": {status: "READY", priority: 3}
-"the_pile:model=full_functionality_text,subset=PhilPapers": {status: "READY", priority: 3}
-"the_pile:model=full_functionality_text,subset=Pile-CC": {status: "READY", priority: 3}
-"the_pile:model=full_functionality_text,subset=PubMed Abstracts": {status: "READY", priority: 3}
-"the_pile:model=full_functionality_text,subset=PubMed Central": {status: "READY", priority: 2}
-"the_pile:model=full_functionality_text,subset=StackExchange": {status: "READY", priority: 3}
-"the_pile:model=full_functionality_text,subset=USPTO Backgrounds": {status: "READY", priority: 3}
-"the_pile:model=full_functionality_text,subset=Ubuntu IRC": {status: "READY", priority: 3}
-"the_pile:model=full_functionality_text,subset=Wikipedia (en)": {status: "READY", priority: 2}
-"the_pile:model=full_functionality_text,subset=YoutubeSubtitles": {status: "READY", priority: 3}
-
-"twitter_aae:model=full_functionality_text,demographic=aa": {status: "READY", priority: 1}
-"twitter_aae:model=full_functionality_text,demographic=white": {status: "READY", priority: 1}
-
-"ice:model=full_functionality_text,subset=can": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=ea": {status: "READY", priority: 2}
-"ice:model=full_functionality_text,subset=hk": {status: "READY", priority: 2}
-"ice:model=full_functionality_text,subset=ind": {status: "READY", priority: 2}
-"ice:model=full_functionality_text,subset=ja": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=phi": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=sin": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=usa": {status: "READY", priority: 2}
-
-# split by text category
-"ice:model=full_functionality_text,subset=can,category=S1": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=can,category=S2": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=can,category=W1": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=can,category=W2": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=ea,category=S1": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=ea,category=S2": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=ea,category=W1": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=ea,category=W2": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=hk,category=S1": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=hk,category=S2": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=hk,category=W1": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=hk,category=W2": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=ind,category=S1": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=ind,category=S2": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=ind,category=W1": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=ind,category=W2": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=ja,category=S1": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=ja,category=S2": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=ja,category=W1": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=ja,category=W2": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=phi,category=S1": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=phi,category=S2": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=phi,category=W1": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=phi,category=W2": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=sin,category=S1": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=sin,category=S2": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=sin,category=W1": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=sin,category=W2": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=usa,category=W1": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,subset=usa,category=W2": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,category=S": {status: "READY", priority: 3}
-"ice:model=full_functionality_text,category=W": {status: "READY", priority: 3}
-
-"ice:model=full_functionality_text,gender=female": {status: "READY", priority: 2}
-"ice:model=full_functionality_text,gender=male": {status: "READY", priority: 2}
-
-##### Knowledge #####
-
-# For WikiFact, we sampled the following 10 relation types, which cover diverse topics
-# across general facts, humanities, social sciences and STEM.
-"wikifact:model=text,k=5,subject=plaintiff": {priority: 2}
-"wikifact:model=text,k=5,subject=place_of_birth": {priority: 2}
-"wikifact:model=text,k=5,subject=medical_condition_treated": {priority: 2}
-"wikifact:model=text,k=5,subject=instance_of": {priority: 2}
-"wikifact:model=text,k=5,subject=part_of": {priority: 2}
-"wikifact:model=text,k=5,subject=currency": {priority: 2}
-"wikifact:model=text,k=5,subject=position_held": {priority: 2}
-"wikifact:model=text,k=5,subject=author": {priority: 2}
-"wikifact:model=text,k=5,subject=discoverer_or_inventor": {priority: 2}
-"wikifact:model=text,k=5,subject=symptoms_and_signs": {priority: 2}
-"wikifact:model=text,k=5,subject=applies_to_jurisdiction": {priority: 4}
-"wikifact:model=text,k=5,subject=field_of_work": {priority: 4}
-"wikifact:model=text,k=5,subject=member_of_political_party": {priority: 4}
-"wikifact:model=text,k=5,subject=native_language": {priority: 4}
-"wikifact:model=text,k=5,subject=occupation": {priority: 4}
-"wikifact:model=text,k=5,subject=employer": {priority: 4}
-"wikifact:model=text,k=5,subject=atomic_number": {priority: 4}
-"wikifact:model=text,k=5,subject=measured_physical_quantity": {priority: 4}
-"wikifact:model=text,k=5,subject=solved_by": {priority: 4}
-"wikifact:model=text,k=5,subject=number_of_processor_cores": {priority: 4}
-"wikifact:model=text,k=5,subject=file_extension": {priority: 4}
-"wikifact:model=text,k=5,subject=basic_form_of_government": {priority: 4}
-"wikifact:model=text,k=5,subject=owned_by": {priority: 4}
-"wikifact:model=text,k=5,subject=instrument": {priority: 4}
-"wikifact:model=text,k=5,subject=central_bank": {priority: 4}
-"wikifact:model=text,k=5,subject=located_in_the_administrative_territorial_entity": {priority: 4}
-"wikifact:model=text,k=5,subject=office_held_by_head_of_government": {priority: 4}
-"wikifact:model=text,k=5,subject=movement": {priority: 4}
-"wikifact:model=text,k=5,subject=genre": {priority: 4}
-"wikifact:model=text,k=5,subject=capital_of": {priority: 4}
-"wikifact:model=text,k=5,subject=named_after": {priority: 4}
-"wikifact:model=text,k=5,subject=religion": {priority: 4}
-"wikifact:model=text,k=5,subject=languages_spoken_written_or_signed": {priority: 4}
-"wikifact:model=text,k=5,subject=headquarters_location": {priority: 4}
-"wikifact:model=text,k=5,subject=defendant": {priority: 4}
-"wikifact:model=text,k=5,subject=award_received": {priority: 4}
-"wikifact:model=text,k=5,subject=country": {priority: 4}
-"wikifact:model=text,k=5,subject=creator": {priority: 4}
-"wikifact:model=text,k=5,subject=manufacturer": {priority: 4}
-"wikifact:model=text,k=5,subject=developer": {priority: 4}
-"wikifact:model=text,k=5,subject=location_of_discovery": {priority: 4}
-"wikifact:model=text,k=5,subject=twinned_administrative_body": {priority: 4}
-"wikifact:model=text,k=5,subject=office_held_by_head_of_state": {priority: 4}
-"wikifact:model=text,k=5,subject=participating_team": {priority: 4}
-"wikifact:model=text,k=5,subject=place_of_death": {priority: 4}
-"wikifact:model=text,k=5,subject=drug_or_therapy_used_for_treatment": {priority: 4}
-"wikifact:model=text,k=5,subject=genetic_association": {priority: 4}
-"wikifact:model=text,k=5,subject=statement_describes": {priority: 4}
-"wikifact:model=text,k=5,subject=repealed_by": {priority: 4}
-"wikifact:model=text,k=5,subject=record_label": {priority: 4}
-"wikifact:model=text,k=5,subject=country_of_citizenship": {priority: 4}
-"wikifact:model=text,k=5,subject=location": {priority: 4}
-"wikifact:model=text,k=5,subject=programming_language": {priority: 4}
-"wikifact:model=text,k=5,subject=subclass_of": {priority: 4}
-"wikifact:model=text,k=5,subject=continent": {priority: 4}
-"wikifact:model=text,k=5,subject=laws_applied": {priority: 4}
-"wikifact:model=text,k=5,subject=operating_system": {priority: 4}
-"wikifact:model=text,k=5,subject=head_of_state": {priority: 4}
-"wikifact:model=text,k=5,subject=subsidiary": {priority: 4}
-"wikifact:model=text,k=5,subject=capital": {priority: 4}
-"wikifact:model=text,k=5,subject=original_language_of_film_or_TV_show": {priority: 4}
-"wikifact:model=text,k=5,subject=official_language": {priority: 4}
-"wikifact:model=text,k=5,subject=overrules": {priority: 4}
-"wikifact:model=text,k=5,subject=therapeutic_area": {priority: 4}
-"wikifact:model=text,k=5,subject=language_of_work_or_name": {priority: 4}
-"wikifact:model=text,k=5,subject=position_played_on_team": {priority: 4}
-"wikifact:model=text,k=5,subject=stock_exchange": {priority: 4}
-"wikifact:model=text,k=5,subject=original_network": {priority: 4}
-"wikifact:model=text,k=5,subject=industry": {priority: 4}
-"wikifact:model=text,k=5,subject=member_of": {priority: 4}
-"wikifact:model=text,k=5,subject=shares_border_with": {priority: 4}
-"wikifact:model=text,k=5,subject=country_of_origin": {priority: 4}
-"wikifact:model=text,k=5,subject=has_part": {priority: 4}
-"wikifact:model=text,k=5,subject=diplomatic_relation": {priority: 4}
-"wikifact:model=text,k=5,subject=member_of_sports_team": {priority: 4}
-"wikifact:model=text,k=5,subject=director": {priority: 4}
-"wikifact:model=text,k=5,subject=time_of_discovery_or_invention": {priority: 4}
-"wikifact:model=text,k=5,subject=majority_opinion_by": {priority: 4}
-"wikifact:model=text,k=5,subject=head_of_government": {priority: 4}
-"wikifact:model=text,k=5,subject=educated_at": {priority: 4}
-"wikifact:model=text,k=5,subject=influenced_by": {priority: 4}
-"wikifact:model=text,k=5,subject=location_of_formation": {priority: 4}
-"wikifact:model=text,k=5,subject=electron_configuration": {priority: 4}
-"wikifact:model=text,k=5,subject=recommended_unit_of_measurement": {priority: 4}
-"wikifact:model=text,k=5,subject=composer": {priority: 4}
-"wikifact:model=text,k=5,subject=work_location": {priority: 4}
-
-
-
-##### Reasoning #####
-
-## Synthetic
-# TODO: had to disable these due to a refactor
-#"numeracy:model=all,run_solver=True,relation_type=linear,mode=function": {priority: 2}
-#"numeracy:model=all,run_solver=True,relation_type=plane,mode=function": {priority: 3}
-
-# The DistanceMetric is slow to compute for relation_type 'parabola' and 'paraboloid', so set run_solver=False
-#"numeracy:model=all,run_solver=False,relation_type=parabola,mode=function": {priority: 4}
-#"numeracy:model=all,run_solver=False,relation_type=paraboloid,mode=function": {priority: 4}
-
-"synthetic_reasoning:model=all,mode=pattern_match": {priority: 2}
-"synthetic_reasoning:model=all,mode=variable_substitution": {priority: 2}
-"synthetic_reasoning:model=all,mode=induction": {priority: 2}
-
-"synthetic_reasoning_natural:model=all,difficulty=easy": {priority: 2}
-"synthetic_reasoning_natural:model=all,difficulty=hard": {priority: 2}
-
-"babi_qa:model=all,task=all": {priority: 2}
-"babi_qa:model=all,task=1": {priority: 3}
-"babi_qa:model=all,task=2": {priority: 4}
-"babi_qa:model=all,task=3": {priority: 2}
-"babi_qa:model=all,task=4": {priority: 3}
-"babi_qa:model=all,task=5": {priority: 4}
-"babi_qa:model=all,task=6": {priority: 4}
-"babi_qa:model=all,task=7": {priority: 4}
-"babi_qa:model=all,task=8": {priority: 4}
-"babi_qa:model=all,task=9": {priority: 4}
-"babi_qa:model=all,task=10": {priority: 4}
-"babi_qa:model=all,task=11": {priority: 4}
-"babi_qa:model=all,task=12": {priority: 4}
-"babi_qa:model=all,task=13": {priority: 4}
-"babi_qa:model=all,task=14": {priority: 4}
-"babi_qa:model=all,task=15": {priority: 2}
-"babi_qa:model=all,task=16": {priority: 4}
-"babi_qa:model=all,task=17": {priority: 4}
-"babi_qa:model=all,task=18": {priority: 4}
-"babi_qa:model=all,task=19": {priority: 2}
-"babi_qa:model=all,task=20": {priority: 4}
-
-"dyck_language:model=all,num_parenthesis_pairs=2": {priority: 4}
-"dyck_language:model=all,num_parenthesis_pairs=3": {priority: 2}
-"dyck_language:model=all,num_parenthesis_pairs=4": {priority: 4}
-
-## Real
-
-"math:model=all,subject=number_theory,level=1,use_official_examples=True": {priority: 2}
-"math:model=all,subject=intermediate_algebra,level=1,use_official_examples=True": {priority: 2}
-"math:model=all,subject=algebra,level=1,use_official_examples=True": {priority: 2}
-"math:model=all,subject=prealgebra,level=1,use_official_examples=True": {priority: 2}
-"math:model=all,subject=geometry,level=1,use_official_examples=True": {priority: 2}
-"math:model=all,subject=counting_and_probability,level=1,use_official_examples=True": {priority: 2}
-"math:model=all,subject=precalculus,level=1,use_official_examples=True": {priority: 2}
-
-"math:model=all,subject=number_theory,level=2,use_official_examples=True": {priority: 4}
-"math:model=all,subject=intermediate_algebra,level=2,use_official_examples=True": {priority: 4}
-"math:model=all,subject=algebra,level=2,use_official_examples=True": {priority: 4}
-"math:model=all,subject=prealgebra,level=2,use_official_examples=True": {priority: 4}
-"math:model=all,subject=geometry,level=2,use_official_examples=True": {priority: 4}
-"math:model=all,subject=counting_and_probability,level=2,use_official_examples=True": {priority: 4}
-"math:model=all,subject=precalculus,level=2,use_official_examples=True": {priority: 4}
-
-"math:model=all,subject=number_theory,level=3,use_official_examples=True": {priority: 3}
-"math:model=all,subject=intermediate_algebra,level=3,use_official_examples=True": {priority: 3}
-"math:model=all,subject=algebra,level=3,use_official_examples=True": {priority: 3}
-"math:model=all,subject=prealgebra,level=3,use_official_examples=True": {priority: 3}
-"math:model=all,subject=geometry,level=3,use_official_examples=True": {priority: 3}
-"math:model=all,subject=counting_and_probability,level=3,use_official_examples=True": {priority: 3}
-"math:model=all,subject=precalculus,level=3,use_official_examples=True": {priority: 3}
-
-"math:model=all,subject=number_theory,level=4,use_official_examples=True": {priority: 4}
-"math:model=all,subject=intermediate_algebra,level=4,use_official_examples=True": {priority: 4}
-"math:model=all,subject=algebra,level=4,use_official_examples=True": {priority: 4}
-"math:model=all,subject=prealgebra,level=4,use_official_examples=True": {priority: 4}
-"math:model=all,subject=geometry,level=4,use_official_examples=True": {priority: 4}
-"math:model=all,subject=counting_and_probability,level=4,use_official_examples=True": {priority: 4}
-"math:model=all,subject=precalculus,level=4,use_official_examples=True": {priority: 4}
-
-"math:model=all,subject=number_theory,level=5,use_official_examples=True": {priority: 3}
-"math:model=all,subject=intermediate_algebra,level=5,use_official_examples=True": {priority: 3}
-"math:model=all,subject=algebra,level=5,use_official_examples=True": {priority: 3}
-"math:model=all,subject=prealgebra,level=5,use_official_examples=True": {priority: 3}
-"math:model=all,subject=geometry,level=5,use_official_examples=True": {priority: 3}
-"math:model=all,subject=counting_and_probability,level=5,use_official_examples=True": {priority: 3}
-"math:model=all,subject=precalculus,level=5,use_official_examples=True": {priority: 3}
-
-# With chain-of-thought prompting:
-"math:model=all,subject=number_theory,level=1,use_chain_of_thought=True": {priority: 2}
-"math:model=all,subject=intermediate_algebra,level=1,use_chain_of_thought=True": {priority: 2}
-"math:model=all,subject=algebra,level=1,use_chain_of_thought=True": {priority: 2}
-"math:model=all,subject=prealgebra,level=1,use_chain_of_thought=True": {priority: 2}
-"math:model=all,subject=geometry,level=1,use_chain_of_thought=True": {priority: 2}
-"math:model=all,subject=counting_and_probability,level=1,use_chain_of_thought=True": {priority: 2}
-"math:model=all,subject=precalculus,level=1,use_chain_of_thought=True": {priority: 2}
-
-"math:model=all,subject=number_theory,level=2,use_chain_of_thought=True": {priority: 4}
-"math:model=all,subject=intermediate_algebra,level=2,use_chain_of_thought=True": {priority: 4}
-"math:model=all,subject=algebra,level=2,use_chain_of_thought=True": {priority: 4}
-"math:model=all,subject=prealgebra,level=2,use_chain_of_thought=True": {priority: 4}
-"math:model=all,subject=geometry,level=2,use_chain_of_thought=True": {priority: 4}
-"math:model=all,subject=counting_and_probability,level=2,use_chain_of_thought=True": {priority: 4}
-"math:model=all,subject=precalculus,level=2,use_chain_of_thought=True": {priority: 4}
-
-"math:model=all,subject=number_theory,level=3,use_chain_of_thought=True": {priority: 3}
-"math:model=all,subject=intermediate_algebra,level=3,use_chain_of_thought=True": {priority: 3}
-"math:model=all,subject=algebra,level=3,use_chain_of_thought=True": {priority: 3}
-"math:model=all,subject=prealgebra,level=3,use_chain_of_thought=True": {priority: 3}
-"math:model=all,subject=geometry,level=3,use_chain_of_thought=True": {priority: 3}
-"math:model=all,subject=counting_and_probability,level=3,use_chain_of_thought=True": {priority: 3}
-"math:model=all,subject=precalculus,level=3,use_chain_of_thought=True": {priority: 3}
-
-"math:model=all,subject=number_theory,level=4,use_chain_of_thought=True": {priority: 4}
-"math:model=all,subject=intermediate_algebra,level=4,use_chain_of_thought=True": {priority: 4}
-"math:model=all,subject=algebra,level=4,use_chain_of_thought=True": {priority: 4}
-"math:model=all,subject=prealgebra,level=4,use_chain_of_thought=True": {priority: 4}
-"math:model=all,subject=geometry,level=4,use_chain_of_thought=True": {priority: 4}
-"math:model=all,subject=counting_and_probability,level=4,use_chain_of_thought=True": {priority: 4}
-"math:model=all,subject=precalculus,level=4,use_chain_of_thought=True": {priority: 4}
-
-"math:model=all,subject=number_theory,level=5,use_chain_of_thought=True": {priority: 3}
-"math:model=all,subject=intermediate_algebra,level=5,use_chain_of_thought=True": {priority: 3}
-"math:model=all,subject=algebra,level=5,use_chain_of_thought=True": {priority: 3}
-"math:model=all,subject=prealgebra,level=5,use_chain_of_thought=True": {priority: 3}
-"math:model=all,subject=geometry,level=5,use_chain_of_thought=True": {priority: 3}
-"math:model=all,subject=counting_and_probability,level=5,use_chain_of_thought=True": {priority: 3}
-"math:model=all,subject=precalculus,level=5,use_chain_of_thought=True": {priority: 3}
-
-"gsm:model=all": {priority: 2}
-
-# Legal reasoning
-"legal_support:model=all": {priority: 2}
-
-"lsat_qa:model=all,task=all": {priority: 2}
-"lsat_qa:model=all,task=grouping": {priority: 3}
-"lsat_qa:model=all,task=ordering": {priority: 3}
-"lsat_qa:model=all,task=assignment": {priority: 3}
-"lsat_qa:model=all,task=miscellaneous": {priority: 3}
-
-# Data processing
-
-"entity_matching:model=text,dataset=Beer": {priority: 2}
-"entity_matching:model=text,dataset=Abt_Buy": {priority: 2}
-"entity_matching:model=text,dataset=Dirty_iTunes_Amazon": {priority: 2}
-
-"entity_data_imputation:model=text,dataset=Buy": {priority: 2}
-"entity_data_imputation:model=text,dataset=Restaurant": {priority: 2}
-
-# Code
-"code:model=code,dataset=humaneval": {priority: 1}
-"code:model=code,dataset=apps,timeout=3": {priority: 1}
-
-
-##### Harms #####
-
-## Copyright
-
-# Randomly sampled instances from the original BooksCorpus.
-# We expect data here to be less repeated in the pretraining corpus. This approximates the average case.
-"copyright:model=text,datatag=n_books_1000-extractions_per_book_1-prefix_length_125": {priority: 1}
-
-# We expect data here to be repeated more in the pretraining corpus. This approximates the worst case.
-"copyright:model=text,datatag=popular_books-prefix_length_125.json": {priority: 1}
-
-# Large and small codex models.
-"copyright:model=code,datatag=prompt_num_line_1-min_lines_20.json": {priority: 2}
-"copyright:model=code,datatag=prompt_num_line_5-min_lines_20.json": {priority: 3}
-"copyright:model=code,datatag=prompt_num_line_10-min_lines_20.json": {priority: 2}
-
-## Disinformation
-
-"disinformation:model=text,capability=reiteration,topic=climate": {priority: 1}
-"disinformation:model=text,capability=reiteration,topic=covid": {priority: 1}
-"disinformation:model=text,capability=wedging": {priority: 1}
-
-## Bias
-
-"bbq:model=text,subject=all": {priority: 2}
-"bbq:model=text,subject=age": {priority: 3}
-"bbq:model=text,subject=disability_status": {priority: 3}
-"bbq:model=text,subject=gender_identity": {priority: 3}
-"bbq:model=text,subject=nationality": {priority: 3}
-"bbq:model=text,subject=physical_appearance": {priority: 3}
-"bbq:model=text,subject=race_ethnicity": {priority: 3}
-"bbq:model=text,subject=race_x_SES": {priority: 3}
-"bbq:model=text,subject=race_x_gender": {priority: 3}
-"bbq:model=text,subject=religion": {priority: 3}
-"bbq:model=text,subject=SES": {priority: 3}
-"bbq:model=text,subject=sexual_orientation": {priority: 3}
-
-## Toxicity
-
-"real_toxicity_prompts:model=text": {priority: 2}
-
-"bold:model=text,subject=all": {priority: 2}
-"bold:model=text,subject=gender": {priority: 3}
-"bold:model=text,subject=political_ideology": {priority: 3}
-"bold:model=text,subject=profession": {priority: 3}
-"bold:model=text,subject=race": {priority: 3}
-"bold:model=text,subject=religious_ideology": {priority: 3}
-
-
-##### Efficiency #####
-
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=256,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=256,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=256,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=256,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=256,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=256,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=256,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=512,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=512,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=512,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=512,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=512,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=512,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=512,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1024,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1024,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1024,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1024,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1024,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1024,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1024,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1536,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1536,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1536,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1536,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1536,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1536,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1536,num_output_tokens=64": {priority: 1}
-
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=256,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=256,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=256,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=256,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=256,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=256,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=256,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=512,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=512,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=512,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=512,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=512,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=512,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=512,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1024,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1024,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1024,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1024,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1024,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1024,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1024,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1536,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1536,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1536,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1536,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1536,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1536,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1536,num_output_tokens=64": {priority: 1}
-
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=256,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=256,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=256,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=256,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=256,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=256,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=256,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=512,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=512,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=512,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=512,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=512,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=512,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=512,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1024,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1024,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1024,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1024,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1024,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1024,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1024,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1536,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1536,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1536,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1536,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1536,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1536,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1536,num_output_tokens=64": {priority: 1}
-
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=256,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=256,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=256,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=256,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=256,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=256,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=256,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=512,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=512,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=512,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=512,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=512,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=512,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=512,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1024,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1024,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1024,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1024,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1024,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1024,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1024,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1536,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1536,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1536,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1536,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1536,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1536,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1536,num_output_tokens=64": {priority: 1}
-
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=256,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=256,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=256,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=256,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=256,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=256,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=256,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=512,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=512,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=512,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=512,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=512,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=512,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=512,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1024,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1024,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1024,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1024,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1024,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1024,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1024,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1536,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1536,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1536,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1536,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1536,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1536,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1536,num_output_tokens=64": {priority: 1}
-
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=256,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=256,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=256,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=256,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=256,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=256,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=256,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=512,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=512,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=512,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=512,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=512,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=512,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=512,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1024,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1024,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1024,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1024,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1024,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1024,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1024,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1536,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1536,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1536,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1536,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1536,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1536,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1536,num_output_tokens=64": {priority: 1}
-
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=256,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=256,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=256,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=256,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=256,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=256,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=256,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=512,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=512,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=512,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=512,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=512,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=512,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=512,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1024,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1024,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1024,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1024,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1024,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1024,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1024,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1536,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1536,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1536,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1536,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1536,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1536,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1536,num_output_tokens=64": {priority: 1}
-
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=256,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=256,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=256,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=256,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=256,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=256,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=256,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=512,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=512,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=512,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=512,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=512,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=512,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=512,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1024,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1024,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1024,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1024,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1024,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1024,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1024,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1536,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1536,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1536,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1536,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1536,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1536,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1536,num_output_tokens=64": {priority: 1}
-
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=256,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=256,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=256,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=256,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=256,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=256,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=256,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=512,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=512,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=512,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=512,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=512,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=512,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=512,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1024,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1024,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1024,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1024,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1024,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1024,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1024,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1536,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1536,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1536,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1536,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1536,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1536,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1536,num_output_tokens=64": {priority: 1}
-
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=256,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=256,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=256,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=256,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=256,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=256,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=256,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=512,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=512,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=512,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=512,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=512,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=512,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=512,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1024,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1024,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1024,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1024,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1024,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1024,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1024,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1536,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1536,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1536,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1536,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1536,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1536,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1536,num_output_tokens=64": {priority: 1}
-
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=256,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=256,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=256,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=256,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=256,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=256,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=256,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=512,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=512,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=512,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=512,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=512,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=512,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=512,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1024,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1024,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1024,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1024,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1024,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1024,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1024,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1536,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1536,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1536,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1536,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1536,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1536,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1536,num_output_tokens=64": {priority: 1}
-
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=256,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=256,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=256,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=256,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=256,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=256,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=256,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=512,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=512,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=512,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=512,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=512,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=512,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=512,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1024,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1024,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1024,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1024,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1024,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1024,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1024,num_output_tokens=64": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1536,num_output_tokens=1": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1536,num_output_tokens=2": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1536,num_output_tokens=4": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1536,num_output_tokens=8": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1536,num_output_tokens=16": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1536,num_output_tokens=32": {priority: 1}
-"synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1536,num_output_tokens=64": {priority: 1}
-
-##### Robustness #####
-
-## Contrast sets (these are separate runs since we will only consider Instances that have contrast sets
-"boolq:model=text,only_contrast=True,data_augmentation=contrast_sets": {priority: 2}
-"imdb:model=text,only_contrast=True,data_augmentation=contrast_sets": {priority: 2}
+# Main `RunSpec`s for the benchmarking.
+
+entries: [
+  ##### Generic #####
+
+  ##### Question Answering #####
+  # Scenarios: BoolQ, NarrativeQA, NewsQA, QuAC
+  # Scenarios: NaturalQuestions
+  # Scenarios: CommonsenseQA, HellaSwag, OpenBookQA, TruthfulQA
+  # Scenarios: MMLU
+
+  ## Reading comprehension
+
+  {description: "boolq:model=text,data_augmentation=canonical", priority: 1}
+  {description: "narrative_qa:model=text,data_augmentation=canonical", priority: 2}
+  {description: "news_qa:model=text,data_augmentation=canonical", priority: 3}
+  {description: "quac:model=text,data_augmentation=canonical", priority: 1}
+
+  ## Reading comprehension and closedbook QA variants
+
+  {description: "natural_qa:model=text,mode=openbook_longans,data_augmentation=canonical", priority: 1}
+  {description: "natural_qa:model=text,mode=closedbook,data_augmentation=canonical", priority: 1}
+
+  ## Closed-book QA with multiple choice
+
+  {description: "commonsense:model=text,dataset=commonsenseqa,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  # Adaptation method is set to ADAPT_MULTIPLE_CHOICE_SEPARATE_CALIBRATED and echo=True
+  {description: "commonsense:model=full_functionality_text,dataset=hellaswag,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 1}
+  {description: "commonsense:model=full_functionality_text,dataset=openbookqa,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 2}
+  {description: "truthful_qa:model=text,task=mc_single,data_augmentation=canonical", priority: 1}
+
+  # For MMLU, we sampled the following 10 subjects, which cover diverse topics across humanities, social sciences and STEM.
+  {description: "mmlu:model=text,subject=abstract_algebra,data_augmentation=canonical", priority: 2}
+  {description: "mmlu:model=text,subject=anatomy,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=text,subject=college_chemistry,data_augmentation=canonical", priority: 2}
+  {description: "mmlu:model=text,subject=computer_security,data_augmentation=canonical", priority: 2}
+  {description: "mmlu:model=text,subject=econometrics,data_augmentation=canonical", priority: 2}
+  {description: "mmlu:model=text,subject=global_facts,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=text,subject=jurisprudence,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=text,subject=philosophy,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=text,subject=professional_medicine,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=text,subject=us_foreign_policy,data_augmentation=canonical", priority: 2}
+  {description: "mmlu:model=text,subject=astronomy,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=business_ethics,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=clinical_knowledge,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=college_biology,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=college_computer_science,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=college_mathematics,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=college_medicine,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=college_physics,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=conceptual_physics,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=electrical_engineering,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=elementary_mathematics,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=formal_logic,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_biology,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_chemistry,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_computer_science,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_european_history,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_geography,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_government_and_politics,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_macroeconomics,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_mathematics,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_microeconomics,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_physics,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_psychology,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_statistics,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_us_history,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_world_history,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=human_aging,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=human_sexuality,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=international_law,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=logical_fallacies,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=machine_learning,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=management,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=marketing,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=medical_genetics,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=miscellaneous,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=moral_disputes,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=moral_scenarios,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=nutrition,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=prehistory,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=professional_accounting,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=professional_law,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=professional_psychology,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=public_relations,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=security_studies,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=sociology,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=virology,data_augmentation=canonical", priority: 4}
+  {description: "mmlu:model=text,subject=world_religions,data_augmentation=canonical", priority: 4}
+
+
+  ##### Information Retrieval #####
+  # Scenarios: MS Marco (Regular), MS MARCO (TREC)
+
+  # TODO: rename scenario to msmarco, track to msmarco - Issue 527
+  # TODO: Update valid_topk=30 based on AI21 results
+  # TODO: reenable after MultipleInstance refactor
+  # {description: "msmarco:task=passage,model=full_functionality_text,track=regular,use_qrels_passages=True,use_topk_passages=True,valid_topk=30,num_valid_queries=200", priority: 2}
+  # {description: "msmarco:task=passage,model=full_functionality_text,track=trec,use_qrels_passages=True,use_topk_passages=True,valid_topk=30", priority: 1}
+  # {description: "msmarco:task=passage,model=full_functionality_text,track=regular,use_qrels_passages=False,use_topk_passages=True,valid_topk=30,num_valid_queries=200", priority: 2}
+  # {description: "msmarco:task=passage,model=full_functionality_text,track=trec,use_qrels_passages=False,use_topk_passages=True,valid_topk=30", priority: 1}
+
+
+  ##### Summarization #####
+  # Scenarios: XSUM, CNN/DM
+
+  {description: "summarization_cnndm:model=text,temperature=0.3,device=cpu", priority: 1}
+  {description: "summarization_xsum_sampled:model=text,temperature=0.3,device=cpu", priority: 1}
+
+
+  ##### Sentiment Analysis #####
+  # Scenarios: IMDB
+
+  {description: "imdb:model=text,data_augmentation=canonical", priority: 1}
+
+
+  ##### (Miscellaneous) Text Classification #####
+  # Scenarios: RAFT
+
+  {description: "raft:subset=ade_corpus_v2,model=text,data_augmentation=canonical", priority: 2}
+  {description: "raft:subset=banking_77,model=text,data_augmentation=canonical", priority: 2}
+  {description: "raft:subset=neurips_impact_statement_risks,model=text,data_augmentation=canonical", priority: 2}
+  {description: "raft:subset=one_stop_english,model=text,data_augmentation=canonical", priority: 2}
+  {description: "raft:subset=overruling,model=text,data_augmentation=canonical", priority: 2}
+  {description: "raft:subset=semiconductor_org_types,model=text,data_augmentation=canonical", priority: 2}
+  {description: "raft:subset=tweet_eval_hate,model=text,data_augmentation=canonical", priority: 2}
+  {description: "raft:subset=twitter_complaints,model=text,data_augmentation=canonical", priority: 2}
+  {description: "raft:subset=systematic_review_inclusion,model=text,data_augmentation=canonical", priority: 2}
+  {description: "raft:subset=tai_safety_research,model=text,data_augmentation=canonical", priority: 2}
+  {description: "raft:subset=terms_of_service,model=text,data_augmentation=canonical", priority: 2}
+
+
+  ##### Toxicity Detection #####
+  # Scenarios: CivilComments
+
+  {description: "civil_comments:model=text,demographic=all,data_augmentation=canonical", priority: 1}
+  {description: "civil_comments:model=text,demographic=male,data_augmentation=canonical", priority: 2}
+  {description: "civil_comments:model=text,demographic=female,data_augmentation=canonical", priority: 2}
+  {description: "civil_comments:model=text,demographic=LGBTQ,data_augmentation=canonical", priority: 2}
+  {description: "civil_comments:model=text,demographic=christian,data_augmentation=canonical", priority: 2}
+  {description: "civil_comments:model=text,demographic=muslim,data_augmentation=canonical", priority: 2}
+  {description: "civil_comments:model=text,demographic=other_religions,data_augmentation=canonical", priority: 2}
+  {description: "civil_comments:model=text,demographic=black,data_augmentation=canonical", priority: 2}
+  {description: "civil_comments:model=text,demographic=white,data_augmentation=canonical", priority: 2}
+
+
+  ##### Component Skills and Risks #####
+
+  ##### Language #####
+  # Scenarios: BLiMP, The Pile, ICE, WikiText-103, TwitterAAE
+
+  # We select 4 phenomena to elevate to priority 2, one per linguistic field.
+  # The phenomena in BLiMP are annotated belong to one of the following 4 linguistic fields:
+  # Morphology, Semantics, Syntax, and Syntax-Semantics
+  # Beyond ensuring coverage of these 4 fields, to choose the higher priority representative,
+  # we choose the phenomena within the field with the lowest GPT-2 performance reported (Warsadt et al., 2020).
+  {description: "blimp:model=full_functionality_text,phenomenon=anaphor_agreement", priority: 3} # Morphology
+  {description: "blimp:model=full_functionality_text,phenomenon=determiner_noun_agreement", priority: 3} # Morphology
+  {description: "blimp:model=full_functionality_text,phenomenon=irregular_forms", priority: 2} # Morphology
+  {description: "blimp:model=full_functionality_text,phenomenon=subject_verb_agreement", priority: 3} # Morphology
+  {description: "blimp:model=full_functionality_text,phenomenon=quantifiers", priority: 2} # Semantics
+  {description: "blimp:model=full_functionality_text,phenomenon=npi_licensing", priority: 3} # Semantics
+  {description: "blimp:model=full_functionality_text,phenomenon=argument_structure", priority: 3} # Syntax
+  {description: "blimp:model=full_functionality_text,phenomenon=ellipsis", priority: 3} # Syntax
+  {description: "blimp:model=full_functionality_text,phenomenon=filler_gap_dependency", priority: 3} # Syntax
+  {description: "blimp:model=full_functionality_text,phenomenon=island_effects", priority: 2} # Syntax
+  {description: "blimp:model=full_functionality_text,phenomenon=binding", priority: 2} # Syntax-Semantics
+  {description: "blimp:model=full_functionality_text,phenomenon=control_raising", priority: 3} # Syntax-Semantics
+
+  ## Language modeling
+  {description: "wikitext_103:model=full_functionality_text", priority: 3}
+
+  {description: "the_pile:model=full_functionality_text,subset=ArXiv", priority: 2}
+  {description: "the_pile:model=full_functionality_text,subset=BookCorpus2", priority: 2}
+  {description: "the_pile:model=full_functionality_text,subset=Books3", priority: 3}
+  {description: "the_pile:model=full_functionality_text,subset=DM Mathematics", priority: 3}
+  {description: "the_pile:model=full_functionality_text,subset=Enron Emails", priority: 2}
+  {description: "the_pile:model=full_functionality_text,subset=EuroParl", priority: 3}
+  {description: "the_pile:model=full_functionality_text,subset=FreeLaw", priority: 3}
+  {description: "the_pile:model=full_functionality_text,subset=Github", priority: 2}
+  {description: "the_pile:model=full_functionality_text,subset=Gutenberg (PG-19)", priority: 3}
+  {description: "the_pile:model=full_functionality_text,subset=HackerNews", priority: 3}
+  {description: "the_pile:model=full_functionality_text,subset=NIH ExPorter", priority: 3}
+  {description: "the_pile:model=full_functionality_text,subset=OpenSubtitles", priority: 3}
+  {description: "the_pile:model=full_functionality_text,subset=OpenWebText2", priority: 3}
+  {description: "the_pile:model=full_functionality_text,subset=PhilPapers", priority: 3}
+  {description: "the_pile:model=full_functionality_text,subset=Pile-CC", priority: 3}
+  {description: "the_pile:model=full_functionality_text,subset=PubMed Abstracts", priority: 3}
+  {description: "the_pile:model=full_functionality_text,subset=PubMed Central", priority: 2}
+  {description: "the_pile:model=full_functionality_text,subset=StackExchange", priority: 3}
+  {description: "the_pile:model=full_functionality_text,subset=USPTO Backgrounds", priority: 3}
+  {description: "the_pile:model=full_functionality_text,subset=Ubuntu IRC", priority: 3}
+  {description: "the_pile:model=full_functionality_text,subset=Wikipedia (en)", priority: 2}
+  {description: "the_pile:model=full_functionality_text,subset=YoutubeSubtitles", priority: 3}
+
+  {description: "twitter_aae:model=full_functionality_text,demographic=aa", priority: 1}
+  {description: "twitter_aae:model=full_functionality_text,demographic=white", priority: 1}
+
+  {description: "ice:model=full_functionality_text,subset=can", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=ea", priority: 2}
+  {description: "ice:model=full_functionality_text,subset=hk", priority: 2}
+  {description: "ice:model=full_functionality_text,subset=ind", priority: 2}
+  {description: "ice:model=full_functionality_text,subset=ja", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=phi", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=sin", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=usa", priority: 2}
+
+  # split by text category
+  {description: "ice:model=full_functionality_text,subset=can,category=S1", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=can,category=S2", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=can,category=W1", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=can,category=W2", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=ea,category=S1", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=ea,category=S2", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=ea,category=W1", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=ea,category=W2", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=hk,category=S1", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=hk,category=S2", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=hk,category=W1", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=hk,category=W2", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=ind,category=S1", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=ind,category=S2", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=ind,category=W1", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=ind,category=W2", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=ja,category=S1", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=ja,category=S2", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=ja,category=W1", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=ja,category=W2", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=phi,category=S1", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=phi,category=S2", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=phi,category=W1", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=phi,category=W2", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=sin,category=S1", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=sin,category=S2", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=sin,category=W1", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=sin,category=W2", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=usa,category=W1", priority: 3}
+  {description: "ice:model=full_functionality_text,subset=usa,category=W2", priority: 3}
+  {description: "ice:model=full_functionality_text,category=S", priority: 3}
+  {description: "ice:model=full_functionality_text,category=W", priority: 3}
+
+  {description: "ice:model=full_functionality_text,gender=female", priority: 2}
+  {description: "ice:model=full_functionality_text,gender=male", priority: 2}
+
+  ##### Knowledge #####
+
+  # For WikiFact, we sampled the following 10 relation types, which cover diverse topics
+  # across general facts, humanities, social sciences and STEM.
+  {description: "wikifact:model=text,k=5,subject=plaintiff", priority: 2}
+  {description: "wikifact:model=text,k=5,subject=place_of_birth", priority: 2}
+  {description: "wikifact:model=text,k=5,subject=medical_condition_treated", priority: 2}
+  {description: "wikifact:model=text,k=5,subject=instance_of", priority: 2}
+  {description: "wikifact:model=text,k=5,subject=part_of", priority: 2}
+  {description: "wikifact:model=text,k=5,subject=currency", priority: 2}
+  {description: "wikifact:model=text,k=5,subject=position_held", priority: 2}
+  {description: "wikifact:model=text,k=5,subject=author", priority: 2}
+  {description: "wikifact:model=text,k=5,subject=discoverer_or_inventor", priority: 2}
+  {description: "wikifact:model=text,k=5,subject=symptoms_and_signs", priority: 2}
+  {description: "wikifact:model=text,k=5,subject=applies_to_jurisdiction", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=field_of_work", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=member_of_political_party", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=native_language", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=occupation", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=employer", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=atomic_number", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=measured_physical_quantity", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=solved_by", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=number_of_processor_cores", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=file_extension", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=basic_form_of_government", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=owned_by", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=instrument", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=central_bank", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=located_in_the_administrative_territorial_entity", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=office_held_by_head_of_government", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=movement", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=genre", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=capital_of", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=named_after", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=religion", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=languages_spoken_written_or_signed", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=headquarters_location", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=defendant", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=award_received", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=country", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=creator", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=manufacturer", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=developer", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=location_of_discovery", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=twinned_administrative_body", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=office_held_by_head_of_state", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=participating_team", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=place_of_death", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=drug_or_therapy_used_for_treatment", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=genetic_association", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=statement_describes", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=repealed_by", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=record_label", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=country_of_citizenship", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=location", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=programming_language", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=subclass_of", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=continent", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=laws_applied", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=operating_system", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=head_of_state", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=subsidiary", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=capital", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=original_language_of_film_or_TV_show", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=official_language", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=overrules", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=therapeutic_area", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=language_of_work_or_name", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=position_played_on_team", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=stock_exchange", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=original_network", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=industry", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=member_of", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=shares_border_with", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=country_of_origin", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=has_part", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=diplomatic_relation", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=member_of_sports_team", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=director", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=time_of_discovery_or_invention", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=majority_opinion_by", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=head_of_government", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=educated_at", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=influenced_by", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=location_of_formation", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=electron_configuration", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=recommended_unit_of_measurement", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=composer", priority: 4}
+  {description: "wikifact:model=text,k=5,subject=work_location", priority: 4}
+
+
+
+  ##### Reasoning #####
+
+  ## Synthetic
+  # TODO: had to disable these due to a refactor
+  #{description: "numeracy:model=all,run_solver=True,relation_type=linear,mode=function", priority: 2}
+  #{description: "numeracy:model=all,run_solver=True,relation_type=plane,mode=function", priority: 3}
+
+  # The DistanceMetric is slow to compute for relation_type 'parabola' and 'paraboloid', so set run_solver=False
+  #{description: "numeracy:model=all,run_solver=False,relation_type=parabola,mode=function", priority: 4}
+  #{description: "numeracy:model=all,run_solver=False,relation_type=paraboloid,mode=function", priority: 4}
+
+  {description: "synthetic_reasoning:model=all,mode=pattern_match", priority: 2}
+  {description: "synthetic_reasoning:model=all,mode=variable_substitution", priority: 2}
+  {description: "synthetic_reasoning:model=all,mode=induction", priority: 2}
+
+  {description: "synthetic_reasoning_natural:model=all,difficulty=easy", priority: 2}
+  {description: "synthetic_reasoning_natural:model=all,difficulty=hard", priority: 2}
+
+  {description: "babi_qa:model=all,task=all", priority: 2}
+  {description: "babi_qa:model=all,task=1", priority: 3}
+  {description: "babi_qa:model=all,task=2", priority: 4}
+  {description: "babi_qa:model=all,task=3", priority: 2}
+  {description: "babi_qa:model=all,task=4", priority: 3}
+  {description: "babi_qa:model=all,task=5", priority: 4}
+  {description: "babi_qa:model=all,task=6", priority: 4}
+  {description: "babi_qa:model=all,task=7", priority: 4}
+  {description: "babi_qa:model=all,task=8", priority: 4}
+  {description: "babi_qa:model=all,task=9", priority: 4}
+  {description: "babi_qa:model=all,task=10", priority: 4}
+  {description: "babi_qa:model=all,task=11", priority: 4}
+  {description: "babi_qa:model=all,task=12", priority: 4}
+  {description: "babi_qa:model=all,task=13", priority: 4}
+  {description: "babi_qa:model=all,task=14", priority: 4}
+  {description: "babi_qa:model=all,task=15", priority: 2}
+  {description: "babi_qa:model=all,task=16", priority: 4}
+  {description: "babi_qa:model=all,task=17", priority: 4}
+  {description: "babi_qa:model=all,task=18", priority: 4}
+  {description: "babi_qa:model=all,task=19", priority: 2}
+  {description: "babi_qa:model=all,task=20", priority: 4}
+
+  {description: "dyck_language:model=all,num_parenthesis_pairs=2", priority: 4}
+  {description: "dyck_language:model=all,num_parenthesis_pairs=3", priority: 2}
+  {description: "dyck_language:model=all,num_parenthesis_pairs=4", priority: 4}
+
+  ## Real
+
+  {description: "math:model=all,subject=number_theory,level=1,use_official_examples=True", priority: 2}
+  {description: "math:model=all,subject=intermediate_algebra,level=1,use_official_examples=True", priority: 2}
+  {description: "math:model=all,subject=algebra,level=1,use_official_examples=True", priority: 2}
+  {description: "math:model=all,subject=prealgebra,level=1,use_official_examples=True", priority: 2}
+  {description: "math:model=all,subject=geometry,level=1,use_official_examples=True", priority: 2}
+  {description: "math:model=all,subject=counting_and_probability,level=1,use_official_examples=True", priority: 2}
+  {description: "math:model=all,subject=precalculus,level=1,use_official_examples=True", priority: 2}
+
+  {description: "math:model=all,subject=number_theory,level=2,use_official_examples=True", priority: 4}
+  {description: "math:model=all,subject=intermediate_algebra,level=2,use_official_examples=True", priority: 4}
+  {description: "math:model=all,subject=algebra,level=2,use_official_examples=True", priority: 4}
+  {description: "math:model=all,subject=prealgebra,level=2,use_official_examples=True", priority: 4}
+  {description: "math:model=all,subject=geometry,level=2,use_official_examples=True", priority: 4}
+  {description: "math:model=all,subject=counting_and_probability,level=2,use_official_examples=True", priority: 4}
+  {description: "math:model=all,subject=precalculus,level=2,use_official_examples=True", priority: 4}
+
+  {description: "math:model=all,subject=number_theory,level=3,use_official_examples=True", priority: 3}
+  {description: "math:model=all,subject=intermediate_algebra,level=3,use_official_examples=True", priority: 3}
+  {description: "math:model=all,subject=algebra,level=3,use_official_examples=True", priority: 3}
+  {description: "math:model=all,subject=prealgebra,level=3,use_official_examples=True", priority: 3}
+  {description: "math:model=all,subject=geometry,level=3,use_official_examples=True", priority: 3}
+  {description: "math:model=all,subject=counting_and_probability,level=3,use_official_examples=True", priority: 3}
+  {description: "math:model=all,subject=precalculus,level=3,use_official_examples=True", priority: 3}
+
+  {description: "math:model=all,subject=number_theory,level=4,use_official_examples=True", priority: 4}
+  {description: "math:model=all,subject=intermediate_algebra,level=4,use_official_examples=True", priority: 4}
+  {description: "math:model=all,subject=algebra,level=4,use_official_examples=True", priority: 4}
+  {description: "math:model=all,subject=prealgebra,level=4,use_official_examples=True", priority: 4}
+  {description: "math:model=all,subject=geometry,level=4,use_official_examples=True", priority: 4}
+  {description: "math:model=all,subject=counting_and_probability,level=4,use_official_examples=True", priority: 4}
+  {description: "math:model=all,subject=precalculus,level=4,use_official_examples=True", priority: 4}
+
+  {description: "math:model=all,subject=number_theory,level=5,use_official_examples=True", priority: 3}
+  {description: "math:model=all,subject=intermediate_algebra,level=5,use_official_examples=True", priority: 3}
+  {description: "math:model=all,subject=algebra,level=5,use_official_examples=True", priority: 3}
+  {description: "math:model=all,subject=prealgebra,level=5,use_official_examples=True", priority: 3}
+  {description: "math:model=all,subject=geometry,level=5,use_official_examples=True", priority: 3}
+  {description: "math:model=all,subject=counting_and_probability,level=5,use_official_examples=True", priority: 3}
+  {description: "math:model=all,subject=precalculus,level=5,use_official_examples=True", priority: 3}
+
+  # With chain-of-thought prompting:
+  {description: "math:model=all,subject=number_theory,level=1,use_chain_of_thought=True", priority: 2}
+  {description: "math:model=all,subject=intermediate_algebra,level=1,use_chain_of_thought=True", priority: 2}
+  {description: "math:model=all,subject=algebra,level=1,use_chain_of_thought=True", priority: 2}
+  {description: "math:model=all,subject=prealgebra,level=1,use_chain_of_thought=True", priority: 2}
+  {description: "math:model=all,subject=geometry,level=1,use_chain_of_thought=True", priority: 2}
+  {description: "math:model=all,subject=counting_and_probability,level=1,use_chain_of_thought=True", priority: 2}
+  {description: "math:model=all,subject=precalculus,level=1,use_chain_of_thought=True", priority: 2}
+
+  {description: "math:model=all,subject=number_theory,level=2,use_chain_of_thought=True", priority: 4}
+  {description: "math:model=all,subject=intermediate_algebra,level=2,use_chain_of_thought=True", priority: 4}
+  {description: "math:model=all,subject=algebra,level=2,use_chain_of_thought=True", priority: 4}
+  {description: "math:model=all,subject=prealgebra,level=2,use_chain_of_thought=True", priority: 4}
+  {description: "math:model=all,subject=geometry,level=2,use_chain_of_thought=True", priority: 4}
+  {description: "math:model=all,subject=counting_and_probability,level=2,use_chain_of_thought=True", priority: 4}
+  {description: "math:model=all,subject=precalculus,level=2,use_chain_of_thought=True", priority: 4}
+
+  {description: "math:model=all,subject=number_theory,level=3,use_chain_of_thought=True", priority: 3}
+  {description: "math:model=all,subject=intermediate_algebra,level=3,use_chain_of_thought=True", priority: 3}
+  {description: "math:model=all,subject=algebra,level=3,use_chain_of_thought=True", priority: 3}
+  {description: "math:model=all,subject=prealgebra,level=3,use_chain_of_thought=True", priority: 3}
+  {description: "math:model=all,subject=geometry,level=3,use_chain_of_thought=True", priority: 3}
+  {description: "math:model=all,subject=counting_and_probability,level=3,use_chain_of_thought=True", priority: 3}
+  {description: "math:model=all,subject=precalculus,level=3,use_chain_of_thought=True", priority: 3}
+
+  {description: "math:model=all,subject=number_theory,level=4,use_chain_of_thought=True", priority: 4}
+  {description: "math:model=all,subject=intermediate_algebra,level=4,use_chain_of_thought=True", priority: 4}
+  {description: "math:model=all,subject=algebra,level=4,use_chain_of_thought=True", priority: 4}
+  {description: "math:model=all,subject=prealgebra,level=4,use_chain_of_thought=True", priority: 4}
+  {description: "math:model=all,subject=geometry,level=4,use_chain_of_thought=True", priority: 4}
+  {description: "math:model=all,subject=counting_and_probability,level=4,use_chain_of_thought=True", priority: 4}
+  {description: "math:model=all,subject=precalculus,level=4,use_chain_of_thought=True", priority: 4}
+
+  {description: "math:model=all,subject=number_theory,level=5,use_chain_of_thought=True", priority: 3}
+  {description: "math:model=all,subject=intermediate_algebra,level=5,use_chain_of_thought=True", priority: 3}
+  {description: "math:model=all,subject=algebra,level=5,use_chain_of_thought=True", priority: 3}
+  {description: "math:model=all,subject=prealgebra,level=5,use_chain_of_thought=True", priority: 3}
+  {description: "math:model=all,subject=geometry,level=5,use_chain_of_thought=True", priority: 3}
+  {description: "math:model=all,subject=counting_and_probability,level=5,use_chain_of_thought=True", priority: 3}
+  {description: "math:model=all,subject=precalculus,level=5,use_chain_of_thought=True", priority: 3}
+
+  {description: "gsm:model=all", priority: 2}
+
+  # Legal reasoning
+  {description: "legal_support:model=all", priority: 2}
+
+  {description: "lsat_qa:model=all,task=all", priority: 2}
+  {description: "lsat_qa:model=all,task=grouping", priority: 3}
+  {description: "lsat_qa:model=all,task=ordering", priority: 3}
+  {description: "lsat_qa:model=all,task=assignment", priority: 3}
+  {description: "lsat_qa:model=all,task=miscellaneous", priority: 3}
+
+  # Data processing
+
+  {description: "entity_matching:model=text,dataset=Beer", priority: 2}
+  {description: "entity_matching:model=text,dataset=Abt_Buy", priority: 2}
+  {description: "entity_matching:model=text,dataset=Dirty_iTunes_Amazon", priority: 2}
+
+  {description: "entity_data_imputation:model=text,dataset=Buy", priority: 2}
+  {description: "entity_data_imputation:model=text,dataset=Restaurant", priority: 2}
+
+  # Code
+  {description: "code:model=code,dataset=humaneval", priority: 1}
+  {description: "code:model=code,dataset=apps,timeout=3", priority: 1}
+
+
+  ##### Harms #####
+
+  ## Copyright
+
+  # Randomly sampled instances from the original BooksCorpus.
+  # We expect data here to be less repeated in the pretraining corpus. This approximates the average case.
+  {description: "copyright:model=text,datatag=n_books_1000-extractions_per_book_1-prefix_length_125", priority: 1}
+
+  # We expect data here to be repeated more in the pretraining corpus. This approximates the worst case.
+  {description: "copyright:model=text,datatag=popular_books-prefix_length_125.json", priority: 1}
+
+  # Large and small codex models.
+  {description: "copyright:model=code,datatag=prompt_num_line_1-min_lines_20.json", priority: 2}
+  {description: "copyright:model=code,datatag=prompt_num_line_5-min_lines_20.json", priority: 3}
+  {description: "copyright:model=code,datatag=prompt_num_line_10-min_lines_20.json", priority: 2}
+
+  ## Disinformation
+
+  {description: "disinformation:model=text,capability=reiteration,topic=climate", priority: 1}
+  {description: "disinformation:model=text,capability=reiteration,topic=covid", priority: 1}
+  {description: "disinformation:model=text,capability=wedging", priority: 1}
+
+  ## Bias
+
+  {description: "bbq:model=text,subject=all", priority: 2}
+  {description: "bbq:model=text,subject=age", priority: 3}
+  {description: "bbq:model=text,subject=disability_status", priority: 3}
+  {description: "bbq:model=text,subject=gender_identity", priority: 3}
+  {description: "bbq:model=text,subject=nationality", priority: 3}
+  {description: "bbq:model=text,subject=physical_appearance", priority: 3}
+  {description: "bbq:model=text,subject=race_ethnicity", priority: 3}
+  {description: "bbq:model=text,subject=race_x_SES", priority: 3}
+  {description: "bbq:model=text,subject=race_x_gender", priority: 3}
+  {description: "bbq:model=text,subject=religion", priority: 3}
+  {description: "bbq:model=text,subject=SES", priority: 3}
+  {description: "bbq:model=text,subject=sexual_orientation", priority: 3}
+
+  ## Toxicity
+
+  {description: "real_toxicity_prompts:model=text", priority: 2}
+
+  {description: "bold:model=text,subject=all", priority: 2}
+  {description: "bold:model=text,subject=gender", priority: 3}
+  {description: "bold:model=text,subject=political_ideology", priority: 3}
+  {description: "bold:model=text,subject=profession", priority: 3}
+  {description: "bold:model=text,subject=race", priority: 3}
+  {description: "bold:model=text,subject=religious_ideology", priority: 3}
+
+
+  ##### Efficiency #####
+
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=256,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=256,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=256,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=256,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=256,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=256,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=256,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=512,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=512,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=512,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=512,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=512,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=512,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=512,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1024,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1024,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1024,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1024,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1024,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1024,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1024,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1536,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1536,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1536,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1536,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1536,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1536,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=gpt2_tokenizer,tokenizer=huggingface/gpt2,num_prompt_tokens=1536,num_output_tokens=64", priority: 1}
+
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=256,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=256,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=256,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=256,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=256,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=256,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=256,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=512,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=512,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=512,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=512,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=512,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=512,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=512,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1024,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1024,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1024,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1024,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1024,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1024,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1024,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1536,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1536,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1536,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1536,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1536,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1536,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=ai21_tokenizer,tokenizer=ai21/j1,num_prompt_tokens=1536,num_output_tokens=64", priority: 1}
+
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=256,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=256,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=256,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=256,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=256,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=256,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=256,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=512,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=512,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=512,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=512,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=512,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=512,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=512,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1024,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1024,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1024,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1024,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1024,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1024,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1024,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1536,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1536,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1536,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1536,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1536,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1536,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=cohere_tokenizer,tokenizer=cohere/cohere,num_prompt_tokens=1536,num_output_tokens=64", priority: 1}
+
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=256,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=256,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=256,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=256,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=256,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=256,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=256,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=512,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=512,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=512,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=512,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=512,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=512,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=512,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1024,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1024,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1024,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1024,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1024,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1024,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1024,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1536,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1536,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1536,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1536,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1536,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1536,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=opt_tokenizer,tokenizer=meta/opt,num_prompt_tokens=1536,num_output_tokens=64", priority: 1}
+
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=256,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=256,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=256,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=256,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=256,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=256,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=256,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=512,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=512,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=512,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=512,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=512,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=512,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=512,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1024,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1024,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1024,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1024,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1024,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1024,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1024,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1536,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1536,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1536,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1536,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1536,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1536,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/yalm,tokenizer=yandex/yalm,num_prompt_tokens=1536,num_output_tokens=64", priority: 1}
+
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=256,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=256,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=256,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=256,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=256,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=256,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=256,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=512,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=512,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=512,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=512,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=512,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=512,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=512,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1024,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1024,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1024,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1024,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1024,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1024,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1024,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1536,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1536,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1536,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1536,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1536,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1536,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/bloom,tokenizer=bigscience/bloom,num_prompt_tokens=1536,num_output_tokens=64", priority: 1}
+
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=256,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=256,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=256,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=256,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=256,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=256,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=256,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=512,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=512,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=512,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=512,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=512,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=512,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=512,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1024,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1024,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1024,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1024,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1024,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1024,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1024,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1536,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1536,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1536,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1536,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1536,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1536,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/t5-11b,tokenizer=google/t5,num_prompt_tokens=1536,num_output_tokens=64", priority: 1}
+
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=256,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=256,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=256,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=256,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=256,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=256,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=256,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=512,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=512,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=512,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=512,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=512,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=512,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=512,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1024,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1024,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1024,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1024,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1024,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1024,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1024,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1536,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1536,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1536,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1536,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1536,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1536,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/t0pp,tokenizer=bigscience/t0pp,num_prompt_tokens=1536,num_output_tokens=64", priority: 1}
+
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=256,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=256,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=256,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=256,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=256,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=256,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=256,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=512,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=512,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=512,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=512,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=512,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=512,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=512,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1024,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1024,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1024,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1024,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1024,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1024,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1024,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1536,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1536,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1536,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1536,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1536,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1536,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/ul2,tokenizer=google/ul2,num_prompt_tokens=1536,num_output_tokens=64", priority: 1}
+
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=256,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=256,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=256,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=256,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=256,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=256,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=256,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=512,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=512,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=512,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=512,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=512,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=512,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=512,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1024,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1024,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1024,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1024,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1024,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1024,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1024,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1536,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1536,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1536,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1536,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1536,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1536,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/glm,tokenizer=tsinghua/glm,num_prompt_tokens=1536,num_output_tokens=64", priority: 1}
+
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=256,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=256,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=256,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=256,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=256,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=256,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=256,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=512,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=512,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=512,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=512,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=512,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=512,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=512,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1024,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1024,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1024,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1024,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1024,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1024,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1024,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1536,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1536,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1536,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1536,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1536,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1536,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-j-6b,tokenizer=eleutherai/gptj,num_prompt_tokens=1536,num_output_tokens=64", priority: 1}
+
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=256,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=256,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=256,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=256,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=256,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=256,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=256,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=512,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=512,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=512,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=512,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=512,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=512,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=512,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1024,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1024,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1024,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1024,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1024,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1024,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1024,num_output_tokens=64", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1536,num_output_tokens=1", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1536,num_output_tokens=2", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1536,num_output_tokens=4", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1536,num_output_tokens=8", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1536,num_output_tokens=16", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1536,num_output_tokens=32", priority: 1}
+  {description: "synthetic_efficiency:model=together/gpt-neox-20b,tokenizer=eleutherai/gptneox,num_prompt_tokens=1536,num_output_tokens=64", priority: 1}
+
+  ##### Robustness #####
+
+  ## Contrast sets (these are separate runs since we will only consider Instances that have contrast sets
+  {description: "boolq:model=text,only_contrast=True,data_augmentation=contrast_sets", priority: 2}
+  {description: "imdb:model=text,only_contrast=True,data_augmentation=contrast_sets", priority: 2}
+]

--- a/src/benchmark/presentation/run_specs_ablations.conf
+++ b/src/benchmark/presentation/run_specs_ablations.conf
@@ -1,300 +1,301 @@
 # The list of RunSpecs associated with ablations.
 
-##### Number of in-context examples #####
-# Scenarios: Canonical scenarios
-# Scenarios list: NaturalQuestions (open), CNN/DM, IMDB, CivilComments
+entries: [
 
-"natural_qa:model=ablation_text,mode=openbook_longans,max_train_instances=all,data_augmentation=canonical": {priority: 1}
-"summarization_cnndm:model=ablation_text,temperature=0.3,device=cpu,max_train_instances=all": {priority: 1}
-"imdb:model=ablation_text,max_train_instances=all,data_augmentation=canonical": {priority: 1}
-"civil_comments:model=ablation_text,demographic=all,max_train_instances=all,data_augmentation=canonical": {priority: 1}
+  ##### Number of in-context examples #####
+  # Scenarios: Canonical scenarios
+  # Scenarios list: NaturalQuestions (open), CNN/DM, IMDB, CivilComments
 
+  {description: "natural_qa:model=ablation_text,mode=openbook_longans,max_train_instances=all,data_augmentation=canonical", priority: 1}
+  {description: "summarization_cnndm:model=ablation_text,temperature=0.3,device=cpu,max_train_instances=all", priority: 1}
+  {description: "imdb:model=ablation_text,max_train_instances=all,data_augmentation=canonical", priority: 1}
+  {description: "civil_comments:model=ablation_text,demographic=all,max_train_instances=all,data_augmentation=canonical", priority: 1}
 
-##### Multiple-choice adaptation method #####
-# Scenarios: Multiple-choice scenarios
-# Generic scenarios list: CommonsenseQA, HellaSwag, OpenbookQA, TruthfulQA, MMLU
-# Component scenarios list: BLiMP, LegalSupport, LSAT, BBQ
+  ##### Multiple-choice adaptation method #####
+  # Scenarios: Multiple-choice scenarios
+  # Generic scenarios list: CommonsenseQA, HellaSwag, OpenbookQA, TruthfulQA, MMLU
+  # Component scenarios list: BLiMP, LegalSupport, LSAT, BBQ
 
-"commonsense:model=ablation_full_functionality_text,dataset=commonsenseqa,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"commonsense:model=ablation_full_functionality_text,dataset=commonsenseqa,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"commonsense:model=ablation_full_functionality_text,dataset=commonsenseqa,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"commonsense:model=ablation_full_functionality_text,dataset=hellaswag,method=multiple_choice_joint,data_augmentation=canonical": {priority: 1}
-"commonsense:model=ablation_full_functionality_text,dataset=hellaswag,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 1}
-"commonsense:model=ablation_full_functionality_text,dataset=hellaswag,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 1}
-"commonsense:model=ablation_full_functionality_text,dataset=openbookqa,method=multiple_choice_joint,data_augmentation=canonical": {priority: 2}
-"commonsense:model=ablation_full_functionality_text,dataset=openbookqa,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 2}
-"commonsense:model=ablation_full_functionality_text,dataset=openbookqa,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 2}
-"truthful_qa:model=ablation_full_functionality_text,task=mc_single,method=multiple_choice_joint,data_augmentation=canonical": {priority: 2}
-"truthful_qa:model=ablation_full_functionality_text,task=mc_single,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 2}
-"truthful_qa:model=ablation_full_functionality_text,task=mc_single,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 2}
+  {description: "commonsense:model=ablation_full_functionality_text,dataset=commonsenseqa,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "commonsense:model=ablation_full_functionality_text,dataset=commonsenseqa,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "commonsense:model=ablation_full_functionality_text,dataset=commonsenseqa,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "commonsense:model=ablation_full_functionality_text,dataset=hellaswag,method=multiple_choice_joint,data_augmentation=canonical", priority: 1}
+  {description: "commonsense:model=ablation_full_functionality_text,dataset=hellaswag,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 1}
+  {description: "commonsense:model=ablation_full_functionality_text,dataset=hellaswag,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 1}
+  {description: "commonsense:model=ablation_full_functionality_text,dataset=openbookqa,method=multiple_choice_joint,data_augmentation=canonical", priority: 2}
+  {description: "commonsense:model=ablation_full_functionality_text,dataset=openbookqa,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 2}
+  {description: "commonsense:model=ablation_full_functionality_text,dataset=openbookqa,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 2}
+  {description: "truthful_qa:model=ablation_full_functionality_text,task=mc_single,method=multiple_choice_joint,data_augmentation=canonical", priority: 2}
+  {description: "truthful_qa:model=ablation_full_functionality_text,task=mc_single,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 2}
+  {description: "truthful_qa:model=ablation_full_functionality_text,task=mc_single,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 2}
 
-# MMLU priorities follow the main `run_specs.conf` with 2 -> 1 and 4 -> 3
-"mmlu:model=ablation_full_functionality_text,subject=abstract_algebra,method=multiple_choice_joint,data_augmentation=canonical": {priority: 1}
-"mmlu:model=ablation_full_functionality_text,subject=abstract_algebra,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 1}
-"mmlu:model=ablation_full_functionality_text,subject=abstract_algebra,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 1}
-"mmlu:model=ablation_full_functionality_text,subject=anatomy,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=anatomy,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=anatomy,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=college_chemistry,method=multiple_choice_joint,data_augmentation=canonical": {priority: 1}
-"mmlu:model=ablation_full_functionality_text,subject=college_chemistry,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 1}
-"mmlu:model=ablation_full_functionality_text,subject=college_chemistry,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 1}
-"mmlu:model=ablation_full_functionality_text,subject=computer_security,method=multiple_choice_joint,data_augmentation=canonical": {priority: 1}
-"mmlu:model=ablation_full_functionality_text,subject=computer_security,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 1}
-"mmlu:model=ablation_full_functionality_text,subject=computer_security,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 1}
-"mmlu:model=ablation_full_functionality_text,subject=econometrics,method=multiple_choice_joint,data_augmentation=canonical": {priority: 1}
-"mmlu:model=ablation_full_functionality_text,subject=econometrics,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 1}
-"mmlu:model=ablation_full_functionality_text,subject=econometrics,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 1}
-"mmlu:model=ablation_full_functionality_text,subject=global_facts,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=global_facts,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=global_facts,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=jurisprudence,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=jurisprudence,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=jurisprudence,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=philosophy,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=philosophy,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=philosophy,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=professional_medicine,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=professional_medicine,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=professional_medicine,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=us_foreign_policy,method=multiple_choice_joint,data_augmentation=canonical": {priority: 1}
-"mmlu:model=ablation_full_functionality_text,subject=us_foreign_policy,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 1}
-"mmlu:model=ablation_full_functionality_text,subject=us_foreign_policy,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 1}
-"mmlu:model=ablation_full_functionality_text,subject=astronomy,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=astronomy,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=astronomy,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=business_ethics,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=business_ethics,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=business_ethics,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=clinical_knowledge,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=clinical_knowledge,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=clinical_knowledge,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=college_biology,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=college_biology,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=college_biology,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=college_computer_science,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=college_computer_science,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=college_computer_science,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=college_mathematics,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=college_mathematics,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=college_mathematics,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=college_medicine,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=college_medicine,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=college_medicine,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=college_physics,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=college_physics,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=college_physics,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=conceptual_physics,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=conceptual_physics,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=conceptual_physics,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=electrical_engineering,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=electrical_engineering,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=electrical_engineering,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=elementary_mathematics,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=elementary_mathematics,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=elementary_mathematics,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=formal_logic,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=formal_logic,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=formal_logic,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_biology,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_biology,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_biology,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_chemistry,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_chemistry,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_chemistry,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_computer_science,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_computer_science,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_computer_science,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_european_history,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_european_history,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_european_history,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_geography,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_geography,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_geography,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_government_and_politics,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_government_and_politics,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_government_and_politics,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_macroeconomics,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_macroeconomics,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_macroeconomics,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_mathematics,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_mathematics,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_mathematics,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_microeconomics,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_microeconomics,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_microeconomics,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_physics,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_physics,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_physics,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_psychology,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_psychology,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_psychology,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_statistics,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_statistics,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_statistics,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_us_history,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_us_history,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_us_history,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_world_history,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_world_history,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=high_school_world_history,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=human_aging,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=human_aging,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=human_aging,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=human_sexuality,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=human_sexuality,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=human_sexuality,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=international_law,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=international_law,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=international_law,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=logical_fallacies,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=logical_fallacies,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=logical_fallacies,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=machine_learning,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=machine_learning,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=machine_learning,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=management,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=management,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=management,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=marketing,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=marketing,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=marketing,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=medical_genetics,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=medical_genetics,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=medical_genetics,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=miscellaneous,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=miscellaneous,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=miscellaneous,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=moral_disputes,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=moral_disputes,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=moral_disputes,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=moral_scenarios,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=moral_scenarios,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=moral_scenarios,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=nutrition,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=nutrition,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=nutrition,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=prehistory,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=prehistory,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=prehistory,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=professional_accounting,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=professional_accounting,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=professional_accounting,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=professional_law,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=professional_law,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=professional_law,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=professional_psychology,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=professional_psychology,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=professional_psychology,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=public_relations,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=public_relations,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=public_relations,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=security_studies,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=security_studies,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=security_studies,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=sociology,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=sociology,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=sociology,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=virology,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=virology,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=virology,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=world_religions,method=multiple_choice_joint,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=world_religions,method=multiple_choice_separate_original,data_augmentation=canonical": {priority: 3}
-"mmlu:model=ablation_full_functionality_text,subject=world_religions,method=multiple_choice_separate_calibrated,data_augmentation=canonical": {priority: 3}
+  # MMLU priorities follow the main `run_specs.conf` with 2 -> 1 and 4 -> 3
+  {description: "mmlu:model=ablation_full_functionality_text,subject=abstract_algebra,method=multiple_choice_joint,data_augmentation=canonical", priority: 1}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=abstract_algebra,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 1}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=abstract_algebra,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 1}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=anatomy,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=anatomy,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=anatomy,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=college_chemistry,method=multiple_choice_joint,data_augmentation=canonical", priority: 1}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=college_chemistry,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 1}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=college_chemistry,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 1}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=computer_security,method=multiple_choice_joint,data_augmentation=canonical", priority: 1}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=computer_security,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 1}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=computer_security,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 1}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=econometrics,method=multiple_choice_joint,data_augmentation=canonical", priority: 1}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=econometrics,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 1}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=econometrics,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 1}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=global_facts,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=global_facts,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=global_facts,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=jurisprudence,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=jurisprudence,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=jurisprudence,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=philosophy,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=philosophy,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=philosophy,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=professional_medicine,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=professional_medicine,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=professional_medicine,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=us_foreign_policy,method=multiple_choice_joint,data_augmentation=canonical", priority: 1}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=us_foreign_policy,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 1}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=us_foreign_policy,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 1}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=astronomy,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=astronomy,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=astronomy,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=business_ethics,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=business_ethics,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=business_ethics,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=clinical_knowledge,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=clinical_knowledge,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=clinical_knowledge,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=college_biology,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=college_biology,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=college_biology,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=college_computer_science,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=college_computer_science,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=college_computer_science,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=college_mathematics,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=college_mathematics,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=college_mathematics,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=college_medicine,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=college_medicine,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=college_medicine,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=college_physics,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=college_physics,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=college_physics,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=conceptual_physics,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=conceptual_physics,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=conceptual_physics,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=electrical_engineering,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=electrical_engineering,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=electrical_engineering,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=elementary_mathematics,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=elementary_mathematics,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=elementary_mathematics,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=formal_logic,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=formal_logic,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=formal_logic,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_biology,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_biology,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_biology,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_chemistry,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_chemistry,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_chemistry,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_computer_science,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_computer_science,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_computer_science,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_european_history,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_european_history,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_european_history,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_geography,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_geography,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_geography,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_government_and_politics,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_government_and_politics,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_government_and_politics,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_macroeconomics,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_macroeconomics,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_macroeconomics,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_mathematics,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_mathematics,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_mathematics,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_microeconomics,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_microeconomics,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_microeconomics,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_physics,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_physics,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_physics,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_psychology,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_psychology,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_psychology,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_statistics,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_statistics,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_statistics,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_us_history,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_us_history,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_us_history,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_world_history,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_world_history,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=high_school_world_history,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=human_aging,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=human_aging,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=human_aging,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=human_sexuality,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=human_sexuality,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=human_sexuality,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=international_law,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=international_law,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=international_law,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=logical_fallacies,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=logical_fallacies,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=logical_fallacies,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=machine_learning,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=machine_learning,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=machine_learning,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=management,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=management,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=management,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=marketing,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=marketing,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=marketing,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=medical_genetics,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=medical_genetics,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=medical_genetics,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=miscellaneous,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=miscellaneous,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=miscellaneous,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=moral_disputes,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=moral_disputes,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=moral_disputes,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=moral_scenarios,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=moral_scenarios,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=moral_scenarios,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=nutrition,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=nutrition,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=nutrition,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=prehistory,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=prehistory,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=prehistory,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=professional_accounting,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=professional_accounting,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=professional_accounting,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=professional_law,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=professional_law,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=professional_law,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=professional_psychology,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=professional_psychology,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=professional_psychology,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=public_relations,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=public_relations,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=public_relations,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=security_studies,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=security_studies,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=security_studies,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=sociology,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=sociology,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=sociology,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=virology,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=virology,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=virology,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=world_religions,method=multiple_choice_joint,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=world_religions,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 3}
+  {description: "mmlu:model=ablation_full_functionality_text,subject=world_religions,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
 
-"blimp:model=ablation_full_functionality_text,phenomenon=anaphor_agreement,method=multiple_choice_joint": {priority: 3} # Morphology
-"blimp:model=ablation_full_functionality_text,phenomenon=anaphor_agreement,method=multiple_choice_separate_original": {priority: 3} # Morphology
-"blimp:model=ablation_full_functionality_text,phenomenon=anaphor_agreement,method=multiple_choice_separate_calibrated": {priority: 3} # Morphology
-"blimp:model=ablation_full_functionality_text,phenomenon=determiner_noun_agreement,method=multiple_choice_joint": {priority: 3} # Morphology
-"blimp:model=ablation_full_functionality_text,phenomenon=determiner_noun_agreement,method=multiple_choice_separate_original": {priority: 3} # Morphology
-"blimp:model=ablation_full_functionality_text,phenomenon=determiner_noun_agreement,method=multiple_choice_separate_calibrated": {priority: 3} # Morphology
-"blimp:model=ablation_full_functionality_text,phenomenon=irregular_forms,method=multiple_choice_joint": {priority: 2} # Morphology
-"blimp:model=ablation_full_functionality_text,phenomenon=irregular_forms,method=multiple_choice_separate_original": {priority: 2} # Morphology
-"blimp:model=ablation_full_functionality_text,phenomenon=irregular_forms,method=multiple_choice_separate_calibrated": {priority: 2} # Morphology
-"blimp:model=ablation_full_functionality_text,phenomenon=subject_verb_agreement,method=multiple_choice_joint": {priority: 3} # Morphology
-"blimp:model=ablation_full_functionality_text,phenomenon=subject_verb_agreement,method=multiple_choice_separate_original": {priority: 3} # Morphology
-"blimp:model=ablation_full_functionality_text,phenomenon=subject_verb_agreement,method=multiple_choice_separate_calibrated": {priority: 3} # Morphology
-"blimp:model=ablation_full_functionality_text,phenomenon=quantifiers,method=multiple_choice_joint": {priority: 2} # Semantics
-"blimp:model=ablation_full_functionality_text,phenomenon=quantifiers,method=multiple_choice_separate_original": {priority: 2} # Semantics
-"blimp:model=ablation_full_functionality_text,phenomenon=quantifiers,method=multiple_choice_separate_calibrated": {priority: 2} # Semantics
-"blimp:model=ablation_full_functionality_text,phenomenon=npi_licensing,method=multiple_choice_joint": {priority: 3} # Semantics
-"blimp:model=ablation_full_functionality_text,phenomenon=npi_licensing,method=multiple_choice_separate_original": {priority: 3} # Semantics
-"blimp:model=ablation_full_functionality_text,phenomenon=npi_licensing,method=multiple_choice_separate_calibrated": {priority: 3} # Semantics
-"blimp:model=ablation_full_functionality_text,phenomenon=argument_structure,method=multiple_choice_joint": {priority: 3} # Syntax
-"blimp:model=ablation_full_functionality_text,phenomenon=argument_structure,method=multiple_choice_separate_original": {priority: 3} # Syntax
-"blimp:model=ablation_full_functionality_text,phenomenon=argument_structure,method=multiple_choice_separate_calibrated": {priority: 3} # Syntax
-"blimp:model=ablation_full_functionality_text,phenomenon=ellipsis,method=multiple_choice_joint": {priority: 3} # Syntax
-"blimp:model=ablation_full_functionality_text,phenomenon=ellipsis,method=multiple_choice_separate_original": {priority: 3} # Syntax
-"blimp:model=ablation_full_functionality_text,phenomenon=ellipsis,method=multiple_choice_separate_calibrated": {priority: 3} # Syntax
-"blimp:model=ablation_full_functionality_text,phenomenon=filler_gap_dependency,method=multiple_choice_joint": {priority: 3} # Syntax
-"blimp:model=ablation_full_functionality_text,phenomenon=filler_gap_dependency,method=multiple_choice_separate_original": {priority: 3} # Syntax
-"blimp:model=ablation_full_functionality_text,phenomenon=filler_gap_dependency,method=multiple_choice_separate_calibrated": {priority: 3} # Syntax
-"blimp:model=ablation_full_functionality_text,phenomenon=island_effects,method=multiple_choice_joint": {priority: 2} # Syntax
-"blimp:model=ablation_full_functionality_text,phenomenon=island_effects,method=multiple_choice_separate_original": {priority: 2} # Syntax
-"blimp:model=ablation_full_functionality_text,phenomenon=island_effects,method=multiple_choice_separate_calibrated": {priority: 2} # Syntax
-"blimp:model=ablation_full_functionality_text,phenomenon=binding,method=multiple_choice_joint": {priority: 2} # Syntax-Semantics
-"blimp:model=ablation_full_functionality_text,phenomenon=binding,method=multiple_choice_separate_original": {priority: 2} # Syntax-Semantics
-"blimp:model=ablation_full_functionality_text,phenomenon=binding,method=multiple_choice_separate_calibrated": {priority: 2} # Syntax-Semantics
-"blimp:model=ablation_full_functionality_text,phenomenon=control_raising,method=multiple_choice_joint": {priority: 3} # Syntax-Semantics
-"blimp:model=ablation_full_functionality_text,phenomenon=control_raising,method=multiple_choice_separate_original": {priority: 3} # Syntax-Semantics
-"blimp:model=ablation_full_functionality_text,phenomenon=control_raising,method=multiple_choice_separate_calibrated": {priority: 3} # Syntax-Semantics
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=anaphor_agreement,method=multiple_choice_joint", priority: 3} # Morphology
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=anaphor_agreement,method=multiple_choice_separate_original", priority: 3} # Morphology
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=anaphor_agreement,method=multiple_choice_separate_calibrated", priority: 3} # Morphology
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=determiner_noun_agreement,method=multiple_choice_joint", priority: 3} # Morphology
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=determiner_noun_agreement,method=multiple_choice_separate_original", priority: 3} # Morphology
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=determiner_noun_agreement,method=multiple_choice_separate_calibrated", priority: 3} # Morphology
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=irregular_forms,method=multiple_choice_joint", priority: 2} # Morphology
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=irregular_forms,method=multiple_choice_separate_original", priority: 2} # Morphology
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=irregular_forms,method=multiple_choice_separate_calibrated", priority: 2} # Morphology
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=subject_verb_agreement,method=multiple_choice_joint", priority: 3} # Morphology
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=subject_verb_agreement,method=multiple_choice_separate_original", priority: 3} # Morphology
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=subject_verb_agreement,method=multiple_choice_separate_calibrated", priority: 3} # Morphology
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=quantifiers,method=multiple_choice_joint", priority: 2} # Semantics
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=quantifiers,method=multiple_choice_separate_original", priority: 2} # Semantics
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=quantifiers,method=multiple_choice_separate_calibrated", priority: 2} # Semantics
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=npi_licensing,method=multiple_choice_joint", priority: 3} # Semantics
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=npi_licensing,method=multiple_choice_separate_original", priority: 3} # Semantics
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=npi_licensing,method=multiple_choice_separate_calibrated", priority: 3} # Semantics
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=argument_structure,method=multiple_choice_joint", priority: 3} # Syntax
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=argument_structure,method=multiple_choice_separate_original", priority: 3} # Syntax
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=argument_structure,method=multiple_choice_separate_calibrated", priority: 3} # Syntax
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=ellipsis,method=multiple_choice_joint", priority: 3} # Syntax
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=ellipsis,method=multiple_choice_separate_original", priority: 3} # Syntax
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=ellipsis,method=multiple_choice_separate_calibrated", priority: 3} # Syntax
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=filler_gap_dependency,method=multiple_choice_joint", priority: 3} # Syntax
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=filler_gap_dependency,method=multiple_choice_separate_original", priority: 3} # Syntax
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=filler_gap_dependency,method=multiple_choice_separate_calibrated", priority: 3} # Syntax
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=island_effects,method=multiple_choice_joint", priority: 2} # Syntax
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=island_effects,method=multiple_choice_separate_original", priority: 2} # Syntax
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=island_effects,method=multiple_choice_separate_calibrated", priority: 2} # Syntax
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=binding,method=multiple_choice_joint", priority: 2} # Syntax-Semantics
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=binding,method=multiple_choice_separate_original", priority: 2} # Syntax-Semantics
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=binding,method=multiple_choice_separate_calibrated", priority: 2} # Syntax-Semantics
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=control_raising,method=multiple_choice_joint", priority: 3} # Syntax-Semantics
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=control_raising,method=multiple_choice_separate_original", priority: 3} # Syntax-Semantics
+  {description: "blimp:model=ablation_full_functionality_text,phenomenon=control_raising,method=multiple_choice_separate_calibrated", priority: 3} # Syntax-Semantics
 
-"legal_support:model=ablation_full_functionality_text,method=multiple_choice_joint": {priority: 2}
-"legal_support:model=ablation_full_functionality_text,method=multiple_choice_separate_original": {priority: 2}
-"legal_support:model=ablation_full_functionality_text,method=multiple_choice_separate_calibrated": {priority: 2}
+  {description: "legal_support:model=ablation_full_functionality_text,method=multiple_choice_joint", priority: 2}
+  {description: "legal_support:model=ablation_full_functionality_text,method=multiple_choice_separate_original", priority: 2}
+  {description: "legal_support:model=ablation_full_functionality_text,method=multiple_choice_separate_calibrated", priority: 2}
 
-"lsat_qa:model=ablation_full_functionality_text,task=all,method=multiple_choice_joint": {priority: 2}
-"lsat_qa:model=ablation_full_functionality_text,task=all,method=multiple_choice_separate_original": {priority: 2}
-"lsat_qa:model=ablation_full_functionality_text,task=all,method=multiple_choice_separate_calibrated": {priority: 2}
-"lsat_qa:model=ablation_full_functionality_text,task=grouping,method=multiple_choice_joint": {priority: 3}
-"lsat_qa:model=ablation_full_functionality_text,task=grouping,method=multiple_choice_separate_original": {priority: 3}
-"lsat_qa:model=ablation_full_functionality_text,task=grouping,method=multiple_choice_separate_calibrated": {priority: 3}
-"lsat_qa:model=ablation_full_functionality_text,task=ordering,method=multiple_choice_joint": {priority: 3}
-"lsat_qa:model=ablation_full_functionality_text,task=ordering,method=multiple_choice_separate_original": {priority: 3}
-"lsat_qa:model=ablation_full_functionality_text,task=ordering,method=multiple_choice_separate_calibrated": {priority: 3}
-"lsat_qa:model=ablation_full_functionality_text,task=assignment,method=multiple_choice_joint": {priority: 3}
-"lsat_qa:model=ablation_full_functionality_text,task=assignment,method=multiple_choice_separate_original": {priority: 3}
-"lsat_qa:model=ablation_full_functionality_text,task=assignment,method=multiple_choice_separate_calibrated": {priority: 3}
-"lsat_qa:model=ablation_full_functionality_text,task=miscellaneous,method=multiple_choice_joint": {priority: 3}
-"lsat_qa:model=ablation_full_functionality_text,task=miscellaneous,method=multiple_choice_separate_original": {priority: 3}
-"lsat_qa:model=ablation_full_functionality_text,task=miscellaneous,method=multiple_choice_separate_calibrated": {priority: 3}
+  {description: "lsat_qa:model=ablation_full_functionality_text,task=all,method=multiple_choice_joint", priority: 2}
+  {description: "lsat_qa:model=ablation_full_functionality_text,task=all,method=multiple_choice_separate_original", priority: 2}
+  {description: "lsat_qa:model=ablation_full_functionality_text,task=all,method=multiple_choice_separate_calibrated", priority: 2}
+  {description: "lsat_qa:model=ablation_full_functionality_text,task=grouping,method=multiple_choice_joint", priority: 3}
+  {description: "lsat_qa:model=ablation_full_functionality_text,task=grouping,method=multiple_choice_separate_original", priority: 3}
+  {description: "lsat_qa:model=ablation_full_functionality_text,task=grouping,method=multiple_choice_separate_calibrated", priority: 3}
+  {description: "lsat_qa:model=ablation_full_functionality_text,task=ordering,method=multiple_choice_joint", priority: 3}
+  {description: "lsat_qa:model=ablation_full_functionality_text,task=ordering,method=multiple_choice_separate_original", priority: 3}
+  {description: "lsat_qa:model=ablation_full_functionality_text,task=ordering,method=multiple_choice_separate_calibrated", priority: 3}
+  {description: "lsat_qa:model=ablation_full_functionality_text,task=assignment,method=multiple_choice_joint", priority: 3}
+  {description: "lsat_qa:model=ablation_full_functionality_text,task=assignment,method=multiple_choice_separate_original", priority: 3}
+  {description: "lsat_qa:model=ablation_full_functionality_text,task=assignment,method=multiple_choice_separate_calibrated", priority: 3}
+  {description: "lsat_qa:model=ablation_full_functionality_text,task=miscellaneous,method=multiple_choice_joint", priority: 3}
+  {description: "lsat_qa:model=ablation_full_functionality_text,task=miscellaneous,method=multiple_choice_separate_original", priority: 3}
+  {description: "lsat_qa:model=ablation_full_functionality_text,task=miscellaneous,method=multiple_choice_separate_calibrated", priority: 3}
 
-"bbq:model=ablation_full_functionality_text,subject=all,method=multiple_choice_joint": {priority: 2}
-"bbq:model=ablation_full_functionality_text,subject=all,method=multiple_choice_separate_original": {priority: 2}
-"bbq:model=ablation_full_functionality_text,subject=all,method=multiple_choice_separate_calibrated": {priority: 2}
-"bbq:model=ablation_full_functionality_text,subject=age,method=multiple_choice_joint": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=age,method=multiple_choice_separate_original": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=age,method=multiple_choice_separate_calibrated": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=disability_status,method=multiple_choice_joint": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=disability_status,method=multiple_choice_separate_original": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=disability_status,method=multiple_choice_separate_calibrated": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=gender_identity,method=multiple_choice_joint": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=gender_identity,method=multiple_choice_separate_original": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=gender_identity,method=multiple_choice_separate_calibrated": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=nationality,method=multiple_choice_joint": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=nationality,method=multiple_choice_separate_original": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=nationality,method=multiple_choice_separate_calibrated": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=physical_appearance,method=multiple_choice_joint": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=physical_appearance,method=multiple_choice_separate_original": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=physical_appearance,method=multiple_choice_separate_calibrated": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=race_ethnicity,method=multiple_choice_joint": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=race_ethnicity,method=multiple_choice_separate_original": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=race_ethnicity,method=multiple_choice_separate_calibrated": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=race_x_SES,method=multiple_choice_joint": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=race_x_SES,method=multiple_choice_separate_original": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=race_x_SES,method=multiple_choice_separate_calibrated": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=race_x_gender,method=multiple_choice_joint": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=race_x_gender,method=multiple_choice_separate_original": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=race_x_gender,method=multiple_choice_separate_calibrated": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=religion,method=multiple_choice_joint": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=religion,method=multiple_choice_separate_original": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=religion,method=multiple_choice_separate_calibrated": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=SES,method=multiple_choice_joint": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=SES,method=multiple_choice_separate_original": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=SES,method=multiple_choice_separate_calibrated": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=sexual_orientation,method=multiple_choice_joint": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=sexual_orientation,method=multiple_choice_separate_original": {priority: 3}
-"bbq:model=ablation_full_functionality_text,subject=sexual_orientation,method=multiple_choice_separate_calibrated": {priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=all,method=multiple_choice_joint", priority: 2}
+  {description: "bbq:model=ablation_full_functionality_text,subject=all,method=multiple_choice_separate_original", priority: 2}
+  {description: "bbq:model=ablation_full_functionality_text,subject=all,method=multiple_choice_separate_calibrated", priority: 2}
+  {description: "bbq:model=ablation_full_functionality_text,subject=age,method=multiple_choice_joint", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=age,method=multiple_choice_separate_original", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=age,method=multiple_choice_separate_calibrated", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=disability_status,method=multiple_choice_joint", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=disability_status,method=multiple_choice_separate_original", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=disability_status,method=multiple_choice_separate_calibrated", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=gender_identity,method=multiple_choice_joint", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=gender_identity,method=multiple_choice_separate_original", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=gender_identity,method=multiple_choice_separate_calibrated", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=nationality,method=multiple_choice_joint", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=nationality,method=multiple_choice_separate_original", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=nationality,method=multiple_choice_separate_calibrated", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=physical_appearance,method=multiple_choice_joint", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=physical_appearance,method=multiple_choice_separate_original", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=physical_appearance,method=multiple_choice_separate_calibrated", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=race_ethnicity,method=multiple_choice_joint", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=race_ethnicity,method=multiple_choice_separate_original", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=race_ethnicity,method=multiple_choice_separate_calibrated", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=race_x_SES,method=multiple_choice_joint", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=race_x_SES,method=multiple_choice_separate_original", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=race_x_SES,method=multiple_choice_separate_calibrated", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=race_x_gender,method=multiple_choice_joint", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=race_x_gender,method=multiple_choice_separate_original", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=race_x_gender,method=multiple_choice_separate_calibrated", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=religion,method=multiple_choice_joint", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=religion,method=multiple_choice_separate_original", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=religion,method=multiple_choice_separate_calibrated", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=SES,method=multiple_choice_joint", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=SES,method=multiple_choice_separate_original", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=SES,method=multiple_choice_separate_calibrated", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=sexual_orientation,method=multiple_choice_joint", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=sexual_orientation,method=multiple_choice_separate_original", priority: 3}
+  {description: "bbq:model=ablation_full_functionality_text,subject=sexual_orientation,method=multiple_choice_separate_calibrated", priority: 3}
 
-
-##### Prompting #####
-# TODO: Add prompting-based ablations
+  ##### Prompting #####
+  # TODO: Add prompting-based ablations
+]

--- a/src/benchmark/presentation/run_specs_big_bench_lite.conf
+++ b/src/benchmark/presentation/run_specs_big_bench_lite.conf
@@ -6,117 +6,120 @@
 # There are 24 tasks total. Some tasks have multiple subtasks.
 ########################################################################################################################
 
-# 1. auto_debugging: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/auto_debugging
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=auto_debugging,subtask=": {priority: 1}
+entries: [
 
-# 2. bbq_lite_json: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/bbq_lite_json
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=age_ambig": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=age_disambig": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=disability_status_ambig": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=disability_status_disambig": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=gender_identity_ambig": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=gender_identity_disambig": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=nationality_ambig": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=nationality_disambig": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=physical_appearance_ambig": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=physical_appearance_disambig": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=race_ethnicity_ambig": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=race_ethnicity_disambig": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=religion_ambig": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=religion_disambig": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=ses_ambig": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=ses_disambig": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=sexual_orientation_ambig": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=sexual_orientation_disambig": {priority: 1}
+  # 1. auto_debugging: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/auto_debugging
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=auto_debugging,subtask=", priority: 1}
 
-# 3. code_line_description: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/code_line_description
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=code_line_description,subtask=": {priority: 1}
+  # 2. bbq_lite_json: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/bbq_lite_json
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=age_ambig", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=age_disambig", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=disability_status_ambig", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=disability_status_disambig", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=gender_identity_ambig", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=gender_identity_disambig", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=nationality_ambig", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=nationality_disambig", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=physical_appearance_ambig", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=physical_appearance_disambig", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=race_ethnicity_ambig", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=race_ethnicity_disambig", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=religion_ambig", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=religion_disambig", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=ses_ambig", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=ses_disambig", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=sexual_orientation_ambig", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=bbq_lite_json,subtask=sexual_orientation_disambig", priority: 1}
 
-# 4. conceptual_combinations: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/conceptual_combinations
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conceptual_combinations,subtask=contradictions": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conceptual_combinations,subtask=emergent_properties": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conceptual_combinations,subtask=fanciful_fictional_combinations": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conceptual_combinations,subtask=homonyms": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conceptual_combinations,subtask=invented_words": {priority: 1}
+  # 3. code_line_description: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/code_line_description
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=code_line_description,subtask=", priority: 1}
 
-# 5. conlang_translation: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/conlang_translation
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=adna_from": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=adna_to": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=atikampe_from": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=atikampe_to": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=gornam_from": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=gornam_to": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=holuan_from": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=holuan_to": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=mkafala_from": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=mkafala_to": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=postpositive_english_from": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=postpositive_english_to": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=unapuri_from": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=unapuri_to": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=vaomi_from": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=vaomi_to": {priority: 1}
+  # 4. conceptual_combinations: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/conceptual_combinations
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conceptual_combinations,subtask=contradictions", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conceptual_combinations,subtask=emergent_properties", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conceptual_combinations,subtask=fanciful_fictional_combinations", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conceptual_combinations,subtask=homonyms", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conceptual_combinations,subtask=invented_words", priority: 1}
 
-# 6. emoji_movie: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/emoji_movie
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=emoji_movie,subtask=": {priority: 1}
+  # 5. conlang_translation: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/conlang_translation
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=adna_from", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=adna_to", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=atikampe_from", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=atikampe_to", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=gornam_from", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=gornam_to", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=holuan_from", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=holuan_to", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=mkafala_from", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=mkafala_to", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=postpositive_english_from", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=postpositive_english_to", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=unapuri_from", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=unapuri_to", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=vaomi_from", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=conlang_translation,subtask=vaomi_to", priority: 1}
 
-# 7. formal_fallacies_syllogisms_negation: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/formal_fallacies_syllogisms_negation
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=formal_fallacies_syllogisms_negation,subtask=": {priority: 1}
+  # 6. emoji_movie: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/emoji_movie
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=emoji_movie,subtask=", priority: 1}
 
-# 8. hindu_knowledge: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/hindu_knowledge
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=hindu_knowledge,subtask=": {priority: 1}
+  # 7. formal_fallacies_syllogisms_negation: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/formal_fallacies_syllogisms_negation
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=formal_fallacies_syllogisms_negation,subtask=", priority: 1}
 
-# 9. known_unknowns: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/known_unknowns
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=known_unknowns,subtask=": {priority: 1}
+  # 8. hindu_knowledge: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/hindu_knowledge
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=hindu_knowledge,subtask=", priority: 1}
 
-# 10. language_identification: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/language_identification
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=language_identification,subtask=": {priority: 1}
+  # 9. known_unknowns: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/known_unknowns
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=known_unknowns,subtask=", priority: 1}
 
-# 11. linguistics_puzzles: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/linguistics_puzzles
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=linguistics_puzzles,subtask=": {priority: 1}
+  # 10. language_identification: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/language_identification
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=language_identification,subtask=", priority: 1}
 
-# 12. logic_grid_puzzle: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/logic_grid_puzzle
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=logic_grid_puzzle,subtask=": {priority: 1}
+  # 11. linguistics_puzzles: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/linguistics_puzzles
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=linguistics_puzzles,subtask=", priority: 1}
 
-# 13. logical_deduction: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/logical_deduction
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=logical_deduction,subtask=three_objects": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=logical_deduction,subtask=five_objects": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=logical_deduction,subtask=seven_objects": {priority: 1}
+  # 12. logic_grid_puzzle: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/logic_grid_puzzle
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=logic_grid_puzzle,subtask=", priority: 1}
 
-# 14. misconceptions_russian: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/misconceptions_russian
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=misconceptions_russian,subtask=": {priority: 1}
+  # 13. logical_deduction: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/logical_deduction
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=logical_deduction,subtask=three_objects", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=logical_deduction,subtask=five_objects", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=logical_deduction,subtask=seven_objects", priority: 1}
 
-# 15. novel_concepts: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/novel_concepts
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=novel_concepts,subtask=": {priority: 1}
+  # 14. misconceptions_russian: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/misconceptions_russian
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=misconceptions_russian,subtask=", priority: 1}
 
-# 16. operators: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/operators
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=operators,subtask=": {priority: 1}
+  # 15. novel_concepts: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/novel_concepts
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=novel_concepts,subtask=", priority: 1}
 
-# 17. parsinlu_reading_comprehension: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/parsinlu_reading_comprehension
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=parsinlu_reading_comprehension,subtask=": {priority: 1}
+  # 16. operators: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/operators
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=operators,subtask=", priority: 1}
 
-# 18. play_dialog_same_or_different: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/play_dialog_same_or_different
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=play_dialog_same_or_different,subtask=": {priority: 1}
+  # 17. parsinlu_reading_comprehension: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/parsinlu_reading_comprehension
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=parsinlu_reading_comprehension,subtask=", priority: 1}
 
-# 19. repeat_copy_logic: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/repeat_copy_logic
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=repeat_copy_logic,subtask=": {priority: 1}
+  # 18. play_dialog_same_or_different: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/play_dialog_same_or_different
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=play_dialog_same_or_different,subtask=", priority: 1}
 
-# 20. strange_stories: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/strange_stories
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=strange_stories,subtask=boolean": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=strange_stories,subtask=multiple_choice": {priority: 1}
+  # 19. repeat_copy_logic: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/repeat_copy_logic
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=repeat_copy_logic,subtask=", priority: 1}
 
-# 21. strategyqa: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/strategyqa
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=strategyqa,subtask=": {priority: 1}
+  # 20. strange_stories: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/strange_stories
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=strange_stories,subtask=boolean", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=strange_stories,subtask=multiple_choice", priority: 1}
 
-# 22. symbol_interpretation: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/symbol_interpretation
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=symbol_interpretation,subtask=adversarial": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=symbol_interpretation,subtask=emoji_agnostic": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=symbol_interpretation,subtask=name_agnostic": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=symbol_interpretation,subtask=plain": {priority: 1}
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=symbol_interpretation,subtask=tricky": {priority: 1}
+  # 21. strategyqa: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/strategyqa
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=strategyqa,subtask=", priority: 1}
 
-# 23. vitaminc_fact_verification: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/vitaminc_fact_verification
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=vitaminc_fact_verification,subtask=": {priority: 1}
+  # 22. symbol_interpretation: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/symbol_interpretation
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=symbol_interpretation,subtask=adversarial", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=symbol_interpretation,subtask=emoji_agnostic", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=symbol_interpretation,subtask=name_agnostic", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=symbol_interpretation,subtask=plain", priority: 1}
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=symbol_interpretation,subtask=tricky", priority: 1}
 
-# 24. winowhy: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/winowhy
-"big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=winowhy,subtask=": {priority: 1}
+  # 23. vitaminc_fact_verification: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/vitaminc_fact_verification
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=vitaminc_fact_verification,subtask=", priority: 1}
+
+  # 24. winowhy: https://github.com/google/big-bench/tree/main/bigbench/benchmark_tasks/winowhy
+  {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=winowhy,subtask=", priority: 1}
+]

--- a/src/benchmark/presentation/run_specs_gpu.conf
+++ b/src/benchmark/presentation/run_specs_gpu.conf
@@ -1,18 +1,9 @@
-# List the RunSpecs that we want to display on the website in this file.
-# A RunSpec specifies how to do a single run, which gets a scenario, adapts it, and computes a list of metrics.
-#
-# RunSpecs are unique. Mark the RunSpec with either READY or WIP (work in progress):
-#    For READY RunSpecs, we evaluate and generate metrics.
-#    For WIP RunSpecs, we just estimate token usage.
-#
-# and assign them a priority where a RunSpec with a lower priority value gets run
-# before a one with a higher priority value.
-#
-# Place your new RunSpec description under the appropriate section.
+# RunSpecs whose creation requires GPU (e.g., computing metrics requires a model).
 
+entries: [
+  ##### Summarization #####
+  # Scenarios: XSUM, CNN/DM
 
-##### Summarization #####
-# Scenarios: XSUM, CNN/DM
-
-"summarization_cnndm:model=text,temperature=0.3,device=cuda": {priority: 1}
-"summarization_xsum_sampled:model=text,temperature=0.3,device=cuda": {priority: 1}
+  {description: "summarization_cnndm:model=text,temperature=0.3,device=cuda", priority: 1}
+  {description: "summarization_xsum_sampled:model=text,temperature=0.3,device=cuda", priority: 1}
+]

--- a/src/benchmark/presentation/run_specs_interaction.conf
+++ b/src/benchmark/presentation/run_specs_interaction.conf
@@ -1,65 +1,67 @@
 # RunSpecs for the Interaction benchmarking paper
 #
-# Run:
+# Run: # TODO: update this
 # benchmark-present --conf-path src/benchmark/presentation/run_specs_interaction.conf --suite interaction --max-eval-instances 1000 --local &> interaction.log
 
-##### Interactive Q&A #####
+entries: [
+  ##### Interactive Q&A #####
 
-# All the MMLU subjects on openai/text-davinci-001
-"mmlu:model=openai/text-davinci-001,subject=abstract_algebra": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=anatomy": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=college_chemistry": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=computer_security": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=econometrics": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=global_facts": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=jurisprudence": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=philosophy": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=professional_medicine": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=us_foreign_policy": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=astronomy": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=business_ethics": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=clinical_knowledge": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=college_biology": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=college_computer_science": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=college_mathematics": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=college_medicine": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=college_physics": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=conceptual_physics": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=electrical_engineering": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=elementary_mathematics": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=formal_logic": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=high_school_biology": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=high_school_chemistry": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=high_school_computer_science": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=high_school_european_history": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=high_school_geography": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=high_school_government_and_politics": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=high_school_macroeconomics": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=high_school_mathematics": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=high_school_microeconomics": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=high_school_physics": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=high_school_psychology": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=high_school_statistics": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=high_school_us_history": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=high_school_world_history": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=human_aging": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=human_sexuality": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=international_law": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=logical_fallacies": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=machine_learning": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=management": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=marketing": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=medical_genetics": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=miscellaneous": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=moral_disputes": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=moral_scenarios": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=nutrition": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=prehistory": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=professional_accounting": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=professional_law": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=professional_psychology": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=public_relations": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=security_studies": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=sociology": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=virology": {priority: 1}
-"mmlu:model=openai/text-davinci-001,subject=world_religions": {priority: 1}
+  # All the MMLU subjects on openai/text-davinci-001
+  {description: "mmlu:model=openai/text-davinci-001,subject=abstract_algebra", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=anatomy", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=college_chemistry", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=computer_security", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=econometrics", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=global_facts", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=jurisprudence", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=philosophy", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=professional_medicine", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=us_foreign_policy", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=astronomy", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=business_ethics", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=clinical_knowledge", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=college_biology", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=college_computer_science", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=college_mathematics", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=college_medicine", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=college_physics", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=conceptual_physics", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=electrical_engineering", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=elementary_mathematics", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=formal_logic", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=high_school_biology", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=high_school_chemistry", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=high_school_computer_science", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=high_school_european_history", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=high_school_geography", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=high_school_government_and_politics", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=high_school_macroeconomics", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=high_school_mathematics", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=high_school_microeconomics", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=high_school_physics", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=high_school_psychology", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=high_school_statistics", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=high_school_us_history", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=high_school_world_history", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=human_aging", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=human_sexuality", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=international_law", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=logical_fallacies", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=machine_learning", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=management", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=marketing", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=medical_genetics", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=miscellaneous", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=moral_disputes", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=moral_scenarios", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=nutrition", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=prehistory", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=professional_accounting", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=professional_law", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=professional_psychology", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=public_relations", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=security_studies", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=sociology", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=virology", priority: 1}
+  {description: "mmlu:model=openai/text-davinci-001,subject=world_religions", priority: 1}
+]

--- a/src/benchmark/presentation/run_specs_ir.conf
+++ b/src/benchmark/presentation/run_specs_ir.conf
@@ -1,2 +1,5 @@
-"msmarco:task=passage,model=full_functionality_text,track=regular,use_qrels_passages=True,use_topk_passages=True,valid_topk=30,num_valid_queries=200": {priority: 2}
-"msmarco:task=passage,model=full_functionality_text,track=trec,use_qrels_passages=True,use_topk_passages=True,valid_topk=30": {priority: 1}
+# TODO: merge this in with run_specs.conf
+entries: [
+  {description: "msmarco:task=passage,model=full_functionality_text,track=regular,use_qrels_passages=True,use_topk_passages=True,valid_topk=30,num_valid_queries=200", priority: 2}
+  {description: "msmarco:task=passage,model=full_functionality_text,track=trec,use_qrels_passages=True,use_topk_passages=True,valid_topk=30", priority: 1}
+]

--- a/src/benchmark/presentation/run_specs_robustness.conf
+++ b/src/benchmark/presentation/run_specs_robustness.conf
@@ -3,42 +3,45 @@
 # We choose a set of canonical scenarios covering different tasks: mmlu (specialized QA), imdb (sentiment analysis),
 # naturalQA (general knowledge QA), RAFT (classification), civil comments (toxicity).
 
-# TODO: should we restrict these to fewer instances?
+entries: [
 
-# imdb
-"imdb:model=text,data_augmentation=robustness_all": {priority: 1}
+  # TODO: should we restrict these to fewer instances?
 
-# natural questions
-"natural_qa:model=text,data_augmentation=robustness_all,mode=closedbook": {priority: 1}
+  # imdb
+  {description: "imdb:model=text,data_augmentation=robustness_all", priority: 1}
 
-# raft
-"raft:subset=ade_corpus_v2,model=text,data_augmentation=robustness_all": {priority: 1}
-"raft:subset=banking_77,model=text,data_augmentation=robustness_all": {priority: 1}
-"raft:subset=neurips_impact_statement_risks,model=text,data_augmentation=robustness_all": {priority: 1}
-"raft:subset=one_stop_english,model=text,data_augmentation=robustness_all": {priority: 1}
-"raft:subset=overruling,model=text,data_augmentation=robustness_all": {priority: 1}
-"raft:subset=semiconductor_org_types,model=text,data_augmentation=robustness_all": {priority: 1}
-"raft:subset=tweet_eval_hate,model=text,data_augmentation=robustness_all": {priority: 1}
-"raft:subset=twitter_complaints,model=text,data_augmentation=robustness_all": {priority: 1}
-"raft:subset=systematic_review_inclusion,model=text,data_augmentation=robustness_all": {priority: 1}
-"raft:subset=tai_safety_research,model=text,data_augmentation=robustness_all": {priority: 1}
-"raft:subset=terms_of_service,model=text,data_augmentation=robustness_all": {priority: 1}
+  # natural questions
+  {description: "natural_qa:model=text,data_augmentation=robustness_all,mode=closedbook", priority: 1}
 
-# mmlu (only subjects with priority <= 2 in run_specs.conf)
-"mmlu:model=text,subject=abstract_algebra,data_augmentation=robustness_all": {priority: 1}
-"mmlu:model=text,subject=college_chemistry,data_augmentation=robustness_all": {priority: 1}
-"mmlu:model=text,subject=computer_security,data_augmentation=robustness_all": {priority: 1}
-"mmlu:model=text,subject=econometrics,data_augmentation=robustness_all": {priority: 1}
-"mmlu:model=text,subject=us_foreign_policy,data_augmentation=robustness_all": {priority: 1}
+  # raft
+  {description: "raft:subset=ade_corpus_v2,model=text,data_augmentation=robustness_all", priority: 1}
+  {description: "raft:subset=banking_77,model=text,data_augmentation=robustness_all", priority: 1}
+  {description: "raft:subset=neurips_impact_statement_risks,model=text,data_augmentation=robustness_all", priority: 1}
+  {description: "raft:subset=one_stop_english,model=text,data_augmentation=robustness_all", priority: 1}
+  {description: "raft:subset=overruling,model=text,data_augmentation=robustness_all", priority: 1}
+  {description: "raft:subset=semiconductor_org_types,model=text,data_augmentation=robustness_all", priority: 1}
+  {description: "raft:subset=tweet_eval_hate,model=text,data_augmentation=robustness_all", priority: 1}
+  {description: "raft:subset=twitter_complaints,model=text,data_augmentation=robustness_all", priority: 1}
+  {description: "raft:subset=systematic_review_inclusion,model=text,data_augmentation=robustness_all", priority: 1}
+  {description: "raft:subset=tai_safety_research,model=text,data_augmentation=robustness_all", priority: 1}
+  {description: "raft:subset=terms_of_service,model=text,data_augmentation=robustness_all", priority: 1}
 
-# civil comments (only subjects with priority <= 2 in run_specs.conf)
-"civil_comments:model=text,data_augmentation=robustness_all,subject=all": {priority: 1}
-"civil_comments:model=text,data_augmentation=robustness_all,subject=bisexual": {priority: 1}
-"civil_comments:model=text,data_augmentation=robustness_all,subject=christian": {priority: 1}
-"civil_comments:model=text,data_augmentation=robustness_all,subject=heterosexual": {priority: 1}
-"civil_comments:model=text,data_augmentation=robustness_all,subject=homosexual_gay_or_lesbian": {priority: 1}
-"civil_comments:model=text,data_augmentation=robustness_all,subject=intellectual_or_learning_disability": {priority: 1}
-"civil_comments:model=text,data_augmentation=robustness_all,subject=muslim": {priority: 1}
-"civil_comments:model=text,data_augmentation=robustness_all,subject=physical_disability": {priority: 1}
-"civil_comments:model=text,data_augmentation=robustness_all,subject=psychiatric_or_mental_illness": {priority: 1}
-"civil_comments:model=text,data_augmentation=robustness_all,subject=transgender": {priority: 1}
+  # mmlu (only subjects with priority <= 2 in run_specs.conf)
+  {description: "mmlu:model=text,subject=abstract_algebra,data_augmentation=robustness_all", priority: 1}
+  {description: "mmlu:model=text,subject=college_chemistry,data_augmentation=robustness_all", priority: 1}
+  {description: "mmlu:model=text,subject=computer_security,data_augmentation=robustness_all", priority: 1}
+  {description: "mmlu:model=text,subject=econometrics,data_augmentation=robustness_all", priority: 1}
+  {description: "mmlu:model=text,subject=us_foreign_policy,data_augmentation=robustness_all", priority: 1}
+
+  # civil comments (only subjects with priority <= 2 in run_specs.conf)
+  {description: "civil_comments:model=text,data_augmentation=robustness_all,demographic=all", priority: 1}
+  {description: "civil_comments:model=text,data_augmentation=robustness_all,demographic=bisexual", priority: 1}
+  {description: "civil_comments:model=text,data_augmentation=robustness_all,demographic=christian", priority: 1}
+  {description: "civil_comments:model=text,data_augmentation=robustness_all,demographic=heterosexual", priority: 1}
+  {description: "civil_comments:model=text,data_augmentation=robustness_all,demographic=homosexual_gay_or_lesbian", priority: 1}
+  {description: "civil_comments:model=text,data_augmentation=robustness_all,demographic=intellectual_or_learning_disability", priority: 1}
+  {description: "civil_comments:model=text,data_augmentation=robustness_all,demographic=muslim", priority: 1}
+  {description: "civil_comments:model=text,data_augmentation=robustness_all,demographic=physical_disability", priority: 1}
+  {description: "civil_comments:model=text,data_augmentation=robustness_all,demographic=psychiatric_or_mental_illness", priority: 1}
+  {description: "civil_comments:model=text,data_augmentation=robustness_all,demographic=transgender", priority: 1}
+]

--- a/src/benchmark/presentation/run_specs_small.conf
+++ b/src/benchmark/presentation/run_specs_small.conf
@@ -1,13 +1,15 @@
 # A minimal example where we compare a few models on a few benchmarks.
 
-"mmlu:subject=philosophy,data_augmentation=canonical,model=openai/davinci": {priority: 1}
-"mmlu:subject=philosophy,data_augmentation=canonical,model=openai/text-davinci-002": {priority: 1}
+entries: [
+  {description: "mmlu:subject=philosophy,data_augmentation=canonical,model=openai/davinci", priority: 1}
+  {description: "mmlu:subject=philosophy,data_augmentation=canonical,model=openai/text-davinci-002", priority: 1}
 
-"mmlu:subject=anatomy,data_augmentation=canonical,model=openai/davinci": {priority: 1}
-"mmlu:subject=anatomy,data_augmentation=canonical,model=openai/text-davinci-002": {priority: 1}
+  {description: "mmlu:subject=anatomy,data_augmentation=canonical,model=openai/davinci", priority: 1}
+  {description: "mmlu:subject=anatomy,data_augmentation=canonical,model=openai/text-davinci-002", priority: 1}
 
-"boolq:data_augmentation=canonical,model=openai/davinci": {priority: 1}
-"boolq:data_augmentation=canonical,model=openai/text-davinci-002": {priority: 1}
+  {description: "boolq:data_augmentation=canonical,model=openai/davinci", priority: 1}
+  {description: "boolq:data_augmentation=canonical,model=openai/text-davinci-002", priority: 1}
 
-"bold:subject=all,model=openai/davinci": {priority: 1}
-"bold:subject=all,model=openai/text-davinci-002": {priority: 1}
+  {description: "bold:subject=all,model=openai/davinci", priority: 1}
+  {description: "bold:subject=all,model=openai/text-davinci-002", priority: 1}
+]

--- a/src/benchmark/presentation/run_specs_tiny.conf
+++ b/src/benchmark/presentation/run_specs_tiny.conf
@@ -1,2 +1,4 @@
 # Minimal example where we are running something non-trivial.
-"mmlu:subject=philosophy,data_augmentation=canonical,model=openai/text-davinci-002": {priority: 1}
+entries: [
+  {description: "mmlu:subject=philosophy,data_augmentation=canonical,model=openai/text-davinci-002", priority: 1}
+]

--- a/src/benchmark/presentation/test_run_entry.py
+++ b/src/benchmark/presentation/test_run_entry.py
@@ -1,0 +1,14 @@
+import os
+from common.object_spec import parse_object_spec
+from benchmark.presentation.run_entry import read_run_entries
+from benchmark.run_specs import construct_run_specs
+
+
+def test_read_all_specs():
+    """Read all the run entries and make sure they parse and we can instantiate them."""
+    base_path = os.path.dirname(__file__)
+    for fname in os.listdir(base_path):
+        if fname.endswith(".conf"):
+            run_entries = read_run_entries(os.path.join(base_path, fname))
+            for entry in run_entries.entries:
+                construct_run_specs(parse_object_spec(entry.description))

--- a/src/benchmark/run.py
+++ b/src/benchmark/run.py
@@ -29,6 +29,7 @@ def run_benchmarking(
     skip_instances: bool,
     max_eval_instances: Optional[int] = None,
     num_train_trials: Optional[int] = None,
+    groups: Optional[List[str]] = None,
     models_to_run: Optional[List[str]] = None,
     scenario_groups_to_run: Optional[List[str]] = None,
 ) -> List[RunSpec]:
@@ -40,12 +41,19 @@ def run_benchmarking(
 
     def override(run_spec: RunSpec) -> RunSpec:
         """Override parts of `run_spec`."""
+        # Modify AdapterSpec
         adapter_spec: AdapterSpec = run_spec.adapter_spec
         if max_eval_instances is not None:
             adapter_spec = replace(adapter_spec, max_eval_instances=max_eval_instances)
         if num_train_trials is not None:
             adapter_spec = replace(adapter_spec, num_train_trials=num_train_trials)
-        return replace(run_spec, adapter_spec=adapter_spec)
+        run_spec = replace(run_spec, adapter_spec=adapter_spec)
+
+        # Append groups
+        if groups is not None:
+            run_spec = replace(run_spec, groups=run_spec.groups + groups)
+
+        return run_spec
 
     run_specs = [
         override(run_spec)


### PR DESCRIPTION
- Make `RunEntry` field explicitly a dataclass to make types more explicit
- Description was key in `run_specs.conf` before, now explicitly a field called `description`
- Add `groups` field to `RunEntry`
- Added a test that tries to instantiate all the `run_spec*.conf` files
- Fixed a bug in `run_specs_robustness.conf` as a result of the test