### PR TITLE
Clean up requirements

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -11,11 +11,7 @@ if [ "$valid_version" == "False" ]; then
   exit 1
 fi
 
-# Manually upgrade pip to at least 21.1 to avoid issue #1053
-python -m pip install --upgrade pip
 # If this package is already installed under the deprecated name, uninstall it.
-# TODO: Remove this after 2022-12-01
-pip uninstall -y crfm-benchmarking
 # On Mac OS, skip installing pytorch with CUDA because CUDA is not supported
 if [[ $OSTYPE != 'darwin'* ]]; then
   # Manually install pytorch to avoid pip getting killed: https://stackoverflow.com/a/54329850

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -1,6 +1,8 @@
 2captcha-python==1.1.3
 absl-py==1.2.0
+aiodns==3.0.0
 aiohttp==3.8.3
+aiohttp-retry==2.8.3
 aiosignal==1.2.0
 aleph-alpha-client==2.14.0
 async-generator==1.10
@@ -17,7 +19,8 @@ bottle==0.12.23
 cachetools==5.2.0
 catalogue==2.0.8
 cattrs==22.2.0
-certifi==2022.9.24
+certifi==2022.12.7
+cffi==1.15.1
 cfgv==3.3.1
 charset-normalizer==2.1.1
 click==8.0.4
@@ -101,7 +104,9 @@ psutil==5.9.2
 pyarrow==9.0.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
+pycares==4.3.0
 pycodestyle==2.9.1
+pycparser==2.21
 pydantic==1.8.2
 pyemd==0.5.1
 pyext==0.7
@@ -151,8 +156,10 @@ tls-client==0.1.8
 tokenizers==0.13.2
 toml==0.10.2
 tomli==2.0.1
-torch==1.12.1+cu113
-torchvision==0.13.1+cu113
+torch==1.12.1 ; sys_platform == "darwin"
+torchvision==0.13.1 ; sys_platform == "darwin"
+torch==1.12.1+cu113 ; sys_platform == "linux"
+torchvision==0.13.1+cu113 ; sys_platform == "linux"
 tqdm==4.64.1
 transformers==4.26.1
 trio==0.22.0
@@ -174,6 +181,7 @@ wasabi==0.10.1
 websocket-client==1.3.2
 websockets==10.4
 wsproto==1.2.0
+xlrd==2.0.1
 xxhash==3.0.0
 yarl==1.8.1
 zipp==3.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,18 +6,12 @@
 #
 #   pip freeze | xargs pip uninstall -y
 #   pip install -r requirements.txt
+#   pip install -r requirements-dev.txt
 #   pip freeze | grep -v en-core-web-sm > requirements-freeze.txt
 #
 # Also update the versions in the manual installation steps in pre-commit.sh.
 #
 # Check that everything works because the versions might be upgraded.
-
-# Development
-pytest~=7.2.0
-black~=22.10.0
-mypy~=0.982
-pre-commit~=2.20.0
-flake8~=5.0.4
 
 # Common
 zstandard~=0.18.0
@@ -52,6 +46,7 @@ sympy~=1.11.1  # For math scenarios
 sentencepiece~=0.1.97
 numba~=0.56.4
 cattrs~=22.2.0
+xlrd~=2.0.1  # Used by pandas.read_excel in ice_scenario
 
 # Metrics
 importlib-resources~=5.10.0


### PR DESCRIPTION
- Upgrade certifi for [Dependabot #6](https://github.com/stanford-crfm/helm/security/dependabot/6)
- Fixes #1336: Don't install CUDA on Mac OS X
- Fixes #1362: add xlrd