### PR TITLE
Add classification metrics

### DIFF
--- a/src/helm/benchmark/__init__.py
+++ b/src/helm/benchmark/__init__.py
@@ -57,6 +57,7 @@ from .scenarios import wmt_14_scenario  # noqa
 from .metrics import basic_metrics  # noqa
 from .metrics import bbq_metrics  # noqa
 from .metrics import bias_metrics  # noqa
+from .metrics import classification_metrics  # noqa
 from .metrics import code_metrics  # noqa
 from .metrics import copyright_metrics  # noqa
 from .metrics import disinformation_metrics  # noqa

--- a/src/helm/benchmark/metrics/classification_metrics.py
+++ b/src/helm/benchmark/metrics/classification_metrics.py
@@ -1,0 +1,47 @@
+from typing import List, Set
+
+from sklearn.metrics import f1_score
+
+from helm.benchmark.adaptation.request_state import RequestState
+from helm.benchmark.metrics.basic_metrics import normalize_text
+from helm.benchmark.metrics.metric import Metric, MetricName
+from helm.benchmark.metrics.statistic import Stat
+
+
+class ClassificationMetric(Metric):
+    def evaluate_instances(self, request_states: List[RequestState]) -> List[Stat]:
+        normalized_labels: Set[str] = set()
+        y_pred: List[str] = []
+        y_true: List[str] = []
+        for request_state in request_states:
+            # Only the generation adapter is supported.
+            # TODO: Support multiple_choice_* adapters.
+            if request_state.reference_index is not None:
+                raise ValueError("ClassificationMetric does not support multiple choice separate adapters")
+            if request_state.request_mode == "calibration":
+                raise ValueError("ClassificationMetric does not support calibration requests")
+            assert request_state.result is not None
+            if len(request_state.result.completions) != 1:
+                raise ValueError("Result must contain exactly one completion")
+
+            num_correct = 0
+            for reference in request_state.instance.references:
+                normalized_labels.add(normalize_text(reference.output.text))
+                if reference.is_correct:
+                    num_correct += 1
+                    y_true.append(normalize_text(reference.output.text))
+            if num_correct != 1:
+                # TODO: Support multi-label classification.
+                raise ValueError("ClassificationMetric does not support multi-label classification")
+            if request_state.output_mapping is not None:
+                raise ValueError("ClassificationMetric does not support multiple choice adapters")
+            y_pred.append(normalize_text(request_state.result.completions[0].text))
+        # TODO: Support F1 on perturbation slices.
+        return [
+            Stat(MetricName("classification_macro_f1")).add(
+                f1_score(y_pred=y_pred, y_true=y_true, labels=list(normalized_labels), average="macro")
+            ),
+            Stat(MetricName("classification_micro_f1")).add(
+                f1_score(y_pred=y_pred, y_true=y_true, labels=list(normalized_labels), average="micro")
+            ),
+        ]

--- a/src/helm/benchmark/metrics/classification_metrics.py
+++ b/src/helm/benchmark/metrics/classification_metrics.py
@@ -33,7 +33,7 @@ class ClassificationMetric(Metric):
             if num_correct != 1:
                 # TODO: Support multi-label classification.
                 raise ValueError("ClassificationMetric does not support multi-label classification")
-            if request_state.output_mapping is not None:
+            if request_state.output_mapping:
                 raise ValueError("ClassificationMetric does not support multiple choice adapters")
             y_pred.append(normalize_text(request_state.result.completions[0].text))
         # TODO: Support F1 on perturbation slices.

--- a/src/helm/benchmark/metrics/classification_metrics.py
+++ b/src/helm/benchmark/metrics/classification_metrics.py
@@ -1,4 +1,4 @@
-from typing import List, Set
+from typing import List
 
 from sklearn.metrics import f1_score
 
@@ -9,8 +9,27 @@ from helm.benchmark.metrics.statistic import Stat
 
 
 class ClassificationMetric(Metric):
+    """Defines metrics for multi-class classification using the generation adapter.
+
+    Currently provides `classification_macro_f1` and `classification_micro_f1`.
+    These are population-level F1 measures to measure classification performance where each
+    generation is a predicted class, and are different from the instance-level F1 measures
+    in `BasicMetrics` that are intended to measure word overlap between the correct references
+    and generations. The correct class should be provided by the normalized text of a correct
+    reference. The predicted class for each instance is the normalized text of the generation.
+
+    Note:
+    - The set of classes is derived from the correct references from all the instances.
+      This means that classes may be omitted if they never are never used as a correct
+      reference.
+    - Generations that are not in any of the known classes are counted as a
+      negative prediction for every class.
+    - Perturbed classes are considered different classes from unperturbed
+      classes.
+    - Currently, multi-label classification is not supported.
+    """
+
     def evaluate_instances(self, request_states: List[RequestState]) -> List[Stat]:
