### PR TITLE
Support Aleph Alpha's Luminous models

### DIFF
--- a/src/helm/benchmark/window_services/luminous_window_service.py
+++ b/src/helm/benchmark/window_services/luminous_window_service.py
@@ -1,0 +1,119 @@
+from abc import abstractmethod
+from typing import List, Optional
+
+from .local_window_service import LocalWindowService
+from .tokenizer_service import TokenizerService
+from .window_service import EncodeResult
+from helm.common.tokenization_request import TokenizationRequest, TokenizationToken, DecodeRequest
+
+
+class LuminousWindowService(LocalWindowService):
+    def __init__(self, service: TokenizerService):
+        super().__init__(service)
+
+    @property
+    @abstractmethod
+    def tokenizer_name(self) -> str:
+        """Each Luminous model has its own tokenizer."""
+        pass
+
+    @property
+    def max_sequence_length(self) -> int:
+        return self.max_request_length
+
+    @property
+    def max_request_length(self) -> int:
+        """
+        The max request length according to https://docs.aleph-alpha.com/api/complete.
+        TODO: double check if this is only for the completion (not including the prompt).
+        """
+        return 2048
+
+    @property
+    def end_of_text_token(self) -> str:
+        """
+        The end of text token.
+        TODO: echo doesn't seem to be supported.
+        """
+        return ""
+
+    @property
+    def prefix_token(self) -> str:
+        """
+        The prefix token.
+        TODO: echo doesn't seem to be supported.
+        """
+        return self.end_of_text_token
+
+    def encode(self, text: str, truncation: bool = False, max_length: Optional[int] = None) -> EncodeResult:
+        """
+        Encodes the input text to tokens.
+        """
+        if max_length is None:
+            max_length = self.max_request_length
+
+        response = self.service.tokenize(
+            TokenizationRequest(
+                text,
+                tokenizer=self.tokenizer_name,
+                encode=True,
+                truncation=truncation,
+                max_length=max_length,
+            )
+        )
+        return EncodeResult(text=text, tokens=response.tokens)
+
+    def get_num_tokens(self, text: str) -> int:
+        """Tokenizes the text and returns the number of tokens."""
+        return len(self.encode(text).tokens)
+
+    def decode(self, tokens: List[TokenizationToken], normalized_text: Optional[str] = None) -> str:
+        """
+        Decodes the token ids to text.
+        """
+        response = self.service.decode(
+            DecodeRequest(
+                tokens=[token.value for token in tokens],  # type: ignore
+                tokenizer=self.tokenizer_name,
+            )
+        )
+        return response.text
+
+    def fits_within_context_window(self, text: str, expected_completion_token_length: int = 0) -> bool:
+        """
+        Checks if the given text fits within the context window given by `max_request_length`
+        taking to account the expected completion length (defaults to 0).
+        """
+        return self.get_num_tokens(text) + expected_completion_token_length <= self.max_request_length
+
+    def truncate_from_right(self, text: str, expected_completion_token_length: int = 0) -> str:
+        """
+        Truncates text from the right to fit within the context window given by `max_request_length`
+        minus the expected completion length (defaults to 0).
+        """
+        max_length: int = self.max_request_length - expected_completion_token_length
+        return self.decode(self.encode(text, truncation=True, max_length=max_length).tokens)
+
+
+class LuminousBaseWindowService(LuminousWindowService):
+    @property
+    def tokenizer_name(self) -> str:
+        return "AlephAlpha/luminous-base"
+
+
+class LuminousExtendedWindowService(LuminousWindowService):
+    @property
+    def tokenizer_name(self) -> str:
+        return "AlephAlpha/luminous-extended"
+
+
+class LuminousSupremeWindowService(LuminousWindowService):
+    @property
+    def tokenizer_name(self) -> str:
+        return "AlephAlpha/luminous-supreme"
+
+
+class LuminousWorldWindowService(LuminousWindowService):
+    @property
+    def tokenizer_name(self) -> str:
+        return "AlephAlpha/luminous-world"

--- a/src/helm/benchmark/window_services/window_service_factory.py
+++ b/src/helm/benchmark/window_services/window_service_factory.py
@@ -2,6 +2,12 @@ from helm.proxy.models import get_model, get_model_names_with_tag, Model, WIDER_
 from .ai21_window_service import AI21WindowService
 from .anthropic_window_service import AnthropicWindowService
 from .cohere_window_service import CohereWindowService
