### PR TITLE
Lazily instantiate PerspectiveAPIClient

### DIFF
--- a/src/helm/proxy/services/server_service.py
+++ b/src/helm/proxy/services/server_service.py
@@ -1,6 +1,6 @@
 import os
 import signal
-from typing import List
+from typing import List, Optional
 
 from helm.common.authentication import Authentication
 from helm.common.general import ensure_directory_exists, parse_hocon
@@ -15,6 +15,7 @@ from helm.common.request import Request, RequestResult
 from helm.common.hierarchical_logger import hlog
 from helm.proxy.accounts import Accounts, Account
 from helm.proxy.clients.auto_client import AutoClient
+from helm.proxy.clients.perspective_api_client import PerspectiveAPIClient
 from helm.proxy.example_queries import example_queries
 from helm.proxy.models import ALL_MODELS, get_model_group
 from helm.proxy.query import Query, QueryResult
@@ -52,7 +53,8 @@ class ServerService(Service):
         self.client = AutoClient(credentials, cache_path, mongo_uri)
         self.token_counter = AutoTokenCounter(self.client.huggingface_client)
         self.accounts = Accounts(accounts_path, root_mode=root_mode)
-        self.perspective_api_client = self.client.get_toxicity_classifier_client()
+        # Lazily instantiated by get_toxicity_scores()
+        self.perspective_api_client: Optional[PerspectiveAPIClient] = None
 
     def get_general_info(self) -> GeneralInfo:
         return GeneralInfo(version=VERSION, example_queries=example_queries, all_models=ALL_MODELS)
@@ -103,6 +105,8 @@ class ServerService(Service):
     def get_toxicity_scores(self, auth: Authentication, request: PerspectiveAPIRequest) -> PerspectiveAPIRequestResult:
         @retry_request
         def get_toxicity_scores_with_retry(request: PerspectiveAPIRequest) -> PerspectiveAPIRequestResult:
+            if not self.perspective_api_client:
+                self.perspective_api_client = self.client.get_toxicity_classifier_client()
             return self.perspective_api_client.get_toxicity_scores(request)
 
         self.accounts.authenticate(auth)


### PR DESCRIPTION
This only instantiates PerspectiveAPIClient when toxicity metrics are used, which stops an error form being raised if the user is not using toxicity metrics and the Perspective API key is not provided.

Addresses #1417