### PR TITLE
Fix duplicated global metrics with grouped run_specs

### DIFF
--- a/src/benchmark/static/benchmarking.js
+++ b/src/benchmark/static/benchmarking.js
@@ -575,10 +575,8 @@ $(function () {
     // Render metrics/stats
     getJSONList(statsPaths, (statsList) => {
       console.log('metrics', statsList);
-      const keys = sortAndDeduplicate(
-        statsList.map((stats) => stats.map((stat) => stat.name)).flat(),
-        metricNameCompare
-      );
+      const keys = canonicalizeList(statsList.map((stats) => stats.map((stat) => stat.name)), metricNameCompare);
+      keys.sort(metricNameCompare);
 
       function update() {
         $stats.empty().append(renderGlobalStats(query, keys, statsList, statsPaths));

--- a/src/benchmark/static/utils.js
+++ b/src/benchmark/static/utils.js
@@ -148,36 +148,25 @@ function sortListWithReferenceOrder(list, referenceOrder) {
   list.sort(([a, b]) => getKey(a) - getKey(b));
 }
 
-function canonicalizeList(lists) {
-  // Takes as input a list of lists, and returns the list of unique elements (preserving order).
-  // Example: [1, 2, 3], [2, 3, 4] => [1, 2, 3, 4]
+function canonicalizeList(lists, compare) {
+  // Takes as input a list of lists and optional compare function,
+  // and returns the list of unique elements (preserving order).
+  // compare(a, b) should return 0 if and only if a equals b.
+  // Example: lists = [[1, 2, 3], [2, 3, 4]]
+  //   => [1, 2, 3, 4]
+  // Example: lists = [[1, 2, 3], [2, 3, 4]], compare = (a, b) => a % 2 - b % 2
+  //   => [1, 2]
   const result = [];
   lists.forEach((list) => {
     list.forEach((elem) => {
-      if (result.indexOf(elem) === -1) {
+      const inResult = compare ?
+        result.some((resultElem) => compare(resultElem, elem) === 0) :
+        result.indexOf(elem) >= 0;
+      if (!inResult) {
         result.push(elem);
       }
     });
   });
-  return result;
-}
-
-function sortAndDeduplicate(list, compare) {
-  // Given a list of elements and a compare function, return a new list containing the deduplicated elements in sorted order.
-  // The compare function should have the same specification as that for Array.sort().
-  // Example: list = [2, 1, 3, 2, 5], comp = ((a, b) => a - b) => [1, 2, 3, 5]
-  const sorted = list.slice().sort(compare);
-  const result = [];
-  let prevElem = null;
-  for (const elem of sorted) {
-    if (prevElem !== null) {
-      if (compare(prevElem, elem) === 0) {
-        continue;
-      }
-    }
-    result.push(elem);
-    prevElem = elem;
-  }
   return result;
 }
 


### PR DESCRIPTION
The previous deduplication did not work because JavaScript does not perform deep comparisons for nested dicts.

Fixes #862