### PR TITLE
Return non-zero error code when runs fail

### DIFF
--- a/src/helm/benchmark/runner.py
+++ b/src/helm/benchmark/runner.py
@@ -27,6 +27,8 @@ from .window_services.tokenizer_service import TokenizerService
 
 
 class RunnerError(Exception):
+    """Error that happens in the Runner."""
+
     pass
 
 


### PR DESCRIPTION
Currently, `helm-run` returns exit code 0 when runs fail if `--exit-on-error` is not set.