### PR TITLE
Bump protobuf version in pre-commit.sh to match requirements-freeze.txt

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -22,7 +22,7 @@ if [[ $OSTYPE != 'darwin'* ]]; then
   pip install --no-cache-dir --find-links https://download.pytorch.org/whl/torch_stable.html torch==1.12.1+cu113 torchvision==0.13.1+cu113
 fi
 # Manually install protobuf to workaround issue: https://github.com/protocolbuffers/protobuf/issues/6550
-pip install --no-binary=protobuf protobuf==3.20.1
+pip install --no-binary=protobuf protobuf==3.20.2
 # Install all pinned dependencies
 pip install -r requirements-freeze.txt
 pip install -e .


### PR DESCRIPTION
This fixes protobuf installation errors.