+from .luminous_window_service import (
+    LuminousBaseWindowService,
+    LuminousExtendedWindowService,
+    LuminousSupremeWindowService,
+    LuminousWorldWindowService,
+)
 from .openai_window_service import OpenAIWindowService
 from .wider_openai_window_service import WiderOpenAIWindowService
 from .mt_nlg_window_service import MTNLGWindowService
@@ -28,12 +34,24 @@ class WindowServiceFactory:
         """
         model: Model = get_model(model_name)
         organization: str = model.organization
+        engine: str = model.engine
 
         window_service: WindowService
         if model_name in get_model_names_with_tag(WIDER_CONTEXT_WINDOW_TAG):
             window_service = WiderOpenAIWindowService(service)
         elif organization == "openai" or organization == "simple":
             window_service = OpenAIWindowService(service)
+        elif organization == "AlephAlpha":
+            if engine == "luminous-base":
+                window_service = LuminousBaseWindowService(service)
+            elif engine == "luminous-extended":
+                window_service = LuminousExtendedWindowService(service)
+            elif engine == "luminous-supreme":
+                window_service = LuminousSupremeWindowService(service)
+            elif engine == "luminous-world":
+                window_service = LuminousWorldWindowService(service)
+            else:
+                raise ValueError(f"Unhandled Aleph Alpha model: {engine}")
         elif organization == "microsoft":
             window_service = MTNLGWindowService(service)
         elif organization == "anthropic":

--- a/src/helm/common/tokenization_request.py
+++ b/src/helm/common/tokenization_request.py
@@ -26,6 +26,11 @@ class TokenizationRequest:
         """Example: 'huggingface/gpt2' => 'huggingface'"""
         return self.tokenizer.split("/")[0]
 
+    @property
+    def tokenizer_name(self):
+        """Example: 'huggingface/gpt2' => 'gpt2'"""
+        return self.tokenizer.split("/")[1]
+
 
 @dataclass(frozen=True)
 class TextRange:
@@ -98,6 +103,11 @@ class DecodeRequest:
     def tokenizer_organization(self):
         """Example: 'huggingface/gpt2' => 'huggingface'"""
         return self.tokenizer.split("/")[0]
+
+    @property
+    def tokenizer_name(self):
+        """Example: 'huggingface/gpt2' => 'gpt2'"""
+        return self.tokenizer.split("/")[1]
 
 
 @dataclass(frozen=True)

--- a/src/helm/proxy/clients/aleph_alpha_client.py
+++ b/src/helm/proxy/clients/aleph_alpha_client.py
@@ -1,0 +1,157 @@
+import json
+import requests
+from typing import Any, Dict, List
+
+from helm.common.cache import Cache, CacheConfig
+from helm.common.request import Request, RequestResult, Sequence, Token
+from helm.common.tokenization_request import (
+    DecodeRequest,
+    DecodeRequestResult,
+    TokenizationRequest,
+    TokenizationRequestResult,
+    TokenizationToken,
+)
+from .client import Client, wrap_request_time, truncate_sequence
+
+
+class AlephAlphaClient(Client):
+    COMPLETION_ENDPOINT: str = "complete"
+    TOKENIZE_ENDPOINT: str = "tokenize"
+    DETOKENIZE_ENDPOINT: str = "detokenize"
+
+    def __init__(self, api_key: str, cache_config: CacheConfig):
+        self.api_key: str = api_key
+        self.cache = Cache(cache_config)
+
+    def _send_request(self, endpoint: str, raw_request: Dict[str, Any]) -> Dict[str, Any]:
+        response = requests.request(
+            method="POST",
+            url=f"https://api.aleph-alpha.com/{endpoint}",
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "Authorization": f"Bearer {self.api_key}",
+            },
+            data=json.dumps(raw_request),
+        )
+        result = json.loads(response.text)
+        assert "error" not in result, f"Request failed with error: {result['error']}"
+        return result
+
+    def make_request(self, request: Request) -> RequestResult:
+        """Make a request following https://docs.aleph-alpha.com/api/complete."""
+        # TODO: echo seems to be not supported. Follow up on this.
+        raw_request = {
+            "model": request.model_engine,
+            "prompt": request.prompt,
+            "maximum_tokens": request.max_tokens,
+            "temperature": request.temperature,
+            "top_k": request.top_k_per_token,
+            "top_p": request.top_p,
+            "presence_penalty": request.presence_penalty,
+            "frequency_penalty": request.frequency_penalty,
+            "n": request.num_completions,
+            "stop_sequences": request.stop_sequences,
+            "log_probs": 0,  # Log probs of generated tokens are returned if set to 0
+            "tokens": True,  # Setting to True returns individual tokens of the completion
+        }
+
+        try:
+
+            def do_it():
+                result = self._send_request(AlephAlphaClient.COMPLETION_ENDPOINT, raw_request)
+                assert "completions" in result, f"Invalid response: {result}"
+                return result
+
+            response, cached = self.cache.get(raw_request, wrap_request_time(do_it))
+        except (requests.exceptions.RequestException, AssertionError) as e:
+            error: str = f"AlephAlphaClient error: {e}"
+            return RequestResult(success=False, cached=False, error=error, completions=[], embedding=[])
+
+        completions: List[Sequence] = []
+        for completion in response["completions"]:
+            sequence_logprob: float = 0
+            tokens: List[Token] = []
+
+            # `completion_tokens` is the list of selected tokens.
+            for i, token in enumerate(completion["completion_tokens"]):
+                # Get the top K logprobs for the ith token
+                top_logprobs: Dict[str, float] = completion["log_probs"][i]
+                # Use the selected token value to get the logprob
+                logprob: float = top_logprobs[token]
+                sequence_logprob += logprob
+                tokens.append(
+                    Token(
+                        text=token,
+                        logprob=logprob,
+                        top_logprobs=top_logprobs,
+                    )
+                )
+
+            sequence: Sequence = Sequence(text=completion["completion"], logprob=sequence_logprob, tokens=tokens)
+            sequence = truncate_sequence(sequence, request)
+            completions.append(sequence)
+
+        return RequestResult(
+            success=True,
+            cached=cached,
+            request_time=response["request_time"],
+            request_datetime=response["request_datetime"],
+            completions=completions,
+            embedding=[],
+        )
+
+    def tokenize(self, request: TokenizationRequest) -> TokenizationRequestResult:
+        """Make a request following https://docs.aleph-alpha.com/api/tokenize."""
+        raw_request = {"model": request.tokenizer_name, "prompt": request.text, "tokens": True, "token_ids": True}
+
+        try:
+
+            def do_it():
+                result = self._send_request(AlephAlphaClient.TOKENIZE_ENDPOINT, raw_request)
+                assert "tokens" in result and "token_ids" in result, f"Invalid response: {result}"
+                return result
+
+            response, cached = self.cache.get(raw_request, wrap_request_time(do_it))
+        except (requests.exceptions.RequestException, AssertionError) as e:
+            error: str = f"AlephAlphaClient error: {e}"
+            return TokenizationRequestResult(error=error, success=False, cached=False, text="", tokens=[])
+
+        tokens = response["token_ids" if request.encode else "tokens"]
+        if request.truncation:
+            tokens = tokens[: request.max_length]
+
+        return TokenizationRequestResult(
+            success=True,
+            cached=cached,
+            tokens=[TokenizationToken(value) for value in tokens],
+            text=request.text,
+            request_time=response["request_time"],
+        )
+
+    def decode(self, request: DecodeRequest) -> DecodeRequestResult:
+        """Make a request following https://docs.aleph-alpha.com/api/detokenize."""
+        raw_request = {
+            "model": request.tokenizer_name,
+            "token_ids": request.tokens,
+        }
+
+        try:
+
+            def do_it():
+                result = self._send_request(AlephAlphaClient.DETOKENIZE_ENDPOINT, raw_request)
+                assert "result" in result, f"Invalid response: {result}"
+                return result
+
+            response, cached = self.cache.get(raw_request, wrap_request_time(do_it))
+        except (requests.exceptions.RequestException, AssertionError) as e:
+            error: str = f"AlephAlphaClient error: {e}"
+            return DecodeRequestResult(error=error, success=False, cached=False, text="")
+
+        return DecodeRequestResult(
+            success=True,
+            cached=cached,
+            # The text always seems to start with a single whitespace when encoding/decoding.
+            text=response["result"].replace(" ", "", 1),
+            request_time=response["request_time"],
+        )

