### PR TITLE
Add 1 to max_tokens for ChatGPT

### DIFF
--- a/src/helm/benchmark/adaptation/adapters/multiple_choice_joint_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/multiple_choice_joint_adapter.py
@@ -57,7 +57,7 @@ class MultipleChoiceJointAdapter(InContextLearningAdapter):
             num_completions=1,
             top_k_per_token=self.adapter_spec.num_outputs,
             temperature=0,
-            max_tokens=1,
+            max_tokens=self.adapter_spec.max_tokens,  # usually this is 1
             stop_sequences=[],
             random=self.adapter_spec.random,
         )

--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -858,7 +858,8 @@ class IncreaseMaxTokensRunExpander(RunExpander):
         self.value = value
 
     def expand(self, run_spec: RunSpec) -> List[RunSpec]:
-        adapter_spec: AdapterSpec = replace(run_spec.adapter_spec, max_tokens=adapter_spec.max_tokens + self.value)
+        adapter_spec: AdapterSpec = run_spec.adapter_spec
+        adapter_spec = replace(adapter_spec, max_tokens=adapter_spec.max_tokens + self.value)
         return [
             replace(
                 run_spec,

--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -18,7 +18,7 @@ from helm.proxy.models import (
     ABLATION_MODEL_TAG,
 )
 from .runner import RunSpec
-from helm.benchmark.adaptation.adapter_spec import Substitution
+from helm.benchmark.adaptation.adapter_spec import AdapterSpec, Substitution
 from .augmentations.perturbation import PerturbationSpec
 from .augmentations.data_augmenter import DataAugmenterSpec
 
@@ -840,6 +840,30 @@ class NumOutputTokensRunExpander(RunExpander):
                 adapter_spec=replace(run_spec.adapter_spec, **{self.adapter_spec_name: value}),
             )
             for value in self.values
+        ]
+
+
+class IncreaseMaxTokensRunExpander(RunExpander):
+    """
+    Run expander for increasing the number of max tokens.
+    """
+
+    name = "increase_max_tokens"
+
+    def __init__(self, value: int):
+        """
+        Args:
+            value (int): The number of tokens to increase max tokens by
+        """
+        self.value = value
+
+    def expand(self, run_spec: RunSpec) -> List[RunSpec]:
+        adapter_spec: AdapterSpec = replace(run_spec.adapter_spec, max_tokens=adapter_spec.max_tokens + self.value)
+        return [
+            replace(
+                run_spec,
+                adapter_spec=adapter_spec,
+            ),
         ]
 
 

