### PR TITLE
Revert IR metrics to their @10 versions

### DIFF
--- a/src/benchmark/static/schema.yaml
+++ b/src/benchmark/static/schema.yaml
@@ -1261,7 +1261,7 @@ run_groups:
       - efficiency
       - general_information
     environment:
-      main_name: RR@20
+      main_name: RR@10
       main_split: valid
 
   - name: msmarco_trec
@@ -1277,7 +1277,7 @@ run_groups:
       - efficiency
       - general_information
     environment:
-      main_name: NDCG@20
+      main_name: NDCG@10
       main_split: valid
 
 # Summarization scenarios


### PR DESCRIPTION
We are interested in showing the @10 versions of NDCG and RR for the information retrieval scenarios (seems like an earlier modification was overwritten).
We would like to get this version merged if `summarize.py` will be run again!