### PR TITLE
Display predictions from all trials

### DIFF
--- a/src/helm/benchmark/static/benchmarking.js
+++ b/src/helm/benchmark/static/benchmarking.js
@@ -537,7 +537,6 @@ $(function () {
 
       // Traverse into the prediction div within the instance div
       const $instance = $instanceDiv.find('.prediction');
-      $instance.empty();
 
       // For adapter method = separate, don't show the calibration requests
       if (requestState.request_mode === 'calibration') {


### PR DESCRIPTION
Previously, only the latest trial was displayed.

Fixes #1211