### PR TITLE
Data contamination with beam

### DIFF
--- a/scripts/contamination/README.md
+++ b/scripts/contamination/README.md
@@ -1,0 +1,51 @@
+# Apache Beam implementation of HELM Contamination
+
+## Installation
+
+```bash
+# Create a virtual environment.
+# Only run this the first time.
+python3 -m pip install virtualenv
+python3 -m virtualenv -p python3 venv
+
+# Activate the virtual environment.
+source venv/bin/activate
+
+# Install requirements
+pip install git+https://github.com/stanford-crfm/helm.git@67033775cae93ab06ece65d006091f72cf841826
+pip install apache-beam~=2.46.0
+pip install bitarray~=2.7.3
+```
+
+## Running
+
+```bash
+python3 run_contamination_beam.py --scenario-data /path/to/scenario_data.jsonl --input-data /path/to/input_data.jsonl --input-format the_pile --output-stats /path/to/output_stats.jsonl --normalization default --tags tag1 tag2
+```
+
+## API
+
+Model developers should implement an Apache Beam pipeline that creates a `PCollection[str]` of documents, and then pass it to `ComputeAndWriteContaminationStats()` with the appropriate arguments.
+
+Note: Each record in the `PCollection[str]` should contain an _entire_ document, not a single line from a document.
+
+```python
+with beam.Pipeline() as pipeline:
+    _ = (
+        pipeline
+        # The model developer should modify these lines to read from the actual training set.
+        | "Read" >> beam.io.ReadFromText(input_data)
+        | "ExtractTextFromDocument" >> beam.Map(extract_text_from_document)
+        # Call the HELM Contamination Apache Beam API.
+        | "ComputeAndWriteContaminationStats" >> ComputeAndWriteContaminationStats(
+            scenario_data_path=scenario_data,
+            n_values=n_values,
+            normalization=normalization,
+            tags=tags
+        )
+    )
+```
+
+## Notes
+
+The beam script does not support outputting contaminated ngrams yet.

--- a/scripts/contamination/contamination_beam.py
+++ b/scripts/contamination/contamination_beam.py
@@ -1,0 +1,112 @@
+"""Apache Beam specific code."""
+
+import apache_beam as beam
+import json
+
+from typing import Dict, List, Iterable, Any
+from dataclasses import dataclass
+from apache_beam.utils.shared import Shared
+
+
+from helm.benchmark.contamination.compute_contamination_metrics import (
+    load_light_scenarios_from_jsonl,
+    create_ngram_index,
+    create_all_contamination_stats,
+    compute_scenario_document_contamination,
+    get_light_tokenizer,
+    AllContaminationStats,
+    NgramIndex,
+)
+from helm.benchmark.contamination.light_tokenizer import LightTokenizer
+
+
+@dataclass(frozen=True)
+class NgramIndexWrapper:
+    """Wraps `NgramIndex` so that it can be shared."""
+
+    ngram_index: NgramIndex
+
+
+class ComputeContaminationStatsFn(beam.CombineFn):
+    def __init__(
+        self,
+        scenario_data_path: str,
+        n_values: List[int],
+        normalization: str,
+        shared_ngram_index: Shared,
+    ) -> None:
+        self.scenario_data_path = scenario_data_path
+        self.n_values = n_values
+        self.tokenizer: LightTokenizer = get_light_tokenizer(normalization)
+        self.shared_ngram_index = shared_ngram_index
+
+    def setup(self, *args, **kwargs) -> None:
+        self.scenarios = load_light_scenarios_from_jsonl(self.scenario_data_path)
+
+        def init_shared_ngram_index():
+            return NgramIndexWrapper(create_ngram_index(self.scenarios, self.n_values, self.tokenizer))
+
+        self.ngram_index_wrapper = self.shared_ngram_index.acquire(init_shared_ngram_index)
+        return super().setup(*args, **kwargs)
+
+    def create_accumulator(self) -> AllContaminationStats:
+        return create_all_contamination_stats(self.scenarios, self.n_values)
+
+    def add_input(self, all_contamination_stats: AllContaminationStats, document: str) -> AllContaminationStats:
+        # update all_contamination_stats in-place
+        compute_scenario_document_contamination(
+            document=document,
+            ngram_index=self.ngram_index_wrapper.ngram_index,  # debug
+            all_contamination_stats=all_contamination_stats,
+            tokenizer=self.tokenizer,
+        )
+        return all_contamination_stats
+
+    def merge_accumulators(self, accumulators: Iterable[AllContaminationStats]) -> AllContaminationStats:
+        assert accumulators
+        merged_accumulator = accumulators[0]
+        for accumulator in accumulators[1:]:
+            for contamination_stats_key, contamination_stats in accumulator:
+                merged_accumulator[contamination_stats_key].merge(contamination_stats)
+        return merged_accumulator
+
+    def extract_output(self, accumulator: AllContaminationStats) -> AllContaminationStats:
+        return accumulator
+
+
+def extract_summary_from_all_contamination_stats(
+    all_contamination_stats: AllContaminationStats, tags: Dict[str, Any]
+) -> str:
+    return "\n".join(
+        json.dumps(contamination_stats.generate_summary(tags))
+        for contamination_stats in all_contamination_stats.values()
+    )
+
+
+class ComputeAndWriteContaminationStats(beam.PTransform):
+    def __init__(
+        self, scenario_data_path: str, n_values: List[int], normalization: str, tags: Dict[str, Any], output_stats: str
+    ):
+        self.scenario_data_path = scenario_data_path
+        self.n_values = n_values
+        self.normalization = normalization
+        self.tags = tags
+        self.output_stats = output_stats
+
+    def expand(self, pcollection: beam.PCollection):
+        shared_ngram_index = Shared()
+        return (
+            pcollection
+            | "ComputeContaminationStats"
+            >> beam.CombineGlobally(
+                ComputeContaminationStatsFn(
+                    scenario_data_path=self.scenario_data_path,
+                    n_values=self.n_values,
+                    normalization=self.normalization,
+                    shared_ngram_index=shared_ngram_index,
+                )
+            )
+            | "ExtractSummaryFromAllContaminationStats"
+            >> beam.Map(extract_summary_from_all_contamination_stats, tags={"tags:": self.tags})
+            | "WriteSummaries" >> beam.io.WriteToText(self.output_stats)
+        )

