### PR TITLE
Add detailed calibration metrics

### DIFF
--- a/src/helm/benchmark/presentation/schema.py
+++ b/src/helm/benchmark/presentation/schema.py
@@ -176,6 +176,9 @@ class RunGroup(Field):
     # groups for each metric (BY_METRIC)
     subgroup_display_mode: str = BY_METRIC
 
+    # Any subgroup metric groups we want to hide (e.g., robustness when running without perturbations)
+    subgroup_metric_groups_hidden: List[str] = field(default_factory=list)
+
     # Defines variables that are substituted in any of the metrics
     environment: Dict[str, str] = field(default_factory=dict)
 

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -25,7 +25,16 @@ from helm.benchmark.metrics.metric import get_all_stats_by_name
 from helm.benchmark.metrics.statistic import Stat, merge_stat
 from helm.benchmark.runner import RunSpec
 from .table import Cell, HeaderCell, Table, Hyperlink, table_to_latex
-from .schema import MetricNameMatcher, RunGroup, read_schema, SCHEMA_YAML_FILENAME, BY_GROUP, THIS_GROUP_ONLY, NO_GROUPS
+from .schema import (
+    MetricNameMatcher,
+    RunGroup,
+    read_schema,
+    SCHEMA_YAML_FILENAME,
+    BY_GROUP,
+    THIS_GROUP_ONLY,
+    NO_GROUPS,
+    UP_ARROW,
+)
 from .contamination import read_contamination, validate_contamination, CONTAMINATION_SYMBOLS, CONTAMINATION_STYLES
 from .run_display import write_run_display_json
 
@@ -577,13 +586,13 @@ class Summarizer:
                 if sub_split is not None:
                     matcher = replace(matcher, sub_split=sub_split)
                 header_field = self.schema.name_to_metric.get(matcher.name)
+                if header_field is None:
+                    hlog(f"WARNING: metric name {matcher.name} undefined in {SCHEMA_YAML_FILENAME}, skipping")
+                    continue
                 metadata = {
                     "metric": header_field.get_short_display_name(),
                     "run_group": run_group.get_short_display_name(),
                 }
-                if header_field is None:
-                    hlog(f"WARNING: metric name {matcher.name} undefined in {SCHEMA_YAML_FILENAME}, skipping")
-                    continue
 
                 header_name = header_field.get_short_display_name(arrow=True)
                 description = (run_group.description + "\n\n" if run_group.description is not None else "") + (
@@ -737,7 +746,8 @@ class Summarizer:
             AVERAGE_WIN_RATE_COLUMN = 1
             description = "How many models this model outperform on average (over columns)."
             table.header.insert(
-                AVERAGE_WIN_RATE_COLUMN, HeaderCell("Average win rate", description=description, lower_is_better=False)
+                AVERAGE_WIN_RATE_COLUMN,
+                HeaderCell(f"Average win rate {UP_ARROW}", description=description, lower_is_better=False),
             )
             for row, win_rate in zip(table.rows, win_rates):
                 row.insert(AVERAGE_WIN_RATE_COLUMN, Cell(win_rate))

--- a/src/helm/benchmark/static/schema.yaml
+++ b/src/helm/benchmark/static/schema.yaml
@@ -1198,6 +1198,20 @@ run_groups:
       - model
       - max_tokens
 
+  - name: calibration
+    display_name: Calibration
+    description: Extended calibration metrics.
+    category: Targeted evaluations
+    subgroups:
+      - imdb
+      - mmlu
+    metric_groups:
+      - calibration_detailed
+      - accuracy
+    environment:  # need to specify an environment for metric placeholders ("none" won't match anything)
+      main_name: none
+      main_split: none
+
 ### Ablations
   - name: ablation_in_context
     display_name: Vary number of in-context examples
@@ -1212,6 +1226,9 @@ run_groups:
     adapter_keys_shown:
       - model
       - max_train_instances
+    subgroup_metric_groups_hidden:
+      - robustness
+      - fairness
 
   - name: ablation_multiple_choice
     display_name: Vary multiple-choice strategy

--- a/src/helm/benchmark/static/schema.yaml
+++ b/src/helm/benchmark/static/schema.yaml
@@ -919,6 +919,14 @@ metric_groups:
         split: ${main_split}
       - name: selective_acc@10
         split: ${main_split}
+      - name: platt_ece_1_bin
+        split: ${main_split}
+      - name: platt_ece_10_bin
+        split: ${main_split}
+      - name: platt_coef
+        split: ${main_split}
+      - name: platt_intercept
+        split: ${main_split}
 
   - name: robustness
     display_name: Robustness
@@ -1246,8 +1254,10 @@ run_groups:
     description: Extended calibration metrics.
     category: Targeted evaluations
     subgroups:
-      - imdb
       - mmlu
+      - imdb
+      - raft
+      - civil_comments
     metric_groups:
       - calibration_detailed
       - accuracy


### PR DESCRIPTION
Added a "targeted evaluation" for calibration where we display additional metrics for some scenarios.

In terms of infrastructure:
- Added logic to handle the `_detailed` metric groups (e.g., `calibration_detailed`).
- Allowed `RunGroup`s to specify `metric_groups` that override those of subgroups. This allows us to use the detailed version of a metric group without needing to specify scenario groups again.
- Orthogonal: Added a `subgroup_metric_groups_hidden` list that allows us to hide some metric groups (e.g., since we run some ablations without perturbations, we hide Robustness there).

In terms of annotation in `schema.yaml`, I was not sure about the following (cc @AnanyaKumar @rishibommasani)
- Which calibration metrics we want, see `calibration_detailed`
- Which scenarios we want to look at, see the "Calibration" targeted evaluation

Resolves #1125 .