### PR TITLE
Fix MicrosoftClient lock file

### DIFF
--- a/src/proxy/clients/auto_client.py
+++ b/src/proxy/clients/auto_client.py
@@ -71,7 +71,7 @@ class AutoClient(Client):
                 client = AnthropicClient(api_key=self.credentials["anthropicApiKey"], cache_config=cache_config)
             elif organization == "microsoft":
                 org_id = self.credentials.get("microsoftOrgId", None)
-                lock_file_path = os.path.join(self.cache_path, f"{organization}.lock")
+                lock_file_path: str = os.path.join(self.cache_path, f"{organization}.lock")
                 client = MicrosoftClient(
                     api_key=self.credentials["microsoftApiKey"],
                     lock_file_path=lock_file_path,

--- a/src/proxy/clients/microsoft_client.py
+++ b/src/proxy/clients/microsoft_client.py
@@ -25,8 +25,6 @@ class MicrosoftClient(Client):
     all tokens have been generated."
     """
 
-    ORGANIZATION: str = "microsoft"
-
     @staticmethod
     def convert_to_raw_request(request: Request) -> Dict:
         return {


### PR DESCRIPTION
Fixes a bug introduced by #988 where the lock file path depends on `cache_config.cache_dir`, which does not exist.