### PR TITLE
Move symlink to summarize

### DIFF
--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -996,11 +996,11 @@ def main():
     summarizer.write_run_specs()
     summarizer.write_groups()
     summarizer.write_cost_report()
-    symlink_latest()
 
     if not args.skip_write_run_display_json:
         summarizer.write_run_display_json()
 
+    symlink_latest()
     hlog("Done.")
 
 

--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -1,6 +1,5 @@
 import argparse
 from dataclasses import replace
-import os
 from typing import List, Optional
 
 from helm.benchmark.presentation.run_entry import RunEntry, read_run_entries
@@ -13,11 +12,8 @@ from helm.proxy.services.remote_service import create_authentication, add_servic
 
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from .executor import ExecutionSpec
-from .runner import Runner, RunSpec
+from .runner import Runner, RunSpec, LATEST_SYMLINK
 from .run_specs import construct_run_specs
-
-
-LATEST_SYMLINK: str = "latest"
 
 
 def run_entries_to_run_specs(
@@ -107,19 +103,6 @@ def run_benchmarking(
     )
     runner.run_all(run_specs)
     return run_specs
-
-
-def symlink_latest(output_path: str, suite: str) -> None:
-    # Create a symlink runs/latest -> runs/<name_of_suite>,
-    # so runs/latest always points to the latest run suite.
-    runs_dir: str = os.path.join(output_path, "runs")
-    suite_dir: str = os.path.join(runs_dir, suite)
-    symlink_path: str = os.path.abspath(os.path.join(runs_dir, LATEST_SYMLINK))
-    hlog(f"Symlinking {suite_dir} to {LATEST_SYMLINK}.")
-    if os.path.islink(symlink_path):
-        # Remove the previous symlink if it exists.
-        os.unlink(symlink_path)
-    os.symlink(os.path.abspath(suite_dir), symlink_path)
 
 
 def add_run_args(parser: argparse.ArgumentParser):
@@ -288,8 +271,6 @@ def main():
         return
 
     auth: Authentication = Authentication("") if args.skip_instances or args.local else create_authentication(args)
-
-    symlink_latest(output_path=args.output_path, suite=args.suite)
 
     run_benchmarking(
         run_specs=run_specs,

--- a/src/helm/benchmark/runner.py
+++ b/src/helm/benchmark/runner.py
@@ -27,6 +27,9 @@ from .metrics.metric import Metric, MetricSpec, MetricResult, PerInstanceStats, 
 from .window_services.tokenizer_service import TokenizerService
 
 
+LATEST_SYMLINK: str = "latest"
+
+
 class RunnerError(Exception):
     """Error that happens in the Runner."""
 


### PR DESCRIPTION
This prevents parallel invocations of `helm-run` from crashing with `No such file or directory: 'current_directory/benchmark_output/runs/latest'` due to the race condition in `symlink_latest`.

This is the more appropriate place anyway, since `helm-summarize` builds files for the web frontend. Also this allows switching to previously run suites easily.