-        normalized_labels: Set[str] = set()
         y_pred: List[str] = []
         y_true: List[str] = []
         for request_state in request_states:
@@ -26,7 +45,6 @@ class ClassificationMetric(Metric):
 
             num_correct = 0
             for reference in request_state.instance.references:
-                normalized_labels.add(normalize_text(reference.output.text))
                 if reference.is_correct:
                     num_correct += 1
                     y_true.append(normalize_text(reference.output.text))
@@ -36,12 +54,12 @@ class ClassificationMetric(Metric):
             if request_state.output_mapping:
                 raise ValueError("ClassificationMetric does not support multiple choice adapters")
             y_pred.append(normalize_text(request_state.result.completions[0].text))
-        # TODO: Support F1 on perturbation slices.
+        labels = list(set(y_true))
         return [
             Stat(MetricName("classification_macro_f1")).add(
-                f1_score(y_pred=y_pred, y_true=y_true, labels=list(normalized_labels), average="macro")
+                f1_score(y_pred=y_pred, y_true=y_true, labels=list(labels), average="macro")
             ),
             Stat(MetricName("classification_micro_f1")).add(
-                f1_score(y_pred=y_pred, y_true=y_true, labels=list(normalized_labels), average="micro")
+                f1_score(y_pred=y_pred, y_true=y_true, labels=list(labels), average="micro")
             ),
         ]

--- a/src/helm/benchmark/metrics/test_classification_metrics.py
+++ b/src/helm/benchmark/metrics/test_classification_metrics.py
@@ -1,0 +1,115 @@
+from collections import defaultdict
+from typing import Dict, List, NamedTuple
+
+from pytest import approx
+
+from helm.benchmark.adaptation.request_state import RequestState
+from helm.benchmark.metrics.classification_metrics import ClassificationMetric
+from helm.benchmark.metrics.statistic import Stat
+from helm.benchmark.scenarios.scenario import Input, Instance, Output, Reference, CORRECT_TAG
+from helm.common.request import Request, RequestResult, Sequence
+
+
+class _Option(NamedTuple):
+    text: str
+    is_correct: bool
+
+
+def _request_state(prediction: str, options: List[_Option]):
+    references = [
+        Reference(output=Output(text=option.text), tags=[CORRECT_TAG] if option.is_correct else [])
+        for option in options
+    ]
+    return RequestState(
+        instance=Instance(input=Input(text=""), references=references),
+        reference_index=None,
+        request_mode=None,
+        train_trial_index=0,
+        output_mapping={},
+        request=Request(),
+        result=RequestResult(
+            success=True, embedding=[], completions=[Sequence(text=prediction, logprob=0.0, tokens=[])], cached=False
+        ),
+        num_train_instances=0,
+        prompt_truncated=False,
+    )
+
+
+def assert_stats_equal(actual_stats: List[Stat], expected_values: Dict[str, float]):
+    actual_values = {stat.name.name: stat.mean for stat in actual_stats}
+    assert actual_values == approx(expected_values)
+
+
+def _expected_stats(all_classes_counts: Dict[str, Dict[str, int]]):
+    micro_counts: Dict[str, int] = defaultdict(int)
+    for class_counts in all_classes_counts.values():
+        for key, class_count in class_counts.items():
+            micro_counts[key] += class_count
+    micro_precision = micro_counts["tp"] / (micro_counts["tp"] + micro_counts["fp"])
+    micro_recall = micro_counts["tp"] / (micro_counts["tp"] + micro_counts["fn"])
+    micro_f1 = 2 * (micro_precision * micro_recall) / (micro_precision + micro_recall)
+
+    class_f1: List[float] = []
+    for class_counts in all_classes_counts.values():
+        class_precision = class_counts["tp"] / (class_counts["tp"] + class_counts["fp"])
+        class_recall = class_counts["tp"] / (class_counts["tp"] + class_counts["fn"])
+        class_f1.append(2 * (class_precision * class_recall) / (class_precision + class_recall))
+    macro_f1 = sum(class_f1) / len(class_f1)
+
+    return {
+        "classification_micro_f1": micro_f1,
+        "classification_macro_f1": macro_f1,
+    }
+
+
+def test_evaluate_instances_binary_generation():
+    metric = ClassificationMetric()
+    request_states = [
+        _request_state("yes", [_Option("yes", True)]),
+        _request_state("yes", [_Option("yes", True)]),
+        _request_state("yes", [_Option("yes", True)]),
+        _request_state("yes", [_Option("no", True)]),
+        _request_state("no", [_Option("yes", True)]),
+        _request_state("no", [_Option("no", True)]),
+        _request_state("invalid", [_Option("no", True)]),
+    ]
+
+    assert_stats_equal(
+        metric.evaluate_instances(request_states),
+        _expected_stats(
+            {
+                "yes": {"tp": 3, "fp": 1, "tn": 2, "fn": 1},
+                "no": {"tp": 1, "fp": 1, "tn": 3, "fn": 2},
+            }
+        ),
+    )
+
+
+def test_evaluate_instances_multi_class():
+    metric = ClassificationMetric()
+
+    def _options(correct: str):
+        return [_Option(text, text == correct) for text in ["a", "b", "c"]]
+
+    request_states = [
+        _request_state("a", _options("a")),
+        _request_state("a", _options("a")),
+        _request_state("a", _options("a")),
+        _request_state("a", _options("b")),
+        _request_state("b", _options("b")),
+        _request_state("b", _options("b")),
+        _request_state("b", _options("c")),
+        _request_state("c", _options("a")),
+        _request_state("c", _options("c")),
+        _request_state("invalid", _options("c")),
+    ]
+    assert_stats_equal(
+        metric.evaluate_instances(request_states),
+        _expected_stats(
+            {
+                "a": {"tp": 3, "fp": 1, "tn": 5, "fn": 1},
+                "b": {"tp": 2, "fp": 1, "tn": 6, "fn": 1},
+                "c": {"tp": 1, "fp": 1, "tn": 6, "fn": 2},
+            }
+        ),
+    )

