### PR TITLE
Support registering HuggingFace Hub models

### DIFF
--- a/src/benchmark/presentation/contamination.py
+++ b/src/benchmark/presentation/contamination.py
@@ -4,7 +4,7 @@ import dacite
 import yaml  # type: ignore
 
 from common.hierarchical_logger import htrack, hlog
-from proxy.models import MODEL_NAME_TO_MODEL
+from proxy.models import get_all_models
 from benchmark.presentation.schema import Schema
 
 CONTAMINATION_YAML_PATH: str = "src/benchmark/static/contamination.yaml"
@@ -67,7 +67,7 @@ def validate_contamination(contamination: Contamination, schema: Schema):
     """Make sure models and groups in contamination are defined according to `schema`."""
     for point in contamination.points:
         for model in point.models:
-            if model not in MODEL_NAME_TO_MODEL:
+            if model not in get_all_models():
                 hlog(f"WARNING: model {model} not defined in schema")
         for group in point.groups:
             if group not in schema.name_to_run_group:

--- a/src/benchmark/window_services/window_service_factory.py
+++ b/src/benchmark/window_services/window_service_factory.py
@@ -1,6 +1,6 @@
 from typing import Dict, Callable
 
-from proxy.models import get_model, Model, WIDER_CONTEXT_WINDOW_TAG
+from proxy.models import ALL_MODELS, WIDER_CONTEXT_WINDOW_TAG
 from .ai21_window_service import AI21WindowService
 from .anthropic_window_service import AnthropicWindowService
 from .cohere_window_service import CohereWindowService
