### PR TITLE
Update Together model name for H3

### DIFF
--- a/src/helm/proxy/clients/together_client.py
+++ b/src/helm/proxy/clients/together_client.py
@@ -12,6 +12,9 @@ from helm.common.tokenization_request import (
 from .client import Client, wrap_request_time, truncate_sequence
 
 
+MODEL_ALIASES = {"h3-2.7b": "h3-2.7b-h3"}
+
+
 def fix_text(x: str, model: str) -> str:
     """Fix text that comes back from the API."""
     x = x.replace("▁", " ")
@@ -31,8 +34,7 @@ class TogetherClient(Client):
         # Following the examples from https://github.com/togethercomputer/open-models-api
         return {
             "request_type": "language-model-inference",
-            # TODO: the Together API expects "together/" in the model name
-            "model": request.model,
+            "model": MODEL_ALIASES.get(request.model_engine, request.model_engine),
             "prompt": request.prompt,
             "temperature": request.temperature,
             "n": request.num_completions,

--- a/src/helm/proxy/clients/together_client.py
+++ b/src/helm/proxy/clients/together_client.py
@@ -13,6 +13,16 @@ from .client import Client, wrap_request_time, truncate_sequence
 
 
 MODEL_ALIASES = {"h3-2.7b": "h3-2.7b-h3"}
+"""Together model name aliases.
+
+HELM users use a shorter model name (e.g. together/bloomz)
+whereas the Together client sends and caches requests using
+a longer model name that is suffixed with the implementation framework
+(e.g. bloomz-176b-alpa). This allows trackcing exactly which
+implementation was used in the cached results, since some results may
+be different depending on the implementation (e.g. efficiency metrics).
+This also allows future migration of results in the case of changes of
+available implementations on Together."""
 
 
 def fix_text(x: str, model: str) -> str:


### PR DESCRIPTION
The Together model name format is now `model-size-framework`, so H3 is `h3-2.7b-h3`.