### PR TITLE
add strong status for pile; removing instruct models

### DIFF
--- a/src/benchmark/static/contamination.yaml
+++ b/src/benchmark/static/contamination.yaml
@@ -75,6 +75,10 @@ points:
     - openai/curie
     - openai/babbage
     - openai/ada
+    - openai/text-curie-001
+    - openai/text-babbage-001
+    - openai/text-ada-001
+    - openai/text-davinci-002
     - openai/code-davinci-002
     - openai/code-davinci-001
     - openai/code-cushman-001


### PR DESCRIPTION
Simple update to contamination status for models:
- Models trained on Pile
- T0++
- Remove Instruct models, since no longer certain they are derivatives and hence inherit the analyses provided for GPT-3. 