### PR TITLE
Fix BBQ: `AttributeError: 'BBQScenario' object has no attribute 'definition_path'`

### DIFF
--- a/src/helm/benchmark/scenarios/bbq_scenario.py
+++ b/src/helm/benchmark/scenarios/bbq_scenario.py
@@ -67,6 +67,7 @@ class BBQScenario(Scenario):
     tags = ["harms", "bias"]
 
     def __init__(self, subject: str = "all"):
+        super().__init__()
         self.subject = subject
 
     def get_instances(self) -> List[Instance]:


### PR DESCRIPTION
Resolves https://github.com/stanford-crfm/helm/issues/1235