### PR TITLE
Update the url of the pile dataset

### DIFF
--- a/src/helm/benchmark/scenarios/the_pile_scenario.py
+++ b/src/helm/benchmark/scenarios/the_pile_scenario.py
@@ -78,7 +78,7 @@ class ThePileScenario(Scenario):
         # Download the raw data
         data_path = os.path.join(self.output_path, "data")
         ensure_file_downloaded(
-            source_url="https://mystic.the-eye.eu/public/AI/pile/test.jsonl.zst",
+            source_url="https://the-eye.eu/public/AI/pile/test.jsonl.zst",
             target_path=data_path,
             unpack=True,
         )


### PR DESCRIPTION
The url of the publicly hosted the pile dataset was changed. Update it in the scenario definition to avoid errors in scenario loading.

Fixes #1376