### PR TITLE
Fix running helm-server from package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
+recursive-include src/benchmark/static/ *.png
 include requirements.txt

--- a/src/benchmark/metrics/basic_metrics.py
+++ b/src/benchmark/metrics/basic_metrics.py
@@ -400,20 +400,18 @@ class BasicMetric(Metric):
         # num_prompt_tokens values.
         # Profiling code and logs, and code to fit the regression model is available at
         # https://github.com/stanford-crfm/benchmarking_efficiency.
-        self.inference_idealized_runtimes_dict = json.load(
-            resources.open_text(EFFICIENCY_DATA_PACKAGE, INFERENCE_IDEALIZED_RUNTIMES_JSON_FILENAME)
-        )
-        self.inference_denoised_runtimes_dict = json.load(
-            resources.open_text(EFFICIENCY_DATA_PACKAGE, INFERENCE_DENOISED_RUNTIMES_JSON_FILENAME)
-        )
+        data_package = resources.files(EFFICIENCY_DATA_PACKAGE)
+        with data_package.joinpath(INFERENCE_IDEALIZED_RUNTIMES_JSON_FILENAME).open("r") as f:
+            self.inference_idealized_runtimes_dict = json.load(f)
+        with data_package.joinpath(INFERENCE_DENOISED_RUNTIMES_JSON_FILENAME).open("r") as f:
+            self.inference_denoised_runtimes_dict = json.load(f)
 
         # We use estimated emitted CO2 during training (in tons of CO2) as a proxy metric
         # for training efficiency. We use reported metrics where applicable, otherwise
         # we estimate them from runtime information, type and number of hardware accelerators
         # used, region, etc.
-        self.training_efficiency_dict = json.load(
-            resources.open_text(EFFICIENCY_DATA_PACKAGE, TRAINING_EFFICIENCY_JSON_FILENAME)
-        )
+        with data_package.joinpath(TRAINING_EFFICIENCY_JSON_FILENAME).open("r") as f:
+            self.training_efficiency_dict = json.load(f)
 
     def __repr__(self):
         return f"BasicMetric({','.join(self.names)})"

--- a/src/benchmark/presentation/contamination.py
+++ b/src/benchmark/presentation/contamination.py
@@ -1,13 +1,16 @@
 from dataclasses import dataclass
 from typing import List, Optional
 import dacite
+import importlib_resources as resources
 import yaml  # type: ignore
 
 from common.hierarchical_logger import htrack, hlog
 from proxy.models import MODEL_NAME_TO_MODEL
 from benchmark.presentation.schema import Schema
 
-CONTAMINATION_YAML_PATH: str = "src/benchmark/static/contamination.yaml"
+
+CONTAMINATION_YAML_PACKAGE: str = "benchmark.static"
+CONTAMINATION_YAML_FILENAME: str = "contamination.yaml"
 
 # Contamination levels
 CONTAMINATION_LEVEL_WEAK = "weak"
@@ -75,7 +78,8 @@ def validate_contamination(contamination: Contamination, schema: Schema):
 
 
 def read_contamination():
-    hlog(f"Reading contamination information from {CONTAMINATION_YAML_PATH}...")
-    with open(CONTAMINATION_YAML_PATH) as f:
+    hlog(f"Reading contamination information from {CONTAMINATION_YAML_FILENAME}...")
+    contamination_path = resources.files(CONTAMINATION_YAML_PACKAGE).joinpath(CONTAMINATION_YAML_FILENAME)
+    with contamination_path.open("r") as f:
         raw = yaml.safe_load(f)
     return dacite.from_dict(Contamination, raw)

--- a/src/benchmark/presentation/schema.py
+++ b/src/benchmark/presentation/schema.py
@@ -4,12 +4,16 @@ from typing import List, Optional, Dict
 import dacite
 import mako.template
 import yaml  # type: ignore
+import importlib_resources as resources
 
 from common.general import hlog
 from benchmark.metrics.metric_name import MetricName
 from benchmark.augmentations.perturbation_description import PERTURBATION_WORST
 
-SCHEMA_YAML_PATH: str = "src/benchmark/static/schema.yaml"
+
+SCHEMA_YAML_PACKAGE: str = "benchmark.static"
+SCHEMA_YAML_FILENAME: str = "schema.yaml"
+
 UP_ARROW = "\u2191"
 DOWN_ARROW = "\u2193"
 
@@ -233,7 +237,8 @@ class Schema:
 
 
 def read_schema():
