### PR TITLE
Upgrade revChatGPT dependency

### DIFF
--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -109,7 +109,7 @@ regex==2022.9.13
 requests==2.28.1
 responses==0.18.0
 retrying==1.3.3
-revChatGPT==0.0.48.2
+revChatGPT==0.1.1
 rouge-score==0.1.2
 rsa==4.9
 s3transfer==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ transformers~=4.22.2  # For HuggingFace tokenizer
 icetk~=0.0.4
 protobuf~=3.20.2  # Can't use 4.21.0 due to backward incompatibility
 google-api-python-client~=2.64.0
-revChatGPT~=0.0.48.2
+revChatGPT~=0.1.1
 
 # Scenarios
 datasets~=2.5.2  # For math scenarios


### PR DESCRIPTION
The current version transitively depends on the `tls-client-for-chatGPT` package, which no longer exists.