@@ -32,26 +32,52 @@ def register_window_service_for_model(model_name: str, factory: WindowServiceFac
     _window_service_factory_registry[model_name] = factory
 
 
-# Register built-in window service factories
-register_window_service_for_model("huggingface/gpt2", GPT2WindowService)
-register_window_service_for_model("together/bloom", BloomWindowService)
-register_window_service_for_model(
-    "together/glm",
-    # From https://github.com/THUDM/GLM-130B, "the tokenizer is implemented based on
-    # icetk---a unified multimodal tokenizer for images, Chinese, and English."
-    ICEWindowService,
-)
-register_window_service_for_model("huggingface/gpt-j-6b", GPTJWindowService)
-register_window_service_for_model("together/gpt-j-6b", GPTJWindowService)
-register_window_service_for_model("gooseai/gpt-j-6b", GPTJWindowService)
-register_window_service_for_model("together/gpt-neox-20b", GPTNeoXWindowService)
-register_window_service_for_model("gooseai/gpt-neo-20b", GPTNeoXWindowService)
-register_window_service_for_model("together/opt-66b", OPTWindowService)
-register_window_service_for_model("together/opt-175b", OPTWindowService)
-register_window_service_for_model("together/t0pp", T0ppWindowService)
-register_window_service_for_model("together/t5-11b", T511bWindowService)
-register_window_service_for_model("together/ul2", UL2WindowService)
-register_window_service_for_model("together/yalm", YaLMWindowService)
+def _register_build_in_window_services():
+    for model in ALL_MODELS:
+        model_name: str = model.name
+        organization: str = model.organization
+        if WIDER_CONTEXT_WINDOW_TAG in model.tags:
+            register_window_service_for_model(model_name, WiderOpenAIWindowService)
+        elif organization == "openai" or organization == "simple":
+            register_window_service_for_model(model_name, OpenAIWindowService)
+        elif organization == "microsoft":
+            register_window_service_for_model(model_name, MTNLGWindowService)
+        elif organization == "anthropic":
+            register_window_service_for_model(model_name, AnthropicWindowService)
+        elif model_name == "huggingface/gpt2":
+            register_window_service_for_model(model_name, GPT2WindowService)
+        elif model_name == "together/bloom":
+            register_window_service_for_model(model_name, BloomWindowService)
+        elif model_name == "together/glm":
+            # From https://github.com/THUDM/GLM-130B, "the tokenizer is implemented based on
+            # icetk---a unified multimodal tokenizer for images, Chinese, and English."
+            register_window_service_for_model(model_name, ICEWindowService)
+        elif model_name in ["huggingface/gpt-j-6b", "together/gpt-j-6b", "gooseai/gpt-j-6b"]:
+            register_window_service_for_model(model_name, GPTJWindowService)
+        elif model_name in ["together/gpt-neox-20b", "gooseai/gpt-neo-20b"]:
+            register_window_service_for_model(model_name, GPTNeoXWindowService)
+        elif model_name in ["together/opt-66b", "together/opt-175b"]:
+            register_window_service_for_model(model_name, OPTWindowService)
+        elif model_name == "together/t0pp":
+            register_window_service_for_model(model_name, T0ppWindowService)
+        elif model_name == "together/t5-11b":
+            register_window_service_for_model(model_name, T511bWindowService)
+        elif model_name == "together/ul2":
+            register_window_service_for_model(model_name, UL2WindowService)
+        elif model_name == "together/yalm":
+            register_window_service_for_model(model_name, YaLMWindowService)
+        elif organization == "cohere":
+            register_window_service_for_model(model_name, CohereWindowService)
+        elif organization == "ai21":
+            register_window_service_for_model(
+                model_name,
+                lambda service: AI21WindowService(service=service, gpt2_window_service=GPT2WindowService(service)),
+            )
+        else:
+            raise ValueError(f"Unhandled model name: {model_name}")
+
+
+_register_build_in_window_services()
 
 
 class WindowServiceFactory:
@@ -61,27 +87,10 @@ class WindowServiceFactory:
         Returns a `WindowService` given the name of the model.
         Make sure this function returns instantaneously on repeated calls.
         """
-        wondow_service_factory_for_model = _window_service_factory_registry.get(model_name)
-        if wondow_service_factory_for_model is not None:
-            return wondow_service_factory_for_model(service)
-
-        model: Model = get_model(model_name)
-        organization: str = model.organization
-
-        window_service: WindowService
-        if WIDER_CONTEXT_WINDOW_TAG in model.tags:
-            window_service = WiderOpenAIWindowService(service)
-        elif organization == "openai" or organization == "simple":
-            window_service = OpenAIWindowService(service)
-        elif organization == "microsoft":
-            window_service = MTNLGWindowService(service)
-        elif organization == "anthropic":
-            window_service = AnthropicWindowService(service)
-        elif organization == "cohere":
-            window_service = CohereWindowService(service)
-        elif organization == "ai21":
-            window_service = AI21WindowService(service=service, gpt2_window_service=GPT2WindowService(service))
-        else:
-            raise ValueError(f"Unhandled model name: {model_name}")
-
-        return window_service
+        window_service_factory = _window_service_factory_registry.get(model_name)
+        if window_service_factory is None:
+            raise ValueError(
+                f"No registered window service found for model: {model_name} - "
+                "register a window service using register_window_service_for_model()"
+            )
+        return window_service_factory(service)

--- a/src/benchmark/window_services/window_service_factory.py
+++ b/src/benchmark/window_services/window_service_factory.py
@@ -1,4 +1,6 @@
-from proxy.models import get_model, get_model_names_with_tag, Model, WIDER_CONTEXT_WINDOW_TAG
+from typing import Dict, Callable
+
+from proxy.models import get_model, Model, WIDER_CONTEXT_WINDOW_TAG
 from .ai21_window_service import AI21WindowService
 from .anthropic_window_service import AnthropicWindowService
 from .cohere_window_service import CohereWindowService
@@ -19,6 +21,39 @@ from .window_service import WindowService
 from .tokenizer_service import TokenizerService
 
 
+WindowServiceFactoryCallable = Callable[[TokenizerService], WindowService]
+# Dict of model name to window service factory
+_window_service_factory_registry: Dict[str, WindowServiceFactoryCallable] = {}
+
+
+def register_window_service_for_model(model_name: str, factory: WindowServiceFactoryCallable) -> None:
+    if model_name in _window_service_factory_registry:
+        raise ValueError(f"A window service factory is already registered for model name {model_name}")
+    _window_service_factory_registry[model_name] = factory
+
+
+# Register built-in window service factories
+register_window_service_for_model("huggingface/gpt2", GPT2WindowService)
+register_window_service_for_model("together/bloom", BloomWindowService)
+register_window_service_for_model(
+    "together/glm",
+    # From https://github.com/THUDM/GLM-130B, "the tokenizer is implemented based on
+    # icetk---a unified multimodal tokenizer for images, Chinese, and English."
+    ICEWindowService,
+)
+register_window_service_for_model("huggingface/gpt-j-6b", GPTJWindowService)
+register_window_service_for_model("together/gpt-j-6b", GPTJWindowService)
+register_window_service_for_model("gooseai/gpt-j-6b", GPTJWindowService)
+register_window_service_for_model("together/gpt-neox-20b", GPTNeoXWindowService)
+register_window_service_for_model("gooseai/gpt-neo-20b", GPTNeoXWindowService)
+register_window_service_for_model("together/opt-66b", OPTWindowService)
+register_window_service_for_model("together/opt-175b", OPTWindowService)
+register_window_service_for_model("together/t0pp", T0ppWindowService)
+register_window_service_for_model("together/t5-11b", T511bWindowService)
+register_window_service_for_model("together/ul2", UL2WindowService)
+register_window_service_for_model("together/yalm", YaLMWindowService)
+
+
 class WindowServiceFactory:
     @staticmethod
     def get_window_service(model_name: str, service: TokenizerService) -> WindowService:
@@ -26,11 +61,15 @@ class WindowServiceFactory:
         Returns a `WindowService` given the name of the model.
         Make sure this function returns instantaneously on repeated calls.
         """
+        wondow_service_factory_for_model = _window_service_factory_registry.get(model_name)
+        if wondow_service_factory_for_model is not None:
+            return wondow_service_factory_for_model(service)
+
         model: Model = get_model(model_name)
         organization: str = model.organization
 
         window_service: WindowService
-        if model_name in get_model_names_with_tag(WIDER_CONTEXT_WINDOW_TAG):
+        if WIDER_CONTEXT_WINDOW_TAG in model.tags:
             window_service = WiderOpenAIWindowService(service)
         elif organization == "openai" or organization == "simple":
             window_service = OpenAIWindowService(service)
@@ -38,28 +77,6 @@ class WindowServiceFactory:
             window_service = MTNLGWindowService(service)
         elif organization == "anthropic":
             window_service = AnthropicWindowService(service)
-        elif model_name == "huggingface/gpt2":
-            window_service = GPT2WindowService(service)
-        elif model_name == "together/bloom":
-            window_service = BloomWindowService(service)
-        elif model_name == "together/glm":
-            # From https://github.com/THUDM/GLM-130B, "the tokenizer is implemented based on
-            # icetk---a unified multimodal tokenizer for images, Chinese, and English."
-            window_service = ICEWindowService(service)
-        elif model_name in ["huggingface/gpt-j-6b", "together/gpt-j-6b", "gooseai/gpt-j-6b"]:
-            window_service = GPTJWindowService(service)
-        elif model_name in ["together/gpt-neox-20b", "gooseai/gpt-neo-20b"]:
-            window_service = GPTNeoXWindowService(service)
-        elif model_name in ["together/opt-66b", "together/opt-175b"]:
-            window_service = OPTWindowService(service)
-        elif model_name == "together/t0pp":
-            window_service = T0ppWindowService(service)
-        elif model_name == "together/t5-11b":
-            window_service = T511bWindowService(service)
-        elif model_name == "together/ul2":
-            window_service = UL2WindowService(service)
-        elif model_name == "together/yalm":
-            window_service = YaLMWindowService(service)
         elif organization == "cohere":
             window_service = CohereWindowService(service)
         elif organization == "ai21":

--- a/src/proxy/models.py
+++ b/src/proxy/models.py
@@ -80,6 +80,7 @@ class Model:
         return self.name.split("/")[1]
 
 
+# TODO: Remove ALL_MODELS and use the model registry instead.
 # For the list of available models, see the following docs:
 # Note that schema.yaml has much of this information now.
 # Over time, we should add more information there.
@@ -490,15 +491,23 @@ ALL_MODELS = [
 ]
 
 
-MODEL_NAME_TO_MODEL: Dict[str, Model] = {model.name: model for model in ALL_MODELS}
+_model_registry: Dict[str, Model] = {}
+
+
+def register_model(model: Model) -> None:
+    key = model.name
+    if key in _model_registry:
+        raise ValueError(f"A model is already registered for model name {key}")
+    _model_registry[key] = model
+
+
+for model in ALL_MODELS:
+    register_model(model)
 
 
 def get_model(model_name: str) -> Model:
     """Get the `Model` given the name."""
-    if model_name not in MODEL_NAME_TO_MODEL:
-        raise ValueError(f"No model with name: {model_name}")
-
-    return MODEL_NAME_TO_MODEL[model_name]
+    return _model_registry[model_name]
 
 
 def get_model_group(model_name: str) -> str:
@@ -509,19 +518,19 @@ def get_model_group(model_name: str) -> str:
 
 def get_all_models() -> List[str]:
     """Get all model names."""
-    return list(MODEL_NAME_TO_MODEL.keys())
+    return list(_model_registry.keys())
 
 
 def get_models_by_organization(organization: str) -> List[str]:
     """
     Gets models by organization e.g., ai21 => ai21/j1-jumbo, ai21/j1-grande, ai21-large.
     """
-    return [model.name for model in ALL_MODELS if model.organization == organization]
+    return [model.name for model in _model_registry.values() if model.organization == organization]
 
 
 def get_model_names_with_tag(tag: str) -> List[str]:
     """Get all the name of the models with tag `tag`."""
-    return [model.name for model in ALL_MODELS if tag in model.tags]
+    return [model.name for model in _model_registry.values() if tag in model.tags]
 
 
 def get_all_text_models() -> List[str]:

--- a/src/proxy/models.py
+++ b/src/proxy/models.py
@@ -507,7 +507,10 @@ for model in ALL_MODELS:
 
 def get_model(model_name: str) -> Model:
     """Get the `Model` given the name."""
-    return _model_registry[model_name]
+    try:
+        return _model_registry[model_name]
+    except KeyError:
+        raise ValueError(f"No model registered for name {model_name} - " "register a model using register_model()")
 
 
 def get_model_group(model_name: str) -> str:


### PR DESCRIPTION
This allows running benchmarks on arbitrary HuggingFace models and revisions. See #1103 for an example use of this API.