### PR TITLE
Reduce Jurassic-2 Jumbo sequence length to 6000

### DIFF
--- a/src/helm/benchmark/window_services/wider_ai21_window_service.py
+++ b/src/helm/benchmark/window_services/wider_ai21_window_service.py
@@ -11,3 +11,14 @@ class WiderAI21WindowService(AI21WindowService):
         so the actual max sequence length is 8192 - 1 = 8191.
         """
         return 8191
+
+
+class AI21Jurassic2JumboWindowService(AI21WindowService):
+    @property
+    def max_sequence_length(self) -> int:
+        """
+        Return the max sequence length of the AI21 Jurassic-2 Jumbo.
+
+        AI21 has recommended using a sequence length of 6000 tokens to avoid OOMs.
+        """
+        return 6000

--- a/src/helm/benchmark/window_services/window_service_factory.py
+++ b/src/helm/benchmark/window_services/window_service_factory.py
@@ -3,13 +3,14 @@ from helm.proxy.models import (
     get_model_names_with_tag,
     Model,
     AI21_WIDER_CONTEXT_WINDOW_TAG,
+    AI21_JURASSIC_2_JUMBO_CONTEXT_WINDOW_TAG,
     WIDER_CONTEXT_WINDOW_TAG,
     GPT4_TOKENIZER_TAG,
     GPT4_CONTEXT_WINDOW_TAG,
     GPT4_32K_CONTEXT_WINDOW_TAG,
 )
 from .ai21_window_service import AI21WindowService
-from .wider_ai21_window_service import WiderAI21WindowService
+from .wider_ai21_window_service import WiderAI21WindowService, AI21Jurassic2JumboWindowService
 from .anthropic_window_service import AnthropicWindowService, LegacyAnthropicWindowService
 from .cohere_window_service import CohereWindowService, CohereCommandWindowService
 from .luminous_window_service import (
@@ -142,6 +143,10 @@ class WindowServiceFactory:
         elif organization == "ai21":
             if model_name in get_model_names_with_tag(AI21_WIDER_CONTEXT_WINDOW_TAG):
                 window_service = WiderAI21WindowService(service=service, gpt2_window_service=GPT2WindowService(service))
+            if model_name in get_model_names_with_tag(AI21_JURASSIC_2_JUMBO_CONTEXT_WINDOW_TAG):
+                window_service = AI21Jurassic2JumboWindowService(
+                    service=service, gpt2_window_service=GPT2WindowService(service)
+                )
             else:
                 window_service = AI21WindowService(service=service, gpt2_window_service=GPT2WindowService(service))
         else:

--- a/src/helm/proxy/models.py
+++ b/src/helm/proxy/models.py
@@ -29,6 +29,10 @@ GPT4_32K_CONTEXT_WINDOW_TAG: str = "gpt4_32k_context_window"  # 32768 tokens
 # For AI21 Jurassic-2 models with wider context windows
 AI21_WIDER_CONTEXT_WINDOW_TAG: str = "ai21_wider_context_window"
 
+# For AI21 Jurassic-2 Jumbo
+# AI21 has recommended using a sequence length of 6000 tokens to avoid OOMs.
+AI21_JURASSIC_2_JUMBO_CONTEXT_WINDOW_TAG: str = "ai21_jurassic_2_jumbo_context_window"  # 6000
+
 # To fetch models that use these tokenizers
 GPT2_TOKENIZER_TAG: str = "gpt2_tokenizer"
 AI21_TOKENIZER_TAG: str = "ai21_tokenizer"
@@ -148,7 +152,12 @@ ALL_MODELS = [
         name="ai21/j2-jumbo",
         display_name="Jurassic-2 Jumbo (178B)",
         description="Jurassic-2 Jumbo (178B parameters)",
-        tags=[TEXT_MODEL_TAG, AI21_WIDER_CONTEXT_WINDOW_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG, AI21_TOKENIZER_TAG],
+        tags=[
+            TEXT_MODEL_TAG,
+            AI21_JURASSIC_2_JUMBO_CONTEXT_WINDOW_TAG,
+            FULL_FUNCTIONALITY_TEXT_MODEL_TAG,
+            AI21_TOKENIZER_TAG,
+        ],
     ),
     Model(
         group="jurassic",


### PR DESCRIPTION
AI21 has recommended using a sequence length of 6000 tokens to avoid OOMs.