### PR TITLE
Fix corner cases in LocalWindowService truncation and In-context Adapter

### DIFF
--- a/src/helm/benchmark/adaptation/adapters/in_context_learning_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/in_context_learning_adapter.py
@@ -222,7 +222,7 @@ class InContextLearningAdapter(Adapter, ABC):
         Returns a single example of the prompt. `include_output` controls whether the gold output is included.
         """
         # Input
-        result: str = self.adapter_spec.input_prefix + str(instance.input.text) + self.adapter_spec.input_suffix
+        result: str = self.adapter_spec.input_prefix + (instance.input.text or "") + self.adapter_spec.input_suffix
 
         # References (optionally) and output
         output: str

--- a/src/helm/benchmark/adaptation/adapters/in_context_learning_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/in_context_learning_adapter.py
@@ -222,7 +222,7 @@ class InContextLearningAdapter(Adapter, ABC):
         Returns a single example of the prompt. `include_output` controls whether the gold output is included.
         """
         # Input
-        result: str = self.adapter_spec.input_prefix + instance.input.text + self.adapter_spec.input_suffix
+        result: str = self.adapter_spec.input_prefix + str(instance.input.text) + self.adapter_spec.input_suffix
 
         # References (optionally) and output
         output: str

--- a/src/helm/benchmark/window_services/local_window_service.py
+++ b/src/helm/benchmark/window_services/local_window_service.py
@@ -93,7 +93,7 @@ class LocalWindowService(WindowService):
         result: str = self.decode(self.encode(text, truncation=True, max_length=max_length).tokens)
 
         # HACK: For the vast majority of cases, the above logic works, but it sometimes doesn't work
-        # for non-English, non-Chinese text (e.g., Russian from multi_eurlex. See more 
+        # for non-English, non-Chinese text (e.g., Russian from multi_eurlex. See more
         # in https://github.com/stanford-crfm/helm/issues/1448).
         # Truncate by removing character by character until the prompt fits within the context window.
         while not self.fits_within_context_window(result, expected_completion_token_length):


### PR DESCRIPTION
- [x] `instance.input.text` can be `None`, and may trigger str + None error. We simply wrapped it with `str()`
- [x] Deal with a corner-case in the truncation logic. More details in https://github.com/stanford-crfm/helm/issues/1448
