### PR TITLE
Changes to Cohere Command model

### DIFF
--- a/src/helm/benchmark/static/schema.yaml
+++ b/src/helm/benchmark/static/schema.yaml
@@ -142,17 +142,17 @@ models:
     access: limited
     num_parameters: 6100000000
     release_date: 2022-11-08
-  - name: cohere/command-medium-nightly
-    display_name: Cohere command nightly (6.1B)
-    description: Cohere command nightly (6.1B parameters) is fine-tuned from the medium model to respond well with instruction-like prompts ([details](https://docs.cohere.ai/docs/command-beta)).
+  - name: cohere/command-medium-beta
+    display_name: Cohere Command beta (6.1B)
+    description: Cohere Command beta (6.1B parameters) is fine-tuned from the medium model to respond well with instruction-like prompts ([details](https://docs.cohere.ai/docs/command-beta)).
     creator_organization: Cohere
     access: limited
     num_parameters: 6100000000
     release_date: 2022-11-08
     todo: true
-  - name: cohere/command-xlarge-nightly
-    display_name: Cohere command nightly (52.4B)
-    description: Cohere command nightly (52.4B parameters) is fine-tuned from the XL model to respond well with instruction-like prompts ([details](https://docs.cohere.ai/docs/command-beta)).
+  - name: cohere/command-xlarge-beta
+    display_name: Cohere Command beta (52.4B)
+    description: Cohere Command beta (52.4B parameters) is fine-tuned from the XL model to respond well with instruction-like prompts ([details](https://docs.cohere.ai/docs/command-beta)).
     creator_organization: Cohere
     access: limited
     num_parameters: 52400000000

--- a/src/helm/benchmark/window_services/cohere_window_service.py
+++ b/src/helm/benchmark/window_services/cohere_window_service.py
@@ -35,8 +35,12 @@ class CohereWindowService(LocalWindowService):
 
         Request failed with too many tokens: total number of tokens (prompt and prediction) cannot
         exceed 2048 - received 2049. Try using a shorter prompt or a smaller max_tokens value.
+
+        In rare situations, the co.tokenize returns a shorter list of tokens than the co.generate.
+        This causes sequence length errors for rare inputs. Cohere's advice is to reduce the sequence
+        length to 2020 to avoid these issues.
         """
-        return 2048
+        return 2020
 
     @property
     def end_of_text_token(self) -> str:

--- a/src/helm/benchmark/window_services/cohere_window_service.py
+++ b/src/helm/benchmark/window_services/cohere_window_service.py
@@ -35,12 +35,8 @@ class CohereWindowService(LocalWindowService):
 
         Request failed with too many tokens: total number of tokens (prompt and prediction) cannot
         exceed 2048 - received 2049. Try using a shorter prompt or a smaller max_tokens value.
-
-        In rare situations, the co.tokenize returns a shorter list of tokens than the co.generate.
-        This causes sequence length errors for rare inputs. Cohere's advice is to reduce the sequence
-        length to 2020 to avoid these issues.
         """
-        return 2020
+        return 2048
 
     @property
     def end_of_text_token(self) -> str:
@@ -145,3 +141,23 @@ class CohereWindowService(LocalWindowService):
             result = result[:-1]
 
         return result
+
+
+class CohereCommandWindowService(CohereWindowService):
+    def __init__(self, service: TokenizerService):
+        super().__init__(service)
+
+    @property
+    def max_request_length(self) -> int:
+        """
+        The max request length of the model. For Cohere, this is the same as the `max_sequence_length`.
+        If we exceed the `max_sequence_length`, we get the following error:
+
+        Request failed with too many tokens: total number of tokens (prompt and prediction) cannot
+        exceed 2048 - received 2049. Try using a shorter prompt or a smaller max_tokens value.
+
+        For the Command model, in rare situations, the co.tokenize returns a shorter list of tokens
+        than the co.generate. This causes sequence length errors for rare inputs. Cohere's advice is
+        to reduce the sequence length to 2020 to avoid these issues.
+        """
+        return 2020

--- a/src/helm/benchmark/window_services/test_cohere_window_service.py
+++ b/src/helm/benchmark/window_services/test_cohere_window_service.py
@@ -39,7 +39,7 @@ class TestCohereWindowService:
         shutil.rmtree(cls.path)
 
     def test_max_request_length(self):
-        assert self.window_service.max_request_length == 2048
+        assert self.window_service.max_request_length == 2020
 
     def test_encode(self):
         assert self.window_service.encode(self.prompt).token_values == self.tokenized_prompt

--- a/src/helm/benchmark/window_services/test_cohere_window_service.py
+++ b/src/helm/benchmark/window_services/test_cohere_window_service.py
@@ -39,7 +39,7 @@ class TestCohereWindowService:
         shutil.rmtree(cls.path)
 
     def test_max_request_length(self):
-        assert self.window_service.max_request_length == 2020
+        assert self.window_service.max_request_length == 2048
 
     def test_encode(self):
         assert self.window_service.encode(self.prompt).token_values == self.tokenized_prompt

--- a/src/helm/benchmark/window_services/window_service_factory.py
+++ b/src/helm/benchmark/window_services/window_service_factory.py
@@ -1,7 +1,7 @@
 from helm.proxy.models import get_model, get_model_names_with_tag, Model, WIDER_CONTEXT_WINDOW_TAG
 from .ai21_window_service import AI21WindowService
 from .anthropic_window_service import AnthropicWindowService
-from .cohere_window_service import CohereWindowService
+from .cohere_window_service import CohereWindowService, CohereCommandWindowService
 from .luminous_window_service import (
     LuminousBaseWindowService,
     LuminousExtendedWindowService,
@@ -88,7 +88,10 @@ class WindowServiceFactory:
         elif model_name == "together/yalm":
             window_service = YaLMWindowService(service)
         elif organization == "cohere":
-            window_service = CohereWindowService(service)
+            if "command" in engine:
+                window_service = CohereCommandWindowService(service)
+            else:
+                window_service = CohereWindowService(service)
         elif organization == "ai21":
             window_service = AI21WindowService(service=service, gpt2_window_service=GPT2WindowService(service))
         else:

--- a/src/helm/proxy/models.py
+++ b/src/helm/proxy/models.py
@@ -256,20 +256,20 @@ ALL_MODELS = [
     Model(
         group="cohere",
         creator_organization="Cohere",
-        name="cohere/command-medium-nightly",
-        display_name="Cohere Command nightly (6.1B)",
-        description="Cohere command nightly (6.1B parameters) is fine-tuned from the medium model "
+        name="cohere/command-medium-beta",
+        display_name="Cohere Command beta (6.1B)",
+        description="Cohere command beta (6.1B parameters) is fine-tuned from the medium model "
         "to respond well with instruction-like prompts",
-        tags=[TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG, COHERE_TOKENIZER_TAG],
+        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG, COHERE_TOKENIZER_TAG],
     ),
     Model(
         group="cohere",
         creator_organization="Cohere",
-        name="cohere/command-xlarge-nightly",
-        display_name="Cohere Command nightly (52.4B)",
-        description="Cohere command nightly (52.4B parameters) is fine-tuned from the XL model "
+        name="cohere/command-xlarge-beta",
+        display_name="Cohere Command beta (52.4B)",
+        description="Cohere command beta (52.4B parameters) is fine-tuned from the XL model "
         "to respond well with instruction-like prompts",
-        tags=[TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG, COHERE_TOKENIZER_TAG],
+        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG, COHERE_TOKENIZER_TAG],
     ),
     # EleutherAI
     Model(

--- a/src/helm/proxy/models.py
+++ b/src/helm/proxy/models.py
@@ -258,7 +258,7 @@ ALL_MODELS = [
         creator_organization="Cohere",
         name="cohere/command-medium-beta",
         display_name="Cohere Command beta (6.1B)",
-        description="Cohere command beta (6.1B parameters) is fine-tuned from the medium model "
+        description="Cohere Command beta (6.1B parameters) is fine-tuned from the medium model "
         "to respond well with instruction-like prompts",
         tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG, COHERE_TOKENIZER_TAG],
     ),
@@ -267,7 +267,7 @@ ALL_MODELS = [
         creator_organization="Cohere",
         name="cohere/command-xlarge-beta",
         display_name="Cohere Command beta (52.4B)",
-        description="Cohere command beta (52.4B parameters) is fine-tuned from the XL model "
+        description="Cohere Command beta (52.4B parameters) is fine-tuned from the XL model "
         "to respond well with instruction-like prompts",
         tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG, COHERE_TOKENIZER_TAG],
     ),


### PR DESCRIPTION
- Use Command beta instead of Command nightly
- Use sequence length of 2020 for Command models
- Mark Command as a full functionality model