### PR TITLE
Use unscaled logprobs for AI21

### DIFF
--- a/src/helm/benchmark/static/schema.yaml
+++ b/src/helm/benchmark/static/schema.yaml
@@ -23,6 +23,13 @@ models:
     access: limited
     num_parameters: 17000000000
     release_date: 2022-05-03
+  - name: ai21/j1-grande-v2-beta
+    display_name: J1-Grande v2 beta (17B)
+    description: Jurassic-1 Grande v2 beta (17B parameters)
+    creator_organization: AI21 Labs
+    access: limited
+    num_parameters: 17000000000
+    release_date: 2022-10-28
 
   # Anthropic
   - name: anthropic/stanford-online-all-v4-s3

--- a/src/helm/proxy/clients/ai21_client.py
+++ b/src/helm/proxy/clients/ai21_client.py
@@ -110,6 +110,7 @@ class AI21Client(Client):
             # e.g. "▁burying"(0,8) -> 8 - 0 = 8; "▁burying"(0,7) -> 7 - 0 = 7
             text_length: int = raw["textRange"]["end"] - raw["textRange"]["start"]
             # "topTokens" can be None when sending a request with topKReturn=0
+            # AI21 sends unscaled logprobs as `raw_logprob` so use this instead of `logprob`.
             top_logprobs: Dict[str, float] = dict(
                 (fix_text(x["token"], first), x["raw_logprob"]) for x in raw["topTokens"] or []
             )

--- a/src/helm/proxy/models.py
+++ b/src/helm/proxy/models.py
@@ -101,7 +101,15 @@ ALL_MODELS = [
         creator_organization="AI21 Labs",
         name="ai21/j1-grande",
         display_name="Jurassic Grande (17B)",
-        description="Jurassic J1-Large (17B parameters with a few tweaks to its training process)",
+        description="Jurassic J1-Grande (17B parameters with a few tweaks to its training process)",
+        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG, AI21_TOKENIZER_TAG],
+    ),
+    Model(
+        group="jurassic",
+        creator_organization="AI21 Labs",
+        name="ai21/j1-grande-v2-beta",
+        display_name="Jurassic Grande v2 beta (17B)",
+        description="Jurassic J1-Grande v2 beta (17B parameters)",
         tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG, AI21_TOKENIZER_TAG],
     ),
     Model(


### PR DESCRIPTION
- AI21 added back unscaled logprobs as `raw_logprob`
- Added J1-Grande v2 beta model

Once this change is in, we need to clear all the cached entries for AI21 models and rerun everything.

Resolves #717 