--- a/scripts/contamination/contamination_beam.py
+++ b/scripts/contamination/contamination_beam.py
@@ -66,9 +66,10 @@ class ComputeContaminationStatsFn(beam.CombineFn):
 
     def merge_accumulators(self, accumulators: Iterable[AllContaminationStats]) -> AllContaminationStats:
         assert accumulators
-        merged_accumulator = accumulators[0]
-        for accumulator in accumulators[1:]:
-            for contamination_stats_key, contamination_stats in accumulator:
+        accumulators_iter = iter(accumulators)
+        merged_accumulator = next(accumulators_iter)
+        for accumulator in accumulators_iter:
+            for contamination_stats_key, contamination_stats in accumulator.items():
                 merged_accumulator[contamination_stats_key].merge(contamination_stats)
         return merged_accumulator
 

--- a/scripts/contamination/run_contamination_beam.py
+++ b/scripts/contamination/run_contamination_beam.py
@@ -7,7 +7,7 @@ from helm.benchmark.contamination.contamination_parser import create_parser
 from contamination_beam import ComputeAndWriteContaminationStats
 
 
-def get_text_extract_function(input_format: str):
+def get_extract_text_function(input_format: str):
     def extract_text_from_the_pile_document(document: str) -> str:
         return json.loads(document)["text"]
 
@@ -27,7 +27,7 @@ def main():
     args = parser.parse_args()
 
     n_values: List[int] = [5, 9, 13]  # TODO: Pick the N values
-    extract_text_from_document: Callable[[str], str] = get_text_extract_function(args.input_format)
+    extract_text_from_document: Callable[[str], str] = get_extract_text_function(args.input_format)
 
     # The model developer should pass in the appropriate PipelineOptions here.
     with beam.Pipeline() as pipeline:
@@ -42,7 +42,7 @@ def main():
                 scenario_data_path=args.scenario_data,
                 n_values=n_values,
                 normalization=args.normalization,
-                tags=args.tags,
+                tags={"tags:": args.tags},
                 output_stats=args.output_stats,
             )
         )

--- a/scripts/contamination/run_contamination_beam.py
+++ b/scripts/contamination/run_contamination_beam.py
@@ -1,7 +1,7 @@
 import json
 import apache_beam as beam
 
