### PR TITLE
Skip auth if not needed in benchmark-run

### DIFF
--- a/src/benchmark/run.py
+++ b/src/benchmark/run.py
@@ -158,7 +158,7 @@ def main():
     args = parser.parse_args()
     validate_args(args)
 
-    auth: Authentication = create_authentication(args)
+    auth: Authentication = Authentication("") if args.skip_instances or args.local else create_authentication(args)
     run_benchmarking(
         args.run_specs,
         auth=auth,


### PR DESCRIPTION
This makes benchmark-run match the current [behavior](https://github.com/stanford-crfm/helm/blob/faab20ffeb96aa6c3572a6116a9884ea94c4315f/src/benchmark/presentation/present.py#L234) in benchmark-present.