### PR TITLE
Respect sort order of default sort column

### DIFF
--- a/src/helm/benchmark/static/benchmarking.js
+++ b/src/helm/benchmark/static/benchmarking.js
@@ -1080,14 +1080,17 @@ $(function () {
     $output.append($('<h3>').append($('<a>', {name: table.title}).append(table.title)));
     const $table = $('<table>', {class: 'query-table results-table'});
     let sortColumnIndex = undefined;
+    let sortOrder = undefined;
     for (let i = 0; i < table.header.length; i++) {
       if (table.header[i].lower_is_better !== undefined) {
         sortColumnIndex = i;
+        sortOrder = table.header[i].lower_is_better === false ? "desc" :
+          (table.header[i].lower_is_better === true ? "asc" : undefined);
         break;
       }
     }
     $table.append(renderTableHeader(table, sortColumnIndex));
-    $table.append(renderTableBody(table, sortColumnIndex));
+    table.append(renderTableBody(table, sortColumnIndex, sortOrder));
     $output.append($table);
 
     // Links


### PR DESCRIPTION
Fixes a bug in #1287 where by default, the sort column values would be sorted in descending order. This respects the sort order of the column instead.
Addresses #832

This change was already made on the live website as a hotfix during the v0.2.0 release, so this is a backport.