### PR TITLE
Fix using revisions with Hugging Face Model Hub

### DIFF
--- a/docs/huggingface_models.md
+++ b/docs/huggingface_models.md
@@ -4,7 +4,7 @@ HELM can be used to evaluate `AutoModelForCausalLM` models (e.g. [`BioMedLM`](ht
 
 To use `AutoModelForCausalLM` models from Hugging Face Model Hub, add the Hugging Face model IDs to the `--enable-huggingface-models` flags to `helm-run`. This will make the corresponding Hugging Face models available to use in your run spec descriptions. In the run spec description, use the Hugging Face model ID as the model name.
 
-To use a revision of a model other than the default main revision, append a `#` followed by the revision name to the model ID passed to the `--enable-huggingface-models` flag. Note that in the run spec description, the model name should not include `#` or the revision name.
+To use a revision of a model other than the default main revision, append a `@` followed by the revision name to the model ID passed to the `--enable-huggingface-models` flag. Note that in the run spec description, the model name should not include `@` or the revision name.
 
 Current restrictions:
 
@@ -26,7 +26,7 @@ helm-run \
 # Run boolq on stanford-crfm/BioMedLM at revision main
 helm-run \
     --run-specs boolq:model=stanford-crfm/BioMedLM \
-    --enable-huggingface-models stanford-crfm/BioMedLM#main \
+    --enable-huggingface-models stanford-crfm/BioMedLM@main \
     --local \
     --suite v1 \
     --max-eval-instances 10

--- a/docs/huggingface_models.md
+++ b/docs/huggingface_models.md
@@ -4,7 +4,7 @@ HELM can be used to evaluate `AutoModelForCausalLM` models (e.g. [`BioMedLM`](ht
 
 To use `AutoModelForCausalLM` models from Hugging Face Model Hub, add the Hugging Face model IDs to the `--enable-huggingface-models` flags to `helm-run`. This will make the corresponding Hugging Face models available to use in your run spec descriptions. In the run spec description, use the Hugging Face model ID as the model name.
 
-To use a revision of a model other than the default main revision, append a `@` followed by the revision name to the model ID passed to the `--enable-huggingface-models` flag. Note that in the run spec description, the model name should not include `@` or the revision name.
+To use a revision of a model other than the default main revision, append a `@` followed by the revision name to the model ID passed to the `--enable-huggingface-models` flag.
 
 Current restrictions:
 
@@ -25,7 +25,7 @@ helm-run \
 
 # Run boolq on stanford-crfm/BioMedLM at revision main
 helm-run \
-    --run-specs boolq:model=stanford-crfm/BioMedLM \
+    --run-specs boolq:model=stanford-crfm/BioMedLM@main \
     --enable-huggingface-models stanford-crfm/BioMedLM@main \
     --local \
     --suite v1 \

--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -219,7 +219,7 @@ def main():
         nargs="+",
         default=[],
         help="Experimental: Enable using AutoModelForCausalLM models from Hugging Face Model Hub. "
-        "Format: namespace/model_name[#revision]",
+        "Format: namespace/model_name[@revision]",
     )
     add_run_args(parser)
     args = parser.parse_args()

--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -225,8 +225,8 @@ def main():
     args = parser.parse_args()
     validate_args(args)
 
-    for raw_huggingface_model_config in args.enable_huggingface_models:
-        register_huggingface_model_config(raw_huggingface_model_config)
+    for huggingface_model_name in args.enable_huggingface_models:
+        register_huggingface_model_config(huggingface_model_name)
 
     run_entries: List[RunEntry] = []
     if args.conf_paths:

--- a/src/helm/benchmark/window_services/huggingface_window_service.py
+++ b/src/helm/benchmark/window_services/huggingface_window_service.py
@@ -7,8 +7,8 @@ from helm.proxy.clients.huggingface_client import HuggingFaceModelConfig
 class HuggingFaceWindowService(LocalWindowService):
     def __init__(self, service: TokenizerService, model_config: HuggingFaceModelConfig):
         super().__init__(service)
-        self._tokenizer_name = model_config.model_id
-        tokenizer = HuggingFaceTokenizers.get_tokenizer(model_config.model_id)
+        self._tokenizer_name = str(model_config)
+        tokenizer = HuggingFaceTokenizers.get_tokenizer(self._tokenizer_name)
         self._prefix_token = tokenizer.bos_token
         self._end_of_text_token = tokenizer.eos_token
         self._max_request_length = tokenizer.model_max_length

--- a/src/helm/proxy/clients/huggingface_client.py
+++ b/src/helm/proxy/clients/huggingface_client.py
@@ -29,11 +29,11 @@ class HuggingFaceServer:
         model_kwargs = {}
         if model_config.revision:
             model_kwargs["revision"] = model_config.revision
-        with htrack_block("Loading model"):
-            self.model = AutoModelForCausalLM.from_pretrained(model_config.model_id, trust_remote_code=True).to(
-                self.device
-            )
-        with htrack_block("Loading tokenizer"):
+        with htrack_block(f"Loading Hugging Face model for config {model_config}"):
+            self.model = AutoModelForCausalLM.from_pretrained(
+                model_config.model_id, trust_remote_code=True, **model_kwargs
+            ).to(self.device)
+        with htrack_block(f"Loading Hugging Face tokenizer model for config {model_config}"):
             self.tokenizer = AutoTokenizer.from_pretrained(model_config.model_id, **model_kwargs)
 
     def serve_request(self, raw_request: Dict[str, Any]):

--- a/src/helm/proxy/clients/huggingface_model_registry.py
+++ b/src/helm/proxy/clients/huggingface_model_registry.py
@@ -39,6 +39,20 @@ class HuggingFaceModelConfig:
             return f"{self.namespace}/{self.model_name}"
         return self.model_name
 
+    def __str__(self) -> str:
+        """Return the full model name used by HELM in the format "[namespace/]model_name[@revision]".
+
+        Examples:
+        - 'gpt2'
+        - 'stanford-crfm/BioMedLM'
+        - 'stanford-crfm/BioMedLM@main'"""
+        result = self.model_name
+        if self.namespace:
+            result = f"{self.namespace}/{result}"
+        if self.revision:
+            result = f"{result}@{self.revision}"
+        return result
+
     @staticmethod
     def from_string(raw: str) -> "HuggingFaceModelConfig":
         """Parses a string in the format "[namespace/]model_name[@revision]" to a HuggingFaceModelConfig.
@@ -61,38 +75,37 @@ class HuggingFaceModelConfig:
 _huggingface_model_registry: Dict[str, HuggingFaceModelConfig] = {}
 
 
-def register_huggingface_model_config(raw_model_config: str) -> HuggingFaceModelConfig:
+def register_huggingface_model_config(model_name: str) -> HuggingFaceModelConfig:
     """Register a AutoModelForCausalLM model from Hugging Face Model Hub for later use.
 
-    raw_model_config format: namespace/model_name[@revision]"""
-    config = HuggingFaceModelConfig.from_string(raw_model_config)
+    model_name format: namespace/model_name[@revision]"""
+    config = HuggingFaceModelConfig.from_string(model_name)
     if config.model_id in _huggingface_model_registry:
-        raise ValueError(f"A HuggingFace model is already registered for model_id {config.model_id}")
-    _huggingface_model_registry[config.model_id] = config
+        raise ValueError(f"A Hugging Face model is already registered for model_id {model_name}")
+    _huggingface_model_registry[model_name] = config
 
     # HELM model names require a namespace
     if not config.namespace:
-        raise Exception("Registration of HuggingFace models without a namespace is not supported")
-    helm_model_name = config.model_id
-    model = MODEL_NAME_TO_MODEL.get(helm_model_name)
-    if not model:
-        description = f"HuggingFace model {config.model_id}"
-        if config.revision:
-            description += f" at revision {config.revision}"
-        model = Model(
-            group=config.namespace,
-            name=helm_model_name,
-            display_name=config.model_id,
-            creator_organization=config.namespace,
-            description=description,
-            tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
-        )
-        MODEL_NAME_TO_MODEL[helm_model_name] = model
-        ALL_MODELS.append(model)
-    hlog(f"Registered HuggingFace model: {model} config: {config}")
+        raise Exception("Registration of Hugging Face models without a namespace is not supported")
+    if model_name in MODEL_NAME_TO_MODEL:
+        raise ValueError(f"A HELM model is already registered for model name: {model_name}")
+    description = f"HuggingFace model {config.model_id}"
+    if config.revision:
+        description += f" at revision {config.revision}"
+    model = Model(
+        group=config.namespace,
+        name=model_name,
+        display_name=model_name,
+        creator_organization=config.namespace,
+        description=description,
+        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
+    )
+    MODEL_NAME_TO_MODEL[model_name] = model
+    ALL_MODELS.append(model)
+    hlog(f"Registered Hugging Face model: {model} config: {config}")
     return config
 
 
-def get_huggingface_model_config(model_id: str) -> Optional[HuggingFaceModelConfig]:
+def get_huggingface_model_config(model_name: str) -> Optional[HuggingFaceModelConfig]:
     """Returns a HuggingFaceModelConfig for the model_id."""
-    return _huggingface_model_registry.get(model_id)
+    return _huggingface_model_registry.get(model_name)

--- a/src/helm/proxy/clients/huggingface_model_registry.py
+++ b/src/helm/proxy/clients/huggingface_model_registry.py
@@ -21,7 +21,7 @@ class HuggingFaceModelConfig:
     model_name: str
     """Name of the model. e.g. 'BioMedLM'
 
-    Does not include the namespace. ."""
+    Does not include the namespace."""
 
     revision: Optional[str]
     """Revision of the model to use e.g. 'main'.
@@ -41,16 +41,16 @@ class HuggingFaceModelConfig:
 
     @staticmethod
     def from_string(raw: str) -> "HuggingFaceModelConfig":
-        """Parses a string in the format "[namespace/]model_name[#revision]" to a HuggingFaceModelConfig.
+        """Parses a string in the format "[namespace/]model_name[@revision]" to a HuggingFaceModelConfig.
 
         Examples:
         - 'gpt2'
         - 'stanford-crfm/BioMedLM'
-        - 'stanford-crfm/BioMedLM#main'"""
-        pattern = r"((?P<namespace>[^/#]+)/)?(?P<model_name>[^/#]+)(#(?P<revision>[^/#]+))?"
+        - 'stanford-crfm/BioMedLM@main'"""
+        pattern = r"((?P<namespace>[^/@]+)/)?(?P<model_name>[^/@]+)(@(?P<revision>[^/@]+))?"
         match = re.fullmatch(pattern, raw)
         if not match:
-            raise ValueError(f"Could not parse model name: '{raw}'; Expected format: [namespace/]model_name[#revision]")
+            raise ValueError(f"Could not parse model name: '{raw}'; Expected format: [namespace/]model_name[@revision]")
         model_name = match.group("model_name")
         assert model_name
         return HuggingFaceModelConfig(
@@ -64,7 +64,7 @@ _huggingface_model_registry: Dict[str, HuggingFaceModelConfig] = {}
 def register_huggingface_model_config(raw_model_config: str) -> HuggingFaceModelConfig:
     """Register a AutoModelForCausalLM model from Hugging Face Model Hub for later use.
 
-    raw_model_config format: namespace/model_name[#revision]"""
+    raw_model_config format: namespace/model_name[@revision]"""
     config = HuggingFaceModelConfig.from_string(raw_model_config)
     if config.model_id in _huggingface_model_registry:
         raise ValueError(f"A HuggingFace model is already registered for model_id {config.model_id}")

--- a/src/helm/proxy/clients/test_huggingface_model_registry.py
+++ b/src/helm/proxy/clients/test_huggingface_model_registry.py
@@ -1,7 +1,14 @@
 import pytest
-from .huggingface_model_registry import register_huggingface_model_config
-from ..models import get_all_models, get_all_text_models
-from ...benchmark.run_expander import ModelRunExpander
+import unittest
+from typing import List, Tuple
+
+from helm.benchmark.run_expander import ModelRunExpander
+from helm.proxy.clients.huggingface_model_registry import (
+    HuggingFaceModelConfig,
+    register_huggingface_model_config,
+    get_huggingface_model_config,
+)
+from helm.proxy.models import get_all_models, get_all_text_models
 
 
 @pytest.mark.parametrize("model_name", ["EleutherAI/pythia-70m"])
@@ -10,3 +17,41 @@ def test_hf_model_register(model_name):
     assert model_name in ModelRunExpander("all").values
     assert model_name in get_all_models()
     assert model_name in get_all_text_models()
+
+
+class TestHuggingFaceModelRegistry(unittest.TestCase):
+    def test_round_trip(self):
+        config_pairs: List[Tuple[str, HuggingFaceModelConfig]] = [
+            ("gpt2", HuggingFaceModelConfig(namespace=None, model_name="gpt2", revision=None)),
+            (
+                "stanford-crfm/BioMedLM",
+                HuggingFaceModelConfig(namespace="stanford-crfm", model_name="BioMedLM", revision=None),
+            ),
+            (
+                "stanford-crfm/BioMedLM@main",
+                HuggingFaceModelConfig(namespace="stanford-crfm", model_name="BioMedLM", revision="main"),
+            ),
+        ]
+        for expected_model_name, expected_model_config in config_pairs:
+            actual_model_config = HuggingFaceModelConfig.from_string(expected_model_name)
+            actual_model_name = str(actual_model_config)
+            self.assertEqual(actual_model_name, expected_model_name)
+            self.assertEqual(actual_model_config, expected_model_config)
+
+    def test_model_id(self):
+        config_pairs: List[Tuple[str, str]] = [
+            ("gpt2", "gpt2"),
+            ("stanford-crfm/BioMedLM", "stanford-crfm/BioMedLM"),
+            ("stanford-crfm/BioMedLM@main", "stanford-crfm/BioMedLM"),
+        ]
+        for expected_model_name, expected_model_id in config_pairs:
+            actual_model_config = HuggingFaceModelConfig.from_string(expected_model_name)
+            self.assertEqual(actual_model_config.model_id, expected_model_id)
+
+    def test_register_huggingface_model_config(self):
+        register_huggingface_model_config("stanford-crfm/BioMedLM@main")
+        expected_model_config = HuggingFaceModelConfig(
+            namespace="stanford-crfm", model_name="BioMedLM", revision="main"
+        )
+        actual_model_config = get_huggingface_model_config("stanford-crfm/BioMedLM@main")
+        self.assertEqual(actual_model_config, expected_model_config)


### PR DESCRIPTION
- Previously, it always used the main revision; now it actually uses the correct revision
- Also changes Hugging Face revision syntax to use @ instead of #; this makes it consistent with [pip VCS syntax](https://pip.pypa.io/en/stable/topics/vcs-support/)
- The HELM model name now includes the @ suffix as well, rather than truncating it

Addresses #1103