### PR TITLE
Remove basic metric evaluate references condition

### DIFF
--- a/src/benchmark/metrics/basic_metrics.py
+++ b/src/benchmark/metrics/basic_metrics.py
@@ -684,13 +684,6 @@ class BasicMetric(Metric):
             reference_tokens: List[str] = window_service.tokenize(f" {reference}")
             num_tokens: int = len(reference_tokens)
             answer_tokens: List[Token] = sequence.tokens[-num_tokens:]
-            if (len(answer_tokens) != len(reference_tokens)) or (
-                not all(
-                    answer_token.text == reference_token
-                    for answer_token, reference_token in zip(answer_tokens, reference_tokens)
-                )
-            ):
-                hlog(f"WARNING: Expected {reference_tokens} but got {[token.text for token in answer_tokens]}")
             logprob: float = sum(token.logprob for token in answer_tokens)
 
             return ReferenceStat(logprob, num_tokens)


### PR DESCRIPTION
# Purpose

Addressing #947 by removing the condition that produces the warning as it isn't relevant for all the scenarios. @yuhui-zh15 @tonywu95 let me know if I'm misinterpreting the purpose of the condition and/or feel free to change.