### PR TITLE
Write run_specs.json in helm-summarize instead of helm-run

### DIFF
--- a/src/helm/benchmark/presentation/present.py
+++ b/src/helm/benchmark/presentation/present.py
@@ -225,13 +225,6 @@ def main():
         help="Run RunSpecs with priority less than or equal to this number. "
         "If a value for --priority is not specified, run on everything",
     )
-    parser.add_argument(
-        "--skip-run-specs-json",
-        action="store_true",
-        default=None,
-        help="Skip generating run_specs.json "
-        "(do this when you're running a subset of the scenarios/models in parallel).",
-    )
     add_run_args(parser)
     args = parser.parse_args()
     validate_args(args)

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -286,8 +286,8 @@ class Summarizer:
         """Load the runs in the run suite path."""
         self.runs: List[Run] = []
         # run_suite_path can contain subdirectories that are not runs (e.g. eval_cache, groups)
-        # so filter them out by checking if they contain ":", which only run subdirectories should have
-        run_dir_names = sorted([p for p in os.listdir(self.run_suite_path) if ":" in p])
+        # so filter them out.
+        run_dir_names = sorted([p for p in os.listdir(self.run_suite_path) if p != "eval_cache" and p != "groups"])
         for run_dir_name in tqdm(run_dir_names):
             run_spec_path: str = os.path.join(self.run_suite_path, run_dir_name, "run_spec.json")
             stats_path: str = os.path.join(self.run_suite_path, run_dir_name, "stats.json")


### PR DESCRIPTION
This avoids `run_specs.json` getting overwritten repeatedly if `helm-run` is run multiple times with different run specs.

Fixes #1222.