### PR TITLE
Allow instances to be pre-downloaded and then read from files.

### DIFF
--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -75,9 +75,8 @@ def run_benchmarking(
     suite: str,
     dry_run: bool,
     skip_instances: bool,
-    write_instances: bool,
-    write_instances_only: bool,
-    read_instances_from_file: bool,
+    cache_instances: bool,
+    cache_instances_only: bool,
     skip_completed_runs: bool,
     exit_on_error: bool,
     mongo_uri: str = "",
@@ -101,9 +100,8 @@ def run_benchmarking(
         output_path,
         suite,
         skip_instances,
-        write_instances,
-        write_instances_only,
-        read_instances_from_file,
+        cache_instances,
+        cache_instances_only,
         skip_completed_runs,
         exit_on_error,
     )
@@ -136,22 +134,16 @@ def add_run_args(parser: argparse.ArgumentParser):
         help="Skip creation of instances (basically do nothing but just parse everything).",
     )
     parser.add_argument(
-        "--write-instances",
+        "--cache-instances",
         action="store_true",
         default=None,
-        help="Save generated instances input to model to disk.",
+        help="Save generated instances input to model to disk. If they're already cached, read instances from cache file.",
     )
     parser.add_argument(
-        "--write-instances-only",
+        "--cache-instances-only",
         action="store_true",
         default=None,
         help="Generate and save instances for scenario ONLY (i.e. do not evaluate models on instances).",
-    )
-    parser.add_argument(
-        "--read-instances-from-file",
-        action="store_true",
-        default=None,
-        help="Read instances from already generated instances.json file",
     )
     parser.add_argument(
         "-d",
@@ -305,9 +297,8 @@ def main():
         suite=args.suite,
         dry_run=args.dry_run,
         skip_instances=args.skip_instances,
-        write_instances=args.write_instances,
-        write_instances_only=args.write_instances_only,
-        read_instances_from_file=args.read_instances_from_file,
+        cache_instances=args.cache_instances,
+        cache_instances_only=args.cache_instances_only,
         skip_completed_runs=args.skip_completed_runs,
         exit_on_error=args.exit_on_error,
         mongo_uri=args.mongo_uri,

--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -129,13 +129,13 @@ def add_run_args(parser: argparse.ArgumentParser):
         "--save-instances-only",
         action="store_true",
         default=None,
-        help="Test",
+        help="Generate and save instances for scenario ONLY (i.e. do not evaluate models on instances).",
     )
     parser.add_argument(
         "--read-instances-from-file",
         action="store_true",
         default=None,
-        help="Test",
+        help="Read instances from already generated instances.json file (if it exists)",
     )
     parser.add_argument(
         "-d",

--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -94,7 +94,15 @@ def run_benchmarking(
         for run_spec in run_specs:
             hlog(run_spec)
 
-    runner = Runner(execution_spec, output_path, suite, save_instances_only, read_instances_from_file, skip_completed_runs, exit_on_error)
+    runner = Runner(
+        execution_spec,
+        output_path,
+        suite,
+        save_instances_only,
+        read_instances_from_file,
+        skip_completed_runs,
+        exit_on_error,
+    )
     runner.run_all(run_specs)
     return run_specs
 
@@ -269,7 +277,7 @@ def main():
         hlog("There were no RunSpecs or they got filtered out.")
         return
 
-    auth: Authentication = Authentication("") if args.skip_instances or args.local else create_authentication(args)
+    auth: Authentication = Authentication("") if args.local else create_authentication(args)
     run_benchmarking(
         run_specs=run_specs,
         auth=auth,

--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -74,7 +74,8 @@ def run_benchmarking(
     output_path: str,
     suite: str,
     dry_run: bool,
-    skip_instances: bool,
+    save_instances_only: bool,
+    read_instances_from_file: bool,
     skip_completed_runs: bool,
     exit_on_error: bool,
     mongo_uri: str = "",
@@ -93,7 +94,7 @@ def run_benchmarking(
         for run_spec in run_specs:
             hlog(run_spec)
 
-    runner = Runner(execution_spec, output_path, suite, skip_instances, skip_completed_runs, exit_on_error)
+    runner = Runner(execution_spec, output_path, suite, save_instances_only, read_instances_from_file, skip_completed_runs, exit_on_error)
     runner.run_all(run_specs)
     return run_specs
 
@@ -117,10 +118,16 @@ def add_run_args(parser: argparse.ArgumentParser):
     )
     parser.add_argument("-n", "--num-threads", type=int, help="Max number of threads to make requests", default=4)
     parser.add_argument(
-        "--skip-instances",
+        "--save-instances-only",
         action="store_true",
         default=None,
-        help="Skip creation of instances (basically do nothing but just parse everything).",
+        help="Test",
+    )
+    parser.add_argument(
+        "--read-instances-from-file",
+        action="store_true",
+        default=None,
+        help="Test",
     )
     parser.add_argument(
         "-d",
@@ -273,7 +280,8 @@ def main():
         output_path=args.output_path,
         suite=args.suite,
         dry_run=args.dry_run,
-        skip_instances=args.skip_instances,
+        save_instances_only=args.save_instances_only,
+        read_instances_from_file=args.read_instances_from_file,
         skip_completed_runs=args.skip_completed_runs,
         exit_on_error=args.exit_on_error,
         mongo_uri=args.mongo_uri,

--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -193,6 +193,8 @@ def add_run_args(parser: argparse.ArgumentParser):
 
 def validate_args(args):
     assert args.suite != LATEST_SYMLINK, f"Suite name can't be '{LATEST_SYMLINK}'"
+    if args.cache_instances_only:
+        assert args.cache_instances, "If --cache-instances-only is set, --cache-instances must also be set."
 
 
 @htrack(None)

--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -75,7 +75,8 @@ def run_benchmarking(
     suite: str,
     dry_run: bool,
     skip_instances: bool,
-    save_instances_only: bool,
+    write_instances: bool,
+    write_instances_only: bool,
     read_instances_from_file: bool,
     skip_completed_runs: bool,
     exit_on_error: bool,
@@ -100,7 +101,8 @@ def run_benchmarking(
         output_path,
         suite,
         skip_instances,
-        save_instances_only,
+        write_instances,
+        write_instances_only,
         read_instances_from_file,
         skip_completed_runs,
         exit_on_error,
@@ -134,7 +136,13 @@ def add_run_args(parser: argparse.ArgumentParser):
         help="Skip creation of instances (basically do nothing but just parse everything).",
     )
     parser.add_argument(
-        "--save-instances-only",
+        "--write-instances",
+        action="store_true",
+        default=None,
+        help="Save generated instances input to model to disk.",
+    )
+    parser.add_argument(
+        "--write-instances-only",
         action="store_true",
         default=None,
         help="Generate and save instances for scenario ONLY (i.e. do not evaluate models on instances).",
@@ -143,7 +151,7 @@ def add_run_args(parser: argparse.ArgumentParser):
         "--read-instances-from-file",
         action="store_true",
         default=None,
-        help="Read instances from already generated instances.json file (if it exists)",
+        help="Read instances from already generated instances.json file",
     )
     parser.add_argument(
         "-d",
@@ -297,7 +305,8 @@ def main():
         suite=args.suite,
         dry_run=args.dry_run,
         skip_instances=args.skip_instances,
-        save_instances_only=args.save_instances_only,
+        write_instances=args.write_instances,
+        write_instances_only=args.write_instances_only,
         read_instances_from_file=args.read_instances_from_file,
         skip_completed_runs=args.skip_completed_runs,
         exit_on_error=args.exit_on_error,

--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -74,6 +74,7 @@ def run_benchmarking(
     output_path: str,
     suite: str,
     dry_run: bool,
+    skip_instances: bool,
     save_instances_only: bool,
     read_instances_from_file: bool,
     skip_completed_runs: bool,
@@ -98,6 +99,7 @@ def run_benchmarking(
         execution_spec,
         output_path,
         suite,
+        skip_instances,
         save_instances_only,
         read_instances_from_file,
         skip_completed_runs,
@@ -125,6 +127,12 @@ def add_run_args(parser: argparse.ArgumentParser):
         "-o", "--output-path", type=str, help="Where to save all the output", default="benchmark_output"
     )
     parser.add_argument("-n", "--num-threads", type=int, help="Max number of threads to make requests", default=4)
+    parser.add_argument(
+        "--skip-instances",
+        action="store_true",
+        default=None,
+        help="Skip creation of instances (basically do nothing but just parse everything).",
+    )
     parser.add_argument(
         "--save-instances-only",
         action="store_true",
@@ -277,7 +285,7 @@ def main():
         hlog("There were no RunSpecs or they got filtered out.")
         return
 
-    auth: Authentication = Authentication("") if args.local else create_authentication(args)
+    auth: Authentication = Authentication("") if args.skip_instances or args.local else create_authentication(args)
     run_benchmarking(
         run_specs=run_specs,
         auth=auth,
@@ -288,6 +296,7 @@ def main():
         output_path=args.output_path,
         suite=args.suite,
         dry_run=args.dry_run,
+        skip_instances=args.skip_instances,
         save_instances_only=args.save_instances_only,
         read_instances_from_file=args.read_instances_from_file,
         skip_completed_runs=args.skip_completed_runs,

--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -137,7 +137,7 @@ def add_run_args(parser: argparse.ArgumentParser):
         "--cache-instances",
         action="store_true",
         default=None,
-        help="Save generated instances input to model to disk. If they're already cached, read instances from cache file.",
+        help="Save generated instances input to model to disk. If already cached, read instances from file.",
     )
     parser.add_argument(
         "--cache-instances-only",

--- a/src/helm/benchmark/runner.py
+++ b/src/helm/benchmark/runner.py
@@ -98,7 +98,7 @@ class Runner:
         # Decide where to save the raw data (e.g., "output/scenarios/mmlu").
         self.scenarios_path: str = os.path.join(output_path, "scenarios")
         ensure_directory_exists(self.scenarios_path)
-        # Decide where to save pre-processed instances
+        # Decide where to save input instances
         self.instances_path: str = os.path.join(output_path, "scenario_instances")
         ensure_directory_exists(self.instances_path)
 
@@ -136,7 +136,8 @@ class Runner:
 
         # This 'output_path' will be used when the model's input instances are saved.
         args_str = ",".join([f"{k}={v}" for k, v in sorted(run_spec.scenario_spec.args.items())])
-        input_instances_output_path = os.path.join(self.instances_path, f"{scenario.name}:{args_str}")
+        scenario_name_with_args = f"{scenario.name}:{args_str}" if args_str else f"{scenario.name}"
+        input_instances_output_path = os.path.join(self.instances_path, scenario_name_with_args)
         input_instances_file_path = os.path.join(input_instances_output_path, "input_instances.json")
 
         run_path: str = os.path.join(self.runs_path, run_spec.name)

--- a/src/helm/benchmark/runner.py
+++ b/src/helm/benchmark/runner.py
@@ -5,7 +5,7 @@ import traceback
 import typing
 from collections import Counter
 from dataclasses import dataclass, field
-from typing import List
+from typing import Any, Dict, List
 
 from tqdm import tqdm
 
@@ -148,8 +148,8 @@ class Runner:
         else:
             if self.read_instances_from_file:
                 with open(os.path.join(scenario.output_path, "instances.json")) as f:
-                    instances = json.load(f)
-                instances = [dacite.from_dict(Instance, instance) for instance in instances]
+                    json_instances: List[Dict[str, Any]] = json.load(f)
+                instances = [dacite.from_dict(Instance, instance) for instance in json_instances]
             else:
                 # Create the instances of the scenario
                 with htrack_block("scenario.get_instances"):

--- a/src/helm/benchmark/runner.py
+++ b/src/helm/benchmark/runner.py
@@ -152,9 +152,10 @@ class Runner:
             # Save instances to file
             write(
                 os.path.join(scenario.output_path, "instances.json"),
-                json.dumps([asdict_without_nones(instance) for instance in instances], indent=2)
+                json.dumps([asdict_without_nones(instance) for instance in instances], indent=2),
             )
-            if save_instances_only: return  # Exit after saving the instances.
+            if self.save_instances_only:
+                return  # Exit after saving the instances.
 
         # Give each instance a unique ID
         instances = with_instance_ids(instances)

--- a/src/helm/benchmark/runner.py
+++ b/src/helm/benchmark/runner.py
@@ -135,7 +135,7 @@ class Runner:
         ensure_directory_exists(scenario.output_path)
 
         # This 'output_path' will be used when the model's input instances are saved.
-        args_str = ",".join([f"{k}:{v}" for k, v in sorted(run_spec.scenario_spec.args.items())])
+        args_str = ",".join([f"{k}={v}" for k, v in sorted(run_spec.scenario_spec.args.items())])
         input_instances_output_path = os.path.join(self.instances_path, f"{scenario.name}:{args_str}")
         input_instances_file_path = os.path.join(input_instances_output_path, "input_instances.json")
 


### PR DESCRIPTION
For #1489

Right now, all information is cached/saved by helm-run after running models on scenarios (i.e. until basically the whole run has finished). This change allows for users to specify flags to generate the instances for that scenario _only_ without evaluating the model and/or to read instances from an existing file rather than redownloading the dataset and regenerating those instances.

This functionality is meant to be used to make it more feasible to run HELM on Codalab.