### PR TITLE
Don't mutate key of HuggingFaceClient cache

### DIFF
--- a/src/helm/proxy/clients/huggingface_client.py
+++ b/src/helm/proxy/clients/huggingface_client.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import torch
 from dataclasses import asdict
 from transformers import AutoModelForCausalLM, AutoTokenizer
@@ -32,7 +33,7 @@ class HuggingFaceServer:
 
     def serve_request(self, raw_request: Dict[str, Any]):
         encoded_input = self.tokenizer(raw_request["prompt"], return_tensors="pt").to(self.device)
-
+        raw_request = deepcopy(raw_request)
         raw_request["do_sample"] = True
         raw_request["return_dict_in_generate"] = True
         raw_request["output_scores"] = True


### PR DESCRIPTION
This fixes a bug that causes cache misses in HuggingFaceClient even when the exact same request is sent multiple times.

This is because `raw_request`, which is [used for the cache key](https://github.com/stanford-crfm/helm/blob/53b163c640a55d442cb3684567513e0132618ed5/src/helm/proxy/clients/huggingface_client.py#L157), is mutated by [the method called by the cache](https://github.com/stanford-crfm/helm/blob/53b163c640a55d442cb3684567513e0132618ed5/src/helm/proxy/clients/huggingface_client.py#L33), causing the cache to store the result under a mutated key rather than the original key provided by the caller..