### PR TITLE
Use crfm-proxy-server on PATH in test_remote_service

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,13 +47,13 @@ jobs:
       - run: ./pre-commit-venv.sh
       - name: Run tests
         # Skip ICE tokenizer tests. GHA is having trouble downloading ice_text.model.
-        run: venv/bin/pytest --ignore src/helm/benchmark/window_services/test_ice_window_service.py --ignore src/helm/proxy/clients/test_ice_tokenizer_client.py
+        run: source venv/bin/activate && pytest --ignore src/helm/benchmark/window_services/test_ice_window_service.py --ignore src/helm/proxy/clients/test_ice_tokenizer_client.py
         env:
           TEST: ${{ matrix.test }}
           VERSION: ${{ github.head_ref || 'main' }}
       - name: Run entire pipeline quickly without any data
         # Checking RunSpecs with openai/davinci should be comprehensive enough
-        run: venv/bin/helm-run --suite test -m 100 --skip-instances --models-to-run openai/davinci --exit-on-error
+        run: source venv/bin/activate && helm-run --suite test -m 100 --skip-instances --models-to-run openai/davinci --exit-on-error
 
   ci:
     name: All CI tasks complete

--- a/src/helm/proxy/services/test_remote_service.py
+++ b/src/helm/proxy/services/test_remote_service.py
@@ -21,10 +21,6 @@ from .remote_service import RemoteService
 from .service import ACCOUNTS_FILE
 
 
-SERVER_EXECUTABLE: str = "venv/bin/crfm-proxy-server"
-SERVER_TIMEOUT_SECONDS: int = 60
-
-
 @dataclass(frozen=True)
 class TempServerInfo:
     url: str
@@ -39,7 +35,7 @@ class TestRemoteServerService:
     """
 
     _ADMIN_API_KEY: str = "admin"
-    _SERVER_EXECUTABLE: str = "venv/bin/crfm-proxy-server"
+    _SERVER_EXECUTABLE: str = "crfm-proxy-server"
     _SERVER_TIMEOUT_SECONDS: int = 60
 
     @staticmethod


### PR DESCRIPTION
Instead of hardcoding the relative path to `crfm-proxy-server`, instead rely on it being directly invokable via `PATH`. This fixes the test for cases where `crfm-proxy-server` is not located under `venv/bin` e.g. inside Conda.