### PR TITLE
[Bugfix] Fix lextreme

### DIFF
--- a/src/helm/benchmark/scenarios/lextreme_scenario.py
+++ b/src/helm/benchmark/scenarios/lextreme_scenario.py
@@ -423,7 +423,7 @@ class LEXTREMEScenario(Scenario):
                 if "multi_eurlex" in config:
                     input_text = ast.literal_eval(input_text)
                     assert isinstance(input_text, dict)
-                    languages = list(input_text.keys())
+                    languages = list([lang for lang, content in input_text.items() if content is not None])
                     input_text = input_text[self.random.choice(languages)]  # just choose a random language
                 correct_references = [
                     Reference(output=Output(correct_label), tags=[CORRECT_TAG]) for correct_label in correct_labels

--- a/src/helm/common/object_spec.py
+++ b/src/helm/common/object_spec.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 from typing import Any, Dict, Tuple
-import importlib
 
 
 @dataclass(frozen=True)
@@ -19,10 +18,12 @@ class ObjectSpec:
 
 def create_object(spec: ObjectSpec):
     """Create the actual object given the `spec`."""
+    # Adapted from https://stackoverflow.com/questions/547829/how-to-dynamically-load-a-python-class
     components = spec.class_name.split(".")
-    module: Any = importlib.import_module(".".join(components[:-1]))
-    cls = getattr(module, components[-1])
-    return cls(**spec.args)
+    module: Any = __import__(components[0])
+    for component in components[1:]:
+        module = getattr(module, component)
+    return module(**spec.args)
 
 
 def parse_object_spec(description: str) -> ObjectSpec:

--- a/src/helm/common/object_spec.py
+++ b/src/helm/common/object_spec.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Any, Dict, Tuple
+import importlib
 
 
 @dataclass(frozen=True)
@@ -18,12 +19,10 @@ class ObjectSpec:
 
 def create_object(spec: ObjectSpec):
     """Create the actual object given the `spec`."""
-    # Adapted from https://stackoverflow.com/questions/547829/how-to-dynamically-load-a-python-class
     components = spec.class_name.split(".")
-    module: Any = __import__(components[0])
-    for component in components[1:]:
-        module = getattr(module, component)
-    return module(**spec.args)
+    module: Any = importlib.import_module(".".join(components[:-1]))
+    cls = getattr(module, components[-1])
+    return cls(**spec.args)
 
 
 def parse_object_spec(description: str) -> ObjectSpec:


### PR DESCRIPTION
- [x] Inputs in certain languages in multi_eurlex of `lextreme` can be None, e.g., `example={'input': '{\'bg\': None, \'cs\': None, \'da\': \'Kommissionens forordning (EF) nr. 1330/2003\\naf 25. juli 2003\\nom faste importværdier med henblik på fastsættelsen af indgangsprisen for visse frugter og grøntsager\\n`

~~Revise `__import__` with importlib. `importlib` should be preferred over `__import__`. You may test the change via the following code:~~ Noticed that the change cannot handle `helm.benchmark.basic_metric` so I reverted the change.

```python
from helm.common.object_spec import ObjectSpec, create_object

obj_spec = ObjectSpec(class_name="helm.benchmark.scenarios.lextreme_scenario.LEXTREMEScenario", args={"subset": "multi_eurlex_level_2"})
scenario = create_object(obj_spec)

```