--- a/src/helm/proxy/clients/auto_client.py
+++ b/src/helm/proxy/clients/auto_client.py
@@ -16,6 +16,7 @@ from helm.common.tokenization_request import (
 from helm.proxy.retry import retry_request
 from .client import Client
 from .ai21_client import AI21Client
+from .aleph_alpha_client import AlephAlphaClient
 from .anthropic_client import AnthropicClient
 from .cohere_client import CohereClient
 from .together_client import TogetherClient
@@ -61,6 +62,8 @@ class AutoClient(Client):
                 client = OpenAIClient(
                     api_key=self.credentials["openaiApiKey"], cache_config=cache_config, org_id=org_id
                 )
+            elif organization == "AlephAlpha":
+                client = AlephAlphaClient(api_key=self.credentials["alephAlphaKey"], cache_config=cache_config)
             elif organization == "ai21":
                 client = AI21Client(api_key=self.credentials["ai21ApiKey"], cache_config=cache_config)
             elif organization == "cohere":
@@ -136,6 +139,8 @@ class AutoClient(Client):
                 "openai",
             ]:
                 client = HuggingFaceClient(cache_config=cache_config)
+            elif organization == "AlephAlpha":
+                client = AlephAlphaClient(api_key=self.credentials["alephAlphaKey"], cache_config=cache_config)
             elif organization == "TsinghuaKEG":
                 client = ICETokenizerClient(cache_config=cache_config)
             elif organization == "Yandex":

