### PR TITLE
Shuffle labels that have the same number of `Instance`s that belong to them

### DIFF
--- a/src/helm/benchmark/adapter.py
+++ b/src/helm/benchmark/adapter.py
@@ -912,7 +912,7 @@ class Adapter:
             end_count: int = len(label_to_instances[sorted_labels[end]])
 
             if current_count != end_count or end == len(sorted_labels) - 1:
-                # We've reached the end of the window of labels that have the same number of Instances.
+                # Shuffle now that we're at the end of the window of labels that have the same number of Instances.
                 to_shuffle: List[str] = sorted_labels[start:end]
                 random.shuffle(to_shuffle)
                 sorted_labels[start:end] = to_shuffle

--- a/src/helm/benchmark/adapter.py
+++ b/src/helm/benchmark/adapter.py
@@ -878,7 +878,9 @@ class Adapter:
                 Instance("say no", references=[Reference("no", tags=[CORRECT_TAG])]),
                 Instance("say yes", references=[Reference("yes", tags=[CORRECT_TAG])]),
                 Instance("say yes", references=[Reference("yes", tags=[CORRECT_TAG])]),
+
             The following instances would be selected:
+
                 Instance("say yes", references=[Reference("yes", tags=[CORRECT_TAG])])
                 Instance("say no", references=[Reference("no", tags=[CORRECT_TAG])])
 

--- a/src/helm/benchmark/adapter.py
+++ b/src/helm/benchmark/adapter.py
@@ -902,7 +902,7 @@ class Adapter:
         # Build Instance counts to labels
         instances: List[Instance]
         counts_to_labels: Dict[int, List[str]] = defaultdict(list)
-        for label, instances in label_to_instances.items():
+        for label, instances in sorted(label_to_instances.items()):
             counts_to_labels[len(instances)].append(label)
 
         sorted_labels: List[str] = []

--- a/src/helm/benchmark/adapter.py
+++ b/src/helm/benchmark/adapter.py
@@ -865,7 +865,7 @@ class Adapter:
     def sample_examples(self, all_train_instances: List[Instance], seed: int) -> List[Instance]:
         """
         Sample a random set of train instances to use as examples by following the steps below:
-        1. Sort the class labels i.e., correct References by the number of Instances that belong to the
+        1. Sort the class labels (i.e., correct References) by the number of Instances that belong to the
            class so more common labels are included in the in-context examples. Break ties by shuffling.
         2. Keep sampling one train Instance from each class in the order established in step 1, until
            there are k examples.

--- a/src/helm/benchmark/run_specs.py
+++ b/src/helm/benchmark/run_specs.py
@@ -209,7 +209,6 @@ def get_completion_adapter_spec(
     )
 
 
-# TODO: come up with a better name -Tony
 def get_generation_adapter_spec(
     instructions: str = "",
     input_noun: Optional[str] = None,

--- a/src/helm/benchmark/test_adapter.py
+++ b/src/helm/benchmark/test_adapter.py
@@ -161,6 +161,19 @@ class TestAdapter:
         examples = adapter.sample_examples(all_train_instances, seed=0)
         assert len(examples) == 1
 
+    def test_sample_examples_open_ended_generation(self):
+        adapter_spec = AdapterSpec(model=DEFAULT_MODEL, max_train_instances=3)
+        adapter = Adapter(adapter_spec, self.tokenizer_service)
+
+        all_train_instances: List[Instance] = [
+            Instance(f"prompt{i}", references=[Reference(f"reference{i}", tags=[CORRECT_TAG])]) for i in range(1, 10)
+        ]
+        seed0_examples: List[Instance] = adapter.sample_examples(all_train_instances, seed=0)
+        seed1_examples: List[Instance] = adapter.sample_examples(all_train_instances, seed=1)
+
+        assert len(seed0_examples) == len(seed1_examples) == 3
+        assert seed0_examples != seed1_examples, "Expect selected examples differ when changing the seed"
+
     def test_fits_tokens_within_context_window(self):
         adapter_spec = AdapterSpec(
             method=ADAPT_LANGUAGE_MODELING,


### PR DESCRIPTION
This allows us to get different train examples across trials for open-ended generation tasks.