--- a/src/helm/benchmark/metrics/test_classification_metrics.py
+++ b/src/helm/benchmark/metrics/test_classification_metrics.py
@@ -25,7 +25,7 @@ def _request_state(prediction: str, options: List[_Option]):
         reference_index=None,
         request_mode=None,
         train_trial_index=0,
-        output_mapping={},
+        output_mapping=None,
         request=Request(),
         result=RequestResult(
             success=True, embedding=[], completions=[Sequence(text=prediction, logprob=0.0, tokens=[])], cached=False

--- a/src/helm/benchmark/run_specs.py
+++ b/src/helm/benchmark/run_specs.py
@@ -385,6 +385,10 @@ def get_f1_metric_specs() -> List[MetricSpec]:
     return get_basic_metric_specs(["exact_match", "quasi_exact_match", "f1_score"])
 
 
+def get_classification_metric_specs() -> List[MetricSpec]:
+    return [MetricSpec(class_name="helm.benchmark.classification_metrics.ClassificationMetric", args={})]
+
+
 def get_bbq_metric_specs() -> List[MetricSpec]:
     return [MetricSpec(class_name="helm.benchmark.bbq_metrics.BBQMetric", args={})] + get_exact_match_metric_specs()
 
@@ -605,7 +609,9 @@ def get_civil_comments_spec(demographic: str) -> RunSpec:
         name=f"civil_comments:demographic={demographic}",
         scenario_spec=scenario_spec,
         adapter_spec=adapter_spec,
-        metric_specs=get_exact_match_metric_specs() + get_generative_harms_metric_specs(),
+        metric_specs=get_exact_match_metric_specs()
+        + get_generative_harms_metric_specs()
+        + get_classification_metric_specs(),
         groups=["civil_comments"],
     )
 
@@ -850,7 +856,9 @@ def get_raft_spec(subset: str) -> RunSpec:
         name=f"raft:subset={subset}",
         scenario_spec=scenario_spec,
         adapter_spec=adapter_spec,
-        metric_specs=get_exact_match_metric_specs() + get_generative_harms_metric_specs(),
+        metric_specs=get_exact_match_metric_specs()
+        + get_generative_harms_metric_specs()
+        + get_classification_metric_specs(),
         groups=["raft"],
     )
 
@@ -1012,7 +1020,7 @@ def get_imdb_spec(only_contrast=False) -> RunSpec:
         name="imdb" + (":only_contrast=True" if only_contrast else ""),
         scenario_spec=scenario_spec,
         adapter_spec=adapter_spec,
-        metric_specs=get_exact_match_metric_specs(),
+        metric_specs=get_exact_match_metric_specs() + get_classification_metric_specs(),
         groups=["imdb"],
     )
 


### PR DESCRIPTION
Right now this only works for the generation adapter. Also F1 to `raft`, `civil_comments` and `imdb`.

Fixes #1313