### PR TITLE
Only write out the slim version of output files

### DIFF
--- a/scripts/create-www.sh
+++ b/scripts/create-www.sh
@@ -24,4 +24,4 @@ chmod -R og=u-w www || exit 1
 
 # Push to server (https://nlp.stanford.edu/helm)
 echo Pushing to server...
-rsync -arvz www/* /u/apache/htdocs/helm/
+rsync -arvz www/* /u/apache/htdocs/helm/$suite

--- a/src/benchmark/presentation/summarize.py
+++ b/src/benchmark/presentation/summarize.py
@@ -163,7 +163,10 @@ class Summarizer:
 
     @htrack(None)
     def write_slim_per_instance_stats(self) -> None:
-        """For each run, load per_instance_stats.json and write per_instance_stats_slim.json."""
+        """
+        For each run, load per_instance_stats.json and compute the slim version.
+        Write out to per_instance_stats.json.
+        """
         run_specs_path: str = os.path.join(self.run_suite_path, "run_specs.json")
         if not os.path.exists(run_specs_path):
             hlog(f"Summarizer won't run because {run_specs_path} doesn't exist yet. This is expected in a dry run.")
@@ -178,11 +181,11 @@ class Summarizer:
 
             per_instance_stats_path: str = os.path.join(run_path, "per_instance_stats.json")
             if os.path.exists(per_instance_stats_path):
+                per_instance_stats: List[Dict]
                 with open(per_instance_stats_path) as input_file:
                     per_instance_stats = json.load(input_file)
-                per_instance_stats
-                per_instance_stats_slim_path = f"{per_instance_stats_path[:-len('.json')]}_slim.json"
-                with open(per_instance_stats_slim_path, "w") as output_file:
+
+                with open(per_instance_stats_path, "w") as output_file:
                     json.dump(self.compute_slim_per_instance_stats(per_instance_stats), output_file)
 
     def read_runs(self):

--- a/src/benchmark/runner.py
+++ b/src/benchmark/runner.py
@@ -177,10 +177,9 @@ class Runner:
         scenario_dict["instances"] = [asdict_without_nones(instance) for instance in scenario_state.instances]
         write(os.path.join(run_path, "scenario.json"), json.dumps(scenario_dict, indent=2))
 
-        # Write scenario state (including a slim version that is much smaller)
-        write(os.path.join(run_path, "scenario_state.json"), json.dumps(asdict_without_nones(scenario_state), indent=2))
+        # Write out the slim version of scenario state to scenario_state.json
         write(
-            os.path.join(run_path, "scenario_state_slim.json"),
+            os.path.join(run_path, "scenario_state.json"),
             json.dumps(asdict_without_nones(slimmed_scenario_state(scenario_state)), indent=2),
         )
 

--- a/src/benchmark/static/benchmarking.js
+++ b/src/benchmark/static/benchmarking.js
@@ -547,13 +547,13 @@ $(function () {
       return `benchmark_output/runs/${suite}/${runSpec.name}/stats.json`;
     });
     const perInstanceStatsPaths = runSpecs.map((runSpec) => {
-      return `benchmark_output/runs/${suite}/${runSpec.name}/per_instance_stats_slim.json`;
+      return `benchmark_output/runs/${suite}/${runSpec.name}/per_instance_stats.json`;
     });
     const scenarioPaths = runSpecs.map((runSpec) => {
       return `benchmark_output/runs/${suite}/${runSpec.name}/scenario.json`;
     });
     const scenarioStatePaths = runSpecs.map((runSpec) => {
-      return `benchmark_output/runs/${suite}/${runSpec.name}/scenario_state_slim.json`;
+      return `benchmark_output/runs/${suite}/${runSpec.name}/scenario_state.json`;
     });
     const runSpecPaths = runSpecs.map((runSpec) => {
       return `benchmark_output/runs/${suite}/${runSpec.name}/run_spec.json`;


### PR DESCRIPTION
I got rid of {file}_slim.json and instead wrote out the slim version to the original file. Also, rsync output folder to `/u/apache/htdocs/helm/$suite`.