### PR TITLE
clarify: overall helm-summarize creates run_specs.json

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -66,8 +66,6 @@ This reads the pre-existing files in `benchmark_output/runs/v1/` that were writt
 
 Additionally, for each group and group-relavent metric, it will output a pair of files: `benchmark_output/runs/v1/groups/latex/<group_name>_<metric_name>.tex` and `benchmark_output/runs/v1/groups/latex/<group_name>_<metric_name>.json`. These files contain the statistics for that metric from each run within the group.
 
-**Note**: Because `helm-summarize` reads the `run_specs.json` files (in each run's subdirectory) produced by `helm-run`, which are overwritten by every invocation of `helm-run`, `helm-summarize` will only process runs from the most recent invocation of `helm-run`.
-
 ## Using `helm-create-plots`
 
 The `helm-create-plots` reads the `groups` directory created by `helm-summarize` and creates plots, equivalent to those use in the HELM paper. Run the following:

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -46,8 +46,6 @@ Each output sub-directory will contain several JSON files that were generated du
 - `per_instance_stats.json` contains a serialized list of `PerInstanceStats`, which contains the statistics produced for the metrics for each instance (i.e. input).
 - `stats.json` contains a serialized list of `PerInstanceStats`, which contains the statistics produced for the metrics, aggregated across all instances (i.e. inputs).
 
-The command also writes the file `benchmarking_output/runs/v1/run_specs.json`, which contains the run spec descriptions for all the runs. 
-
 `helm-run` provides additional arguments that can be used to filter out `--models-to-run`, `--groups-to-run` and `--priority`. It can be convenient to create a large `run_specs.conf` file containing every run spec description of interest, and then use these flags to filter down the RunSpecs to actually run. As an example, the main `run_specs.conf` file used for the HELM benchmarking paper can be found [here](https://github.com/stanford-crfm/helm/blob/main/src/benchmark/presentation/run_specs.conf).
 
 ## Using `helm-summarize`
@@ -61,13 +59,14 @@ helm-summarize --suite v1
 This reads the pre-existing files in `benchmark_output/runs/v1/` that were written by `helm-run` previously, and writes the following new files back to `benchmark_output/runs/v1/`:
 
 - `summary.json` contains a serialized `ExecutiveSummary` with a date and suite name.
+- `run_specs.json` contains the run spec descriptions for all the runs.
 - `runs.json` contains serialized list of `Run`, which contains the run path, run spec and adapter spec and statistics for each run.
 - `groups.json` contains a serialized list of `Table`, each containing information about groups in a group category.
 - `groups_metadata.json` contains a list of all the groups along with a human-readable description and a taxonomy.
 
 Additionally, for each group and group-relavent metric, it will output a pair of files: `benchmark_output/runs/v1/groups/latex/<group_name>_<metric_name>.tex` and `benchmark_output/runs/v1/groups/latex/<group_name>_<metric_name>.json`. These files contain the statistics for that metric from each run within the group.
 
-**Note**: Because `helm-summarize` reads the `run_specs.json` that was produced by `helm-run` and `run_specs.json` is overwritten by every invocation of `helm-run`, `helm-summarize` will only process runs from the most recent invocation of `helm-run`.
+**Note**: Because `helm-summarize` reads the `run_specs.json` files (in each run's subdirectory) produced by `helm-run`, which are overwritten by every invocation of `helm-run`, `helm-summarize` will only process runs from the most recent invocation of `helm-run`.
 
 ## Using `helm-create-plots`
 


### PR DESCRIPTION
The tutorial initially said that the `run_specs.json` for all runs (e.g. `benchmark_output/runs/v1/run_specs.json` was created by `helm-run`, but it seems to only be created once running `helm-summarize` for the given suite.