-    hlog(f"Reading schema from {SCHEMA_YAML_PATH}...")
-    with open(SCHEMA_YAML_PATH) as f:
+    hlog(f"Reading schema from {SCHEMA_YAML_FILENAME}...")
+    schema_path = resources.files(SCHEMA_YAML_PACKAGE).joinpath(SCHEMA_YAML_FILENAME)
+    with schema_path.open("r") as f:
         raw = yaml.safe_load(f)
     return dacite.from_dict(Schema, raw)

--- a/src/benchmark/presentation/summarize.py
+++ b/src/benchmark/presentation/summarize.py
@@ -29,7 +29,7 @@ from .schema import (
     ModelField,
     RunGroup,
     read_schema,
-    SCHEMA_YAML_PATH,
+    SCHEMA_YAML_FILENAME,
     BY_GROUP,
     THIS_GROUP_ONLY,
     NO_GROUPS,
@@ -248,7 +248,7 @@ class Summarizer:
                 if run_group_name not in self.schema.name_to_run_group:
                     hlog(
                         f"WARNING: group {run_group_name} mentioned in run spec {run.run_spec.name} "
-                        f"but undefined in {SCHEMA_YAML_PATH}, skipping"
+                        f"but undefined in {SCHEMA_YAML_FILENAME}, skipping"
                     )
                     continue
                 run_group = self.schema.name_to_run_group[run_group_name]
@@ -318,7 +318,7 @@ class Summarizer:
         for metric_name, run_spec_names in metric_name_to_run_spec_names.items():
             if metric_name not in defined_metric_names:
                 hlog(
-                    f"WARNING: metric name {metric_name} undefined in {SCHEMA_YAML_PATH} "
+                    f"WARNING: metric name {metric_name} undefined in {SCHEMA_YAML_FILENAME} "
                     f"but appears in {len(run_spec_names)} run specs, including {run_spec_names[0]}"
                 )
 
@@ -572,7 +572,7 @@ class Summarizer:
                     matcher = replace(matcher, sub_split=sub_split)
                 header_field = self.schema.name_to_metric.get(matcher.name)
                 if header_field is None:
-                    hlog(f"WARNING: metric name {matcher.name} undefined in {SCHEMA_YAML_PATH}, skipping")
+                    hlog(f"WARNING: metric name {matcher.name} undefined in {SCHEMA_YAML_FILENAME}, skipping")
                     continue
 
                 header_name = header_field.get_short_display_name(arrow=True)

--- a/src/benchmark/server.py
+++ b/src/benchmark/server.py
@@ -1,22 +1,53 @@
-import http.server
+"""
+Starts a local HTTP server to display benchmarking assets.
+"""
+
+import argparse
+import importlib_resources as resources
+from os import path
+
+from bottle import Bottle, static_file
 
 
-class MyHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
-    """
-    The benchmarking assets can be served off of a static site (e.g., GitHub
-    pages), but for development, it's useful to have a simple local website.
-    The default http server caches, which we need to turn that off.
-    Adapted from: https://stackoverflow.com/questions/42341039/remove-cache-in-a-python-http-server
-    """
+app = Bottle()
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs, directory="src/benchmark/static")
 
-    def send_response_only(self, code, message=None):
-        super().send_response_only(code, message)
-        self.send_header("Cache-Control", "no-cache, no-store, must-revalidate")
-        self.send_header("Expires", "0")
+@app.get("/benchmark_output/<filename:path>")
+def serve_benchmark_output(filename):
+    response = static_file(filename, root=app.config["helm.outputpath"])
+    response.set_header("Cache-Control", "no-cache, no-store, must-revalidate")
+    response.set_header("Expires", "0")
+    return response
+
+
+@app.get("/")
+@app.get("/<filename:path>")
+def serve_static(filename="index.html"):
+    response = static_file(filename, root=app.config["helm.staticpath"])
+    return response
 
 
 def main():
-    http.server.test(HandlerClass=MyHTTPRequestHandler)
+    global service
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--port", type=int, help="What port to listen on", default=8000)
+    parser.add_argument(
+        "-o", "--output-path", type=str, help="The location of the output path", default="benchmark_output"
+    )
+    args = parser.parse_args()
+
+    # Determine the location of the static directory.
+    # This is a hack: it assumes that the static directory has a physical location,
+    # which is not always the case (e.g. when using zipimport).
+    resource_path = resources.files("benchmark.static").joinpath("index.html")
+    with resources.as_file(resource_path) as resource_filename:
+        static_path = str(resource_filename.parent)
+
+    app.config["helm.staticpath"] = static_path
+    app.config["helm.outputpath"] = path.abspath(args.output_path)
+
+    app.run(host="0.0.0.0", port=args.port)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Uses packaged YAML and static files, rather than requiring the user to provide their own.
- Allows the user to set the output path 

Addresses #77
Fixes #1133