### PR TITLE
Use dataclasses instead of JSON in run_display

### DIFF
--- a/src/helm/benchmark/presentation/run_display.py
+++ b/src/helm/benchmark/presentation/run_display.py
@@ -9,10 +9,10 @@ import dacite
 from helm.benchmark.adaptation.adapters.adapter_factory import (
     ADAPT_MULTIPLE_CHOICE_SEPARATE_METHODS,
     ADAPT_MULTIPLE_CHOICE_SEPARATE_CALIBRATED,
-    RequestState,
-    ScenarioState,
 )
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
+from helm.benchmark.adaptation.request_state import RequestState
+from helm.benchmark.adaptation.scenario_state import ScenarioState
 from helm.benchmark.augmentations.dialect_perturbation import DialectPerturbation
 from helm.benchmark.augmentations.extra_space_perturbation import ExtraSpacePerturbation
 from helm.benchmark.augmentations.filler_words_perturbation import FillerWordsPerturbation
@@ -136,7 +136,7 @@ def _truncate_predicted_text(
     method = adapter_spec.method
     prefix = ""
     if method in ADAPT_MULTIPLE_CHOICE_SEPARATE_METHODS:
-        prefix = request_state.instance.input
+        prefix = request_state.instance.input.text
     elif method == "language_modeling":
         if request_state.result is not None and request_state.result.completions:
             tokens = request_state.result.completions[0].tokens

--- a/src/helm/benchmark/presentation/run_display.py
+++ b/src/helm/benchmark/presentation/run_display.py
@@ -2,13 +2,15 @@ from collections import OrderedDict, defaultdict
 from dataclasses import dataclass
 import os
 import json
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, cast
+from typing import Dict, Iterable, List, Optional, Set, Tuple
 
 import dacite
 
 from helm.benchmark.adaptation.adapters.adapter_factory import (
     ADAPT_MULTIPLE_CHOICE_SEPARATE_METHODS,
     ADAPT_MULTIPLE_CHOICE_SEPARATE_CALIBRATED,
+    RequestState,
+    ScenarioState,
 )
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.augmentations.dialect_perturbation import DialectPerturbation
@@ -21,8 +23,10 @@ from helm.benchmark.augmentations.perturbation_description import PerturbationDe
 from helm.benchmark.augmentations.space_perturbation import SpacePerturbation
 from helm.benchmark.augmentations.synonym_perturbation import SynonymPerturbation
 from helm.benchmark.augmentations.typos_perturbation import TyposPerturbation
+from helm.benchmark.metrics.metric import PerInstanceStats
 from helm.benchmark.presentation.schema import Schema
 from helm.benchmark.runner import RunSpec
+from helm.benchmark.scenarios.scenario import Instance
 from helm.common.general import asdict_without_nones, write
 from helm.common.hierarchical_logger import htrack
 from helm.common.request import Request
@@ -42,7 +46,7 @@ _PERTURBATION_NAME_TO_DESCRIPTION = {
 }
 
 
-def _deserialize_perturbation_description(raw_perturbation_description: Dict[Any, Any]) -> PerturbationDescription:
+def _deserialize_perturbation_description(raw_perturbation_description: Dict) -> PerturbationDescription:
     """Convert a raw dictionary to a PerturbationDescription.
     This uses the name field to look up the correct PerturbationDescription subclass to output.
     """
@@ -108,36 +112,38 @@ class DisplayRequest:
     most relevant request e.g. the request for the chosen cohice for multiple choice questions."""
 
 
-def _read_scenario_state(run_path: str) -> Dict:
+def _read_scenario_state(run_path: str) -> ScenarioState:
     scenario_state_path: str = os.path.join(run_path, "scenario_state.json")
     if not os.path.exists(scenario_state_path):
         raise ValueError(f"Could not load ScenarioState from {scenario_state_path}")
     with open(scenario_state_path) as f:
         raw_scenario_state = json.load(f)
-        return raw_scenario_state
+        return dacite.from_dict(ScenarioState, raw_scenario_state, config=_DACITE_CONFIG)
 
 
-def _read_per_instance_stats(run_path: str) -> List[Dict]:
+def _read_per_instance_stats(run_path: str) -> List[PerInstanceStats]:
     per_instance_stats_path: str = os.path.join(run_path, "per_instance_stats.json")
     if not os.path.exists(per_instance_stats_path):
         raise ValueError(f"Could not load PerInstanceStats from {per_instance_stats_path}")
     with open(per_instance_stats_path) as f:
         raw_per_instance_stats = json.load(f)
-        return raw_per_instance_stats
+        return [dacite.from_dict(PerInstanceStats, r, config=_DACITE_CONFIG) for r in raw_per_instance_stats]
 
 
-def _truncate_predicted_text(predicted_text: str, request_state: Dict, adapter_spec: AdapterSpec) -> Optional[str]:
+def _truncate_predicted_text(
+    predicted_text: str, request_state: RequestState, adapter_spec: AdapterSpec
+) -> Optional[str]:
     method = adapter_spec.method
     prefix = ""
     if method in ADAPT_MULTIPLE_CHOICE_SEPARATE_METHODS:
-        prefix = request_state["instance"]["input"]
+        prefix = request_state.instance.input
     elif method == "language_modeling":
-        if "result" in request_state and "completions" in request_state["result"]:
-            tokens = request_state["result"]["completions"][0]["tokens"]
+        if request_state.result is not None and request_state.result.completions:
+            tokens = request_state.result.completions[0].tokens
             if tokens:
                 first_token = tokens[0]
-                if not first_token.get("top_logprobs"):
-                    prefix = first_token["text"]
+                if not first_token.top_logprobs:
+                    prefix = first_token.text
     if prefix:
         predicted_text = predicted_text
         prefix = prefix
@@ -202,46 +208,39 @@ def write_run_display_json(run_path: str, run_spec: RunSpec, schema: Schema):
     stats_by_trial: Dict[Tuple[str, Optional[PerturbationDescription], int], Dict[str, float]] = defaultdict(dict)
     for original_stats in per_instance_stats:
         stats_dict: Dict[str, float] = {
-            original_stat["name"]["name"]: cast(float, original_stat["mean"])
-            for original_stat in original_stats["stats"]
-            if original_stat["name"]["name"] in metric_names and "mean" in original_stat
+            original_stat.name.name: original_stat.mean
+            for original_stat in original_stats.stats
+            if original_stat.name.name in metric_names and original_stat.mean is not None
         }
 
         key = (
-            original_stats["instance_id"],
-            _deserialize_perturbation_description(original_stats["perturbation"])
-            if "perturbation" in original_stats
-            else None,
-            original_stats["train_trial_index"],
+            original_stats.instance_id,
+            original_stats.perturbation,
+            original_stats.train_trial_index,
         )
         stats_by_trial[key].update(stats_dict)
 
-    instance_id_to_instance: Dict[Tuple[str, Optional[PerturbationDescription]], Dict] = OrderedDict()
+    instance_id_to_instance: Dict[Tuple[str, Optional[PerturbationDescription]], Instance] = OrderedDict()
     predictions: List[DisplayPrediction] = []
     requests: List[DisplayRequest] = []
 
-    for request_state in scenario_state["request_states"]:
-        assert "id" in request_state["instance"]["id"]
-        if "result" not in request_state:
+    for request_state in scenario_state.request_states:
+        assert request_state.instance.id is not None
+        if request_state.result is None:
             continue
 
         # For the multiple_choice_separate_calibrated adapter method,
         # only keep the original prediction and discard the calibration prediction.
         if (
             run_spec.adapter_spec.method == ADAPT_MULTIPLE_CHOICE_SEPARATE_CALIBRATED
-            and request_state["request_mode"] == "calibration"
+            and request_state.request_mode == "calibration"
         ):
             continue
 
-        perturbation = (
-            _deserialize_perturbation_description(request_state["instance"]["perturbation"])
-            if "instance" in request_state and "perturbation" in request_state["instance"]
-            else None
-        )
         stats_key = (
-            request_state["instance"]["id"],
-            perturbation,
-            request_state["train_trial_index"],
+            request_state.instance.id,
+            request_state.instance.perturbation,
+            request_state.train_trial_index,
         )
         trial_stats: Dict[str, float] = stats_by_trial[stats_key]
         # For the multiple_choice_separate_* adapter methods,
@@ -249,46 +248,45 @@ def write_run_display_json(run_path: str, run_spec: RunSpec, schema: Schema):
         if (
             run_spec.adapter_spec.method in ADAPT_MULTIPLE_CHOICE_SEPARATE_METHODS
             and "predicted_index" in trial_stats
-            and trial_stats["predicted_index"] != request_state["reference_index"]
+            and trial_stats["predicted_index"] != request_state.reference_index
         ):
             continue
 
         predicted_text = (
-            request_state["result"]["completions"][0]["text"]
-            if "result" in request_state
-            and "completions" in request_state["result"]
-            and request_state["result"]["completions"]
+            request_state.result.completions[0].text
+            if request_state.result is not None and request_state.result.completions
             else ""
         )
         mapped_output = (
-            request_state["output_mapping"].get(predicted_text.strip()) if "output_mapping" in request_state else None
+            request_state.output_mapping.get(predicted_text.strip()) if request_state.output_mapping else None
         )
-
-        instance_id_to_instance[(cast(str, request_state["instance"]["id"]), perturbation)] = request_state["instance"]
+        instance_id_to_instance[
+            (request_state.instance.id, request_state.instance.perturbation)
+        ] = request_state.instance
         predictions.append(
             DisplayPrediction(
-                instance_id=request_state["instance"]["id"],
-                perturbation=perturbation,
-                train_trial_index=request_state["train_trial_index"],
+                instance_id=request_state.instance.id,
+                perturbation=request_state.instance.perturbation,
+                train_trial_index=request_state.train_trial_index,
                 predicted_text=predicted_text,
                 truncated_predicted_text=_truncate_predicted_text(predicted_text, request_state, run_spec.adapter_spec),
                 mapped_output=mapped_output,
-                reference_index=request_state.get("reference_index"),
+                reference_index=request_state.reference_index,
                 stats=trial_stats,
             )
         )
         requests.append(
             DisplayRequest(
-                instance_id=request_state["instance"]["id"],
-                perturbation=perturbation,
-                train_trial_index=request_state["train_trial_index"],
-                request=request_state["request"],
+                instance_id=request_state.instance.id,
+                perturbation=request_state.instance.perturbation,
+                train_trial_index=request_state.train_trial_index,
+                request=request_state.request,
             )
         )
 
     write(
         os.path.join(run_path, "instances.json"),
-        json.dumps(list(instance_id_to_instance.values()), indent=2),
+        json.dumps(list(map(asdict_without_nones, instance_id_to_instance.values())), indent=2),
     )
     write(
         os.path.join(run_path, "display_predictions.json"),


### PR DESCRIPTION
Dataclasses are more readable and maintainable. Partially reverts #1256, which was made for performance reasons. A subsequent PR will reimplement deserialization in a more performant way.