--- a/src/helm/proxy/models.py
+++ b/src/helm/proxy/models.py
@@ -3,6 +3,7 @@ from typing import List, Dict, Optional
 
 # Different modalities
 TEXT_MODEL_TAG: str = "text"
+IMAGE_MODEL_TAG: str = "image"
 CODE_MODEL_TAG: str = "code"
 EMBEDDING_MODEL_TAG: str = "embedding"
 
@@ -120,6 +121,42 @@ ALL_MODELS = [
         description="Jurassic J1-Large (7.5B parameters)",
         tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG, AI21_TOKENIZER_TAG],
     ),
+    # Aleph Alpha's Luminous models: https://docs.aleph-alpha.com/docs/introduction/luminous
+    # TODO: Follow up on the number of parameters. Exact sizes are not available on their website.
+    Model(
+        group="luminous",
+        creator_organization="Aleph Alpha",
+        name="AlephAlpha/luminous-base",
+        display_name="Luminous Base",
+        description="Luminous Base",
+        tags=[TEXT_MODEL_TAG, IMAGE_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
+    ),
+    Model(
+        group="luminous",
+        creator_organization="Aleph Alpha",
+        name="AlephAlpha/luminous-extended",
+        display_name="Luminous Extended",
+        description="Luminous Extended",
+        tags=[TEXT_MODEL_TAG, IMAGE_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
+    ),
+    Model(
+        group="luminous",
+        creator_organization="Aleph Alpha",
+        name="AlephAlpha/luminous-supreme",
+        display_name="Luminous Supreme",
+        description="Luminous Supreme",
+        # Does not support multimodality
+        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
+    ),
+    # TODO: coming soon. Uncomment out the following when Luminous World is released.
+    # Model(
+    #     group="luminous",
+    #     creator_organization="Aleph Alpha",
+    #     name="AlephAlpha/luminous-world",
+    #     display_name="Luminous World",
+    #     description="Luminous World",
+    #     tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
+    # ),
     # Anthropic
     Model(
         group="anthropic",


### PR DESCRIPTION
## Luminous API

The Luminous API supports both encoding and decoding for tokenization. 

## Luminous Models

- Luminous Base (multimodal)
- Luminous Extended (multimodal)
- Luminous Supreme (text only)
- Luminous World (coming soon)

I tested the base model with BoolQ, but we need further testing.

## To follow up on

- [ ] Are the `tokenize` and `detokenize` endpoints free to use?
- [ ]  Is `echo` (prompt is echoed in the completion, and we get log probs for the prompt) supported? If it’s not currently supported, what would be the best way to get log probs for both tokens in the prompt and completion (used for language modeling tasks)?
- [ ]  According to the documentation, it sounds like `maximum_tokens` can be up to 2048, but is 2048 including the prompt? If it’s not including the prompt, how long can prompts be? 
- [ ] Are images always 144 tokens?
- [ ]  Are images supported for the Supreme model? The pricing page makes it look like it is supported: [https://www.aleph-alpha.com/pricing](https://www.aleph-alpha.com/pricingm), but can’t send a request with an image through the playground. 
- [ ] How large are these models in terms of the number of parameters?