### PR TITLE
add @10 metrics for IR to metric definitions in schema

### DIFF
--- a/src/benchmark/static/schema.yaml
+++ b/src/benchmark/static/schema.yaml
@@ -167,6 +167,12 @@ metrics:
     display_name: Valid fraction
     short_display_name: Valid 
     description: Fraction of valid model outputs (as a number).
+  - name: NDCG@10
+    display_name: NDCG@10
+    description: Normalized discounted cumulative gain at 10 in information retrieval.
+  - name: RR@10
+    display_name: RR@10
+    description: Mean reciprocal rank at 10 in information retrieval.
   - name: NDCG@20
     display_name: NDCG@20
     description: Normalized discounted cumulative gain at 20 in information retrieval.


### PR DESCRIPTION
Currently we don't visualize results for accuracy in the main table for IR because we specify `RR/NDCG@10` in the schema tables but only define the `@20` variants. 

**So I am assuming we want the @10 variants**. @okhat @dilarasoylu please confirm this is true.