### PR TITLE
Fix perspective API cache path

### DIFF
--- a/src/proxy/services/server_service.py
+++ b/src/proxy/services/server_service.py
@@ -56,7 +56,7 @@ class ServerService(Service):
         self.accounts = Accounts(accounts_path, root_mode=root_mode)
         self.perspective_api_client = PerspectiveAPIClient(
             api_key=credentials["perspectiveApiKey"] if "perspectiveApiKey" in credentials else "",
-            cache_config=CacheConfig(cache_path),
+            cache_config=CacheConfig(os.path.join(base_path, "perspectiveapi.sqlite")),
         )
 
     def get_general_info(self) -> GeneralInfo:


### PR DESCRIPTION
The cache was attempting to open a directory instead of a file.