### PR TITLE
add perturbation arguments

### DIFF
--- a/src/benchmark/augmentations/data_augmenter.py
+++ b/src/benchmark/augmentations/data_augmenter.py
@@ -27,7 +27,11 @@ class Processor:
         for perturbation in self.perturbations:
             for i in range(self.seeds_per_instance):
                 perturbed_instance: Instance = perturbation.apply(instance, seed=None if i == 0 else i)
-                if self.skip_unchanged and perturbed_instance.input == instance.input:
+                if (
+                    self.skip_unchanged
+                    and perturbed_instance.input == instance.input
+                    and perturbed_instance.references == instance.references
+                ):
                     continue
                 result.append(perturbed_instance)
         return result


### PR DESCRIPTION
- Added (default) arguments for perturbations so that they can be customized for specific perturbations.
- `skip_unchanged` now checks for unchanged inputs as well as references. This is relevant in the multiple-choice-joint setting where the references become part of the inputs.