-from typing import Callable, Dict, List
+from typing import Callable, List
 
 from helm.benchmark.contamination.contamination_parser import create_parser
 from contamination_beam import ComputeAndWriteContaminationStats

--- a/scripts/contamination/run_contamination_beam.py
+++ b/scripts/contamination/run_contamination_beam.py
@@ -1,0 +1,53 @@
+import json
+import apache_beam as beam
+
+from typing import Callable, Dict, List
+
+from helm.benchmark.contamination.contamination_parser import create_parser
+from contamination_beam import ComputeAndWriteContaminationStats
+
+
+def get_text_extract_function(input_format: str):
+    def extract_text_from_the_pile_document(document: str) -> str:
+        return json.loads(document)["text"]
+
+    def extract_text_from_raw_document(document: str) -> str:
+        return document.rstrip("\n")
+
+    if input_format == "raw":
+        return extract_text_from_raw_document
+    elif input_format == "the_pile":
+        return extract_text_from_the_pile_document
+    else:
+        raise NotImplementedError(f"Unknown input format {input_format}")
+
+
+def main():
+    parser = create_parser()
+    args = parser.parse_args()
+
+    n_values: List[int] = [5, 9, 13]  # TODO: Pick the N values
+    extract_text_from_document: Callable[[str], str] = get_text_extract_function(args.input_format)
+
+    # The model developer should pass in the appropriate PipelineOptions here.
+    with beam.Pipeline() as pipeline:
+        _ = (
+            pipeline
+            # The model developer should modify these lines to read from the actual training set.
+            | "Read" >> beam.io.ReadFromText(args.input_data)
+            | "ExtractTextFromDocument" >> beam.Map(extract_text_from_document)
+            # Call the HELM Contamination Apache Beam API.
+            | "ComputeAndWriteContaminationStats"
+            >> ComputeAndWriteContaminationStats(
+                scenario_data_path=args.scenario_data,
+                n_values=n_values,
+                normalization=args.normalization,
+                tags=args.tags,
+                output_stats=args.output_stats,
+            )
+        )
+    print(f"Wrote results to {args.output_stats}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/helm/benchmark/contamination/contamination_parser.py
+++ b/src/helm/benchmark/contamination/contamination_parser.py
@@ -1,0 +1,39 @@
+import argparse
+
+
+def create_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input-data", type=str, required=True, help="Path to your training data")
+    parser.add_argument("--scenario-data", type=str, required=True, help="Path to scenario data (benchmarking data)")
+    parser.add_argument("--output-stats", type=str, required=True, help="Path to the output file")
+    parser.add_argument(
+        "--input-format",
+        type=str,
+        required=True,
+        help="The format of your input file for your training data, e.g. raw, custom, the_pile",
+    )
+    parser.add_argument(
+        "--tags",
+        type=str,
+        nargs="*",
+        help="Other tags, such as whether the input data is for pretraining or instruction tuning",
+    )
+    parser.add_argument(
+        "--normalization", type=str, default="default", help="What normalization and tokenization strategy to apply"
+    )
+    parser.add_argument(
+        "--output-ngrams",
+        type=str,
+        default=None,
+        help="Path to the file of contaminated ngrams. To output the ngrams, you must also specify --max-output-ngrams",
+    )
+    parser.add_argument(
+        "--max-output-ngrams",
+        type=int,
+        default=0,
+        help=(
+            "The max number of contaminated ngrams to be stored for each (n, light_instance, part)."
+            "Set to -1 to store all"
+        ),
+    )
+    return parser


### PR DESCRIPTION
This script is based on the sequential version ([src/helm/benchmark/contamination/compute_contamination_metrics.py](https://github.com/stanford-crfm/helm/blob/main/src/helm/benchmark/contamination/compute_contamination_metrics.py)) and @yifanmai's prototype. The script replicates the outputs of the sequential version on a small yet diverse dataset.

The command to run is the same with the sequential version: `python run_contamination_beam.py --input-data <INPUT_DATA_PATH> --scenario-data <SCENARIO_DATA_PATH> --output-stats <OUPUT_DATA_PATH> --input-format <INPUT_FORMAT> --normalization none --tags <TAG1> <TAG2>`. We also provide some basic instructions for users to customize the script on their own in [README.md](https://github.com/stanford-crfm/helm/tree/data-contamination-beam/scripts/contamination).


TODO: We haven't supported outputting the contaminated ngrams in the distributed mode.