--- a/src/helm/benchmark/run_specs.py
+++ b/src/helm/benchmark/run_specs.py
@@ -128,7 +128,7 @@ def get_multiple_choice_adapter_spec(
     output_noun: str,
     max_train_instances: int = 5,
     num_outputs: int = 5,
-    max_tokens: int = 5,
+    max_tokens: int = 1,
     empty_input: bool = False,
     sample_train: bool = True,
     **kwargs,
@@ -1976,7 +1976,9 @@ def construct_run_specs(spec: ObjectSpec) -> List[RunSpec]:
             global_prefix_expander = GlobalPrefixRunExpander(value="nlg")
             run_spec = singleton(global_prefix_expander.expand(run_spec))
 
-        if OPENAI_CHATGPT_MODEL_TAG in model.tags:
+        # When running ChatGPT on non-language modelling tasks, increase max_tokens by 1
+        # to add room for the special message role token.
+        if OPENAI_CHATGPT_MODEL_TAG in model.tags and run_spec.adapter_spec.max_tokens:
             increase_max_tokens_expander = IncreaseMaxTokensRunExpander(value=1)
             run_spec = singleton(increase_max_tokens_expander.expand(run_spec))
 

--- a/src/helm/benchmark/run_specs.py
+++ b/src/helm/benchmark/run_specs.py
@@ -14,7 +14,13 @@ from helm.benchmark.adaptation.adapters.adapter_factory import (
 from helm.benchmark.adaptation.adapters.binary_ranking_adapter import BinaryRankingAdapter
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from .metrics.metric import MetricSpec
-from .run_expander import RUN_EXPANDERS, GlobalPrefixRunExpander, StopRunExpander, ChatMLRunExpander
+from .run_expander import (
+    RUN_EXPANDERS,
+    GlobalPrefixRunExpander,
+    StopRunExpander,
+    ChatMLRunExpander,
+    IncreaseMaxTokensRunExpander,
+)
 from .runner import RunSpec
 from .scenarios.lex_glue_scenario import (
     get_lex_glue_max_train_instances,
@@ -35,7 +41,7 @@ from .scenarios.lextreme_scenario import (
     TaskType,
     get_lextreme_task_type,
 )
-from helm.proxy.models import get_model, NO_NEWLINES_TAG, NLG_PREFIX_TAG, CHATML_MODEL_TAG
+from helm.proxy.models import get_model, NO_NEWLINES_TAG, NLG_PREFIX_TAG, CHATML_MODEL_TAG, OPENAI_CHATGPT_MODEL_TAG
 from helm.common.general import singleton
 
 
@@ -1969,6 +1975,10 @@ def construct_run_specs(spec: ObjectSpec) -> List[RunSpec]:
         if NLG_PREFIX_TAG in model.tags:
             global_prefix_expander = GlobalPrefixRunExpander(value="nlg")
             run_spec = singleton(global_prefix_expander.expand(run_spec))
+
+        if OPENAI_CHATGPT_MODEL_TAG in model.tags:
+            increase_max_tokens_expander = IncreaseMaxTokensRunExpander(value=1)
+            run_spec = singleton(increase_max_tokens_expander.expand(run_spec))
 
         if CHATML_MODEL_TAG in model.tags:
             chatml_expander = ChatMLRunExpander()

--- a/src/helm/benchmark/test_run_expander.py
+++ b/src/helm/benchmark/test_run_expander.py
@@ -1,0 +1,29 @@
+import unittest
+
+from helm.benchmark.adaptation.adapter_spec import AdapterSpec
+from helm.benchmark.run_expander import IncreaseMaxTokensRunExpander
+from helm.benchmark.runner import RunSpec
+from helm.benchmark.scenarios.scenario import ScenarioSpec
+
+
+class RunExpanderTest(unittest.TestCase):
+    def test_increase_max_tokens_length(self):
+        # Test that each Instance is given a unique ID and is preserved through data augmentation
+        run_expander = IncreaseMaxTokensRunExpander(42)
+
+        original_run_spec = RunSpec(
+            name="test:test=test",
+            scenario_spec=ScenarioSpec(class_name="FakeScenario", args={}),
+            adapter_spec=AdapterSpec(max_tokens=137),
+            metric_specs=[],
+        )
+        actual_run_specs = run_expander.expand(original_run_spec)
+        expected_run_specs = [
+            RunSpec(
+                name="test:test=test",
+                scenario_spec=ScenarioSpec(class_name="FakeScenario", args={}),
+                adapter_spec=AdapterSpec(max_tokens=137 + 42),
+                metric_specs=[],
+            )
+        ]
+        self.assertListEqual(actual_run_specs, expected_run_specs)

--- a/src/helm/proxy/models.py
+++ b/src/helm/proxy/models.py
@@ -14,6 +14,9 @@ LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG: str = "limited_functionality_text"
 # ChatML format
 CHATML_MODEL_TAG: str = "chatml"
 
+# OpenAI Chat format
+OPENAI_CHATGPT_MODEL_TAG: str = "openai_chatgpt"
+
 # For OpenAI models with wider context windows
 WIDER_CONTEXT_WINDOW_TAG: str = "wider_context_window"  # 4000 tokens
 
@@ -569,7 +572,13 @@ ALL_MODELS = [
         # sequence length is smaller at 4087 with one user input message and one assistant
         # output message because ChatGPT uses special tokens for message roles and boundaries.
         # We use a rounded-down sequence length of 4000 to account for these special tokens.
-        tags=[TEXT_MODEL_TAG, WIDER_CONTEXT_WINDOW_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG, GPT2_TOKENIZER_TAG],
+        tags=[
+            TEXT_MODEL_TAG,
+            WIDER_CONTEXT_WINDOW_TAG,
+            OPENAI_CHATGPT_MODEL_TAG,
+            LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG,
+            GPT2_TOKENIZER_TAG,
+        ],
     ),
     Model(
         group="gpt3",


### PR DESCRIPTION
For the `openai/gpt-3.5-turbo-0301` model, the message roles are indicated by special tokens that take up space in the `max_tokens`. When using `multiple_choice_joint` with `max_tokens=1`, the model will output an empty string because the special token takes up the only output token. Therefore we have to set `max_tokens=2` instead to get a non-empty output of a single letter

Addresses #1218.