### PR TITLE
Fix --exit-on-error not working and add --skip-completed-runs

### DIFF
--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -73,6 +73,8 @@ def run_benchmarking(
     suite: str,
     dry_run: bool,
     skip_instances: bool,
+    skip_completed_runs: bool,
+    exit_on_error: bool,
     mongo_uri: str = "",
 ) -> List[RunSpec]:
     """Runs RunSpecs given a list of RunSpec descriptions."""
@@ -89,7 +91,7 @@ def run_benchmarking(
         for run_spec in run_specs:
             hlog(run_spec)
 
-    runner = Runner(execution_spec, output_path, suite, skip_instances)
+    runner = Runner(execution_spec, output_path, suite, skip_instances, skip_completed_runs, exit_on_error)
     runner.run_all(run_specs)
     return run_specs
 
@@ -198,6 +200,12 @@ def main():
         help="Fail and exit immediately if a particular RunSpec fails.",
     )
     parser.add_argument(
+        "--skip-completed-runs",
+        action="store_true",
+        default=None,
+        help="Skip RunSpecs that have completed i.e. output files exists.",
+    )
+    parser.add_argument(
         "--priority",
         type=int,
         default=None,
@@ -242,6 +250,8 @@ def main():
         suite=args.suite,
         dry_run=args.dry_run,
         skip_instances=args.skip_instances,
+        skip_completed_runs=args.skip_completed_runs,
+        exit_on_error=args.exit_on_error,
         mongo_uri=args.mongo_uri,
     )
 

--- a/src/helm/benchmark/runner.py
+++ b/src/helm/benchmark/runner.py
@@ -1,5 +1,6 @@
 import json
 import os
+import traceback
 import typing
 from collections import Counter
 from dataclasses import dataclass, field
@@ -71,12 +72,16 @@ class Runner:
         output_path: str,
         suite: str,
         skip_instances: bool,
+        skip_completed_runs: bool,
+        exit_on_error: bool,
     ):
         self.executor = Executor(execution_spec)
         self.dry_run: bool = execution_spec.dry_run
         self.tokenizer_service = TokenizerService(self.executor.service, execution_spec.auth)
         self.metric_service = MetricService(self.executor.service, execution_spec.auth)
         self.skip_instances: bool = skip_instances
+        self.skip_completed_runs: bool = skip_completed_runs
+        self.exit_on_error: bool = exit_on_error
 
         ensure_directory_exists(output_path)
         # Decide where to save the raw data (e.g., "output/scenarios/mmlu").
@@ -92,8 +97,14 @@ class Runner:
 
     def run_all(self, run_specs: List[RunSpec]):
         for run_spec in tqdm(run_specs):
-            with htrack_block(f"Running {run_spec.name}"):
-                self.run_one(run_spec)
+            try:
+                with htrack_block(f"Running {run_spec.name}"):
+                    self.run_one(run_spec)
+            except Exception as e:
+                if self.exit_on_error:
+                    raise e
+                else:
+                    hlog(f"Error when running {run_spec.name}:\n{traceback.format_exc()}")
 
     def run_one(self, run_spec: RunSpec):
         # Load the scenario
@@ -105,6 +116,12 @@ class Runner:
 
         run_path: str = os.path.join(self.runs_path, run_spec.name)
         ensure_directory_exists(run_path)
+
+        if os.path.exists(os.path.join(run_path, "scenario_state.json")):
+            # If scenario_state.json exists, assume that all other output files exist
+            # because scenario_state.json is the last output file to be written.
+            hlog(f"Skipping run {run_spec.name} because run is completed and all output files exist.")
+            return
 
         # Fetch and initialize the Adapter based on the `AdapterSpec`.
         adapter: Adapter = AdapterFactory.get_adapter(run_spec.adapter_spec, self.tokenizer_service)

--- a/src/helm/benchmark/runner.py
+++ b/src/helm/benchmark/runner.py
@@ -117,7 +117,7 @@ class Runner:
         run_path: str = os.path.join(self.runs_path, run_spec.name)
         ensure_directory_exists(run_path)
 
-        if os.path.exists(os.path.join(run_path, "scenario_state.json")):
+        if self.skip_completed_runs and os.path.exists(os.path.join(run_path, "scenario_state.json")):
             # If scenario_state.json exists, assume that all other output files exist
             # because scenario_state.json is the last output file to be written.
             hlog(f"Skipping run {run_spec.name} because run is completed and all output files exist.")


### PR DESCRIPTION
- `--exit-on-error` was broken by #1302
- `--skip-completed-runs` is useful for re-running `helm-run` on the same `run_specs.conf` if some runs fail, without having to create a new `run_specs.conf` with only the failing runs.