### PR TITLE
Visualize generative harms for generic scenarios

### DIFF
--- a/src/benchmark/static/schema.yaml
+++ b/src/benchmark/static/schema.yaml
@@ -713,6 +713,8 @@ run_groups:
       - calibration
       - robustness
       - fairness
+      - bias
+      - toxicity
       - efficiency
     environment:
       main_name: exact_match
@@ -726,6 +728,8 @@ run_groups:
       - calibration
       - robustness
       - fairness
+      - bias
+      - toxicity
       - efficiency
     environment:
       main_name: f1_score
@@ -739,6 +743,8 @@ run_groups:
       - calibration
       - robustness
       - fairness
+      - bias
+      - toxicity
       - efficiency
     environment:
       main_name: f1_score
@@ -752,6 +758,8 @@ run_groups:
       - calibration
       - robustness
       - fairness
+      - bias
+      - toxicity
       - efficiency
     environment:
       main_name: f1_score
@@ -765,6 +773,8 @@ run_groups:
       - calibration
       - robustness
       - fairness
+      - bias
+      - toxicity
       - efficiency
     environment:
       main_name: f1_score
@@ -830,6 +840,8 @@ run_groups:
       - accuracy
       - robustness
       - fairness
+      - bias
+      - toxicity
       - efficiency
     environment:
       main_name: RR@20
@@ -842,6 +854,8 @@ run_groups:
       - accuracy
       - robustness
       - fairness
+      - bias
+      - toxicity
       - efficiency
     environment:
       main_name: NDCG@20
@@ -883,6 +897,8 @@ run_groups:
       - calibration
       - robustness
       - fairness
+      - bias
+      - toxicity
       - efficiency
     environment:
       main_name: quasi_exact_match
@@ -897,6 +913,8 @@ run_groups:
       - calibration
       - robustness
       - fairness
+      - bias
+      - toxicity
       - efficiency
     environment:
       main_name: quasi_exact_match
@@ -911,6 +929,8 @@ run_groups:
       - calibration
       - robustness
       - fairness
+      - bias
+      - toxicity
       - efficiency
     environment:
       main_name: quasi_exact_match


### PR DESCRIPTION
Currently, we measure generative harms (i.e. bias, toxicity) for anything where we can (I did this in #909). 

However, we only visualize generative harms for summarization (cnn/dm, xsum) and for generative stuff in the harms component (copyright, disinfo, bold, real toxicity prompts).
However we can visualize generative harms for any of the 9 scenarios that use the `adapt_completion` adapter, the 18 that use `adapt_generation` and the 2 that use `adapt_summarization`. 

Thinking about it, I think we definitely should visualize for all the generic scenarios where we generate (i.e. everything except the four multiple choice QA scenarios of hellaswag, mmlu, truthfulqa, openbookqa). This significantly improves density (this means we achieve 88%, i.e 105 of the 119 possibly pairs measured for our 17 generic scenarios and 7 metric categories of acc, cal, rob, fair, bias, tox, eff). And 8 of the 14 are fundamental (we cannot measure generative harms for the 4 scenarios that have no generaiton) and 6 are intentional choices (no perturbations or calibration for summ). 

And I think we should measure (i.e. have in the run view) but not visualize for the non-harms components (since it is not the point for stuff like dyck or synthetic efficiency or what not, and the main table views should visualize what is important). 


Finally, to sanity check I did this right, there are 17 generic scenarios, and we don't include newsqa in schema atm, so there's 16 effectively. The 2 summarization scenarios already had this, and the 4 multiple choice qa are ineligible. So we should be changing 20 lines, which we are, to add bias + toxicity to the 10 scenarios of {NatQA (open), NatQA (closed), NarrQA, BoolQ, QuAC, MS MARCO (reg), MS MARCO (TREC), IMDB, CivilComments, RAFT)}, which is exactly what we do. 