### PR TITLE
Add support GPT2 models decoded via Megatron-LM server

### DIFF
--- a/src/helm/benchmark/static/schema.yaml
+++ b/src/helm/benchmark/static/schema.yaml
@@ -309,7 +309,7 @@ models:
     access: open
     num_parameters: 6700000000
     release_date: 2022-05-02
-  
+
   - name: together/opt-1.3b
     display_name: OPT (1.3B)
     description: Open Pre-trained Transformers (1.3B parameters) is a suite of decoder-only pre-trained transformers that are fully and responsibly shared with interested researchers ([paper](https://arxiv.org/pdf/2205.01068.pdf)).
@@ -548,7 +548,7 @@ models:
     access: limited
     num_parameters: 35000000000
     release_date: 2023-04-13
-  
+
   # Yandex
   - name: together/yalm
     display_name: YaLM (100B)
@@ -557,6 +557,14 @@ models:
     access: open
     num_parameters: 100000000000
     release_date: 2022-06-23
+
+  # Nvidia
+  - name: nvidia/megatron-gpt2
+    display_name: Megatron GPT2
+    description: Megatron GPT2
+    description: GPT-2 implemented in Megatron-LM ([paper](https://arxiv.org/abs/1909.08053)).
+    creator_organization: Nvidia
+    access: open
 
 ############################################################
 adapter:
@@ -2513,21 +2521,21 @@ run_groups:
 ## Aspirational scenarios
 # Task coverage
   - name: data_to_text_generation
-    display_name: Data-to-text generation 
+    display_name: Data-to-text generation
     description: Currently, we prioritize user-facing tasks in our core scenarios, but don't implement data-to-text generation. Could be implemented via WebNLG, E2E, ToTTo, etc.
     taxonomy:
       task: data-to-text generation
     todo: true
 
   - name: fact_verification
-    display_name: Fact verification 
+    display_name: Fact verification
     description: Currently, we prioritize user-facing tasks in our core scenarios, but don't implement fact verification. Could be implemented via FEVER.
     taxonomy:
       task: fact verification
     todo: true
 
   - name: copywriting
-    display_name: Copywriting 
+    display_name: Copywriting
     description: Currently, we prioritize user-facing tasks in our core scenarios, but don't implement tasks that have not been historically studied in the NLP research community like (ad) copywriting.
     taxonomy:
       task: copywriting
@@ -2599,7 +2607,7 @@ run_groups:
     todo: true
 
   - name: non_US_demographics
-    display_name: Scenarios involving data from marginalized demographics in non-US English-speaking regions 
+    display_name: Scenarios involving data from marginalized demographics in non-US English-speaking regions
     description: Currently, we ensure some coverage of language based on US-centric demographic groups, including marginalized groups. We should implement scenarios to ensure coverage of other socially-relevant groups beyond US demographics (e.g., caste in India).
     taxonomy:
       who: relevant demographics in non-US English-speaking regions

--- a/src/helm/benchmark/window_services/megatron_window_service.py
+++ b/src/helm/benchmark/window_services/megatron_window_service.py
@@ -4,7 +4,6 @@ from .gpt2_window_service import GPT2WindowService
 # NOTE: The only difference between this and GPT2WindowService is that
 # the request length is constrained to the sequence length.
 class MegatronWindowService(GPT2WindowService):
-
     @property
     def max_request_length(self) -> int:
         """Return the max request length of GPT-2."""

--- a/src/helm/benchmark/window_services/megatron_window_service.py
+++ b/src/helm/benchmark/window_services/megatron_window_service.py
@@ -1,0 +1,11 @@
+from .gpt2_window_service import GPT2WindowService
+
+
+# NOTE: The only difference between this and GPT2WindowService is that
+# the request length is constrained to the sequence length.
+class MegatronWindowService(GPT2WindowService):
+
+    @property
+    def max_request_length(self) -> int:
+        """Return the max request length of GPT-2."""
+        return self.max_sequence_length

--- a/src/helm/benchmark/window_services/window_service_factory.py
+++ b/src/helm/benchmark/window_services/window_service_factory.py
@@ -136,7 +136,7 @@ class WindowServiceFactory:
             window_service = UL2WindowService(service)
         elif model_name == "together/yalm":
             window_service = YaLMWindowService(service)
-        elif model_name == "megatron/gpt2":
+        elif model_name == "nvidia/megatron-gpt2":
             window_service = MegatronWindowService(service)
         elif organization == "cohere":
             if "command" in engine:

--- a/src/helm/benchmark/window_services/window_service_factory.py
+++ b/src/helm/benchmark/window_services/window_service_factory.py
@@ -35,6 +35,7 @@ from .bigcode_large_model_window_service import BigCodeLargeModelWindowService
 from .gpt2_window_service import GPT2WindowService
 from .gptj_window_service import GPTJWindowService
 from .gptneox_window_service import GPTNeoXWindowService
+from .megatron_window_service import MegatronWindowService
 from .opt_window_service import OPTWindowService
 from .palmyra_window_service import PalmyraWindowService, SilkRoadWindowService
 from .remote_window_service import get_remote_window_service
@@ -136,7 +137,7 @@ class WindowServiceFactory:
         elif model_name == "together/yalm":
             window_service = YaLMWindowService(service)
         elif model_name == "megatron/gpt2":
-            window_service = GPT2WindowService(service)
+            window_service = MegatronWindowService(service)
         elif organization == "cohere":
             if "command" in engine:
                 window_service = CohereCommandWindowService(service)

--- a/src/helm/benchmark/window_services/window_service_factory.py
+++ b/src/helm/benchmark/window_services/window_service_factory.py
@@ -135,6 +135,8 @@ class WindowServiceFactory:
             window_service = UL2WindowService(service)
         elif model_name == "together/yalm":
             window_service = YaLMWindowService(service)
+        elif model_name == "megatron/gpt2":
+            window_service = GPT2WindowService(service)
         elif organization == "cohere":
             if "command" in engine:
                 window_service = CohereCommandWindowService(service)

--- a/src/helm/proxy/clients/auto_client.py
+++ b/src/helm/proxy/clients/auto_client.py
@@ -130,7 +130,7 @@ class AutoClient(Client):
                     cache_config=cache_config,
                     tokenizer_client=self._get_tokenizer_client("huggingface"),
                 )
-            elif organization == "megatron":
+            elif organization == "nvidia":
                 client = MegatronClient(cache_config=cache_config)
             else:
                 raise ValueError(f"Could not find client for model: {model}")
@@ -203,7 +203,7 @@ class AutoClient(Client):
                 client = CohereClient(api_key=self.credentials["cohereApiKey"], cache_config=cache_config)
             elif organization == "simple":
                 client = SimpleClient(cache_config=cache_config)
-            elif organization == "megatron":
+            elif organization == "nvidia":
                 client = MegatronClient(cache_config=cache_config)
             else:
                 raise ValueError(f"Could not find tokenizer client for model: {tokenizer}")

--- a/src/helm/proxy/clients/auto_client.py
+++ b/src/helm/proxy/clients/auto_client.py
@@ -26,6 +26,7 @@ from .google_client import GoogleClient
 from .goose_ai_client import GooseAIClient
 from .huggingface_client import HuggingFaceClient
 from .ice_tokenizer_client import ICETokenizerClient
+from .megatron_client import MegatronClient
 from .openai_client import OpenAIClient
 from .microsoft_client import MicrosoftClient
 from .perspective_api_client import PerspectiveAPIClient
@@ -129,6 +130,8 @@ class AutoClient(Client):
                     cache_config=cache_config,
                     tokenizer_client=self._get_tokenizer_client("huggingface"),
                 )
+            elif organization == "megatron":
+                client = MegatronClient(cache_config=cache_config)
             else:
                 raise ValueError(f"Could not find client for model: {model}")
             self.clients[model] = client
@@ -200,6 +203,8 @@ class AutoClient(Client):
                 client = CohereClient(api_key=self.credentials["cohereApiKey"], cache_config=cache_config)
             elif organization == "simple":
                 client = SimpleClient(cache_config=cache_config)
+            elif organization == "megatron":
+                client = MegatronClient(cache_config=cache_config)
             else:
                 raise ValueError(f"Could not find tokenizer client for model: {tokenizer}")
             self.tokenizer_clients[tokenizer] = client

--- a/src/helm/proxy/clients/megatron_client.py
+++ b/src/helm/proxy/clients/megatron_client.py
@@ -1,0 +1,106 @@
+import json
+import requests
+from typing import Any, Dict, List
+import traceback
+
+from helm.common.cache import CacheConfig
+from helm.common.request import (
+    EMBEDDING_UNAVAILABLE_REQUEST_RESULT,
+    Request,
+    RequestResult,
+    Sequence,
+    Token)
+from helm.common.tokenization_request import TokenizationRequest
+from helm.proxy.clients.huggingface_client import HuggingFaceClient
+from helm.proxy.clients.client import Client, wrap_request_time, truncate_sequence
+
+
+class MegatronClient(HuggingFaceClient):
+
+    def __init__(self, cache_config: CacheConfig):
+        super().__init__(cache_config)
+
+    def _send_request(self, raw_request: Dict[str, Any]) -> Dict[str, Any]:
+        response = requests.request(
+            method="PUT",
+            # TODO(tgale): Make this configurable.
+            url="http://localhost:5000/api",
+            headers={
+                "Content-Type": "application/json; charset=UTF-8",
+            },
+            data=json.dumps(raw_request),
+        )
+        out = json.loads(response.text)
+
+        # Detect if the server returned an error string.
+        if type(out) != dict:
+            raise ValueError(f"{response}: {response.text}")
+        return out
+
+    def _tokenize_response(self, text: str) -> List[Token]:
+        tokenized_text = self.tokenize(
+            TokenizationRequest(text, tokenizer="huggingface/gpt2"))
+
+        # TODO(tgale): Support logprobs.
+        tokens = [
+            Token(text=str(token), logprob=0, top_logprobs={})
+            for token in tokenized_text.raw_tokens
+        ]
+        return tokens
+
+    def _make_request(self, request: Request) -> RequestResult:
+        # Embedding not supported for this model
+        if request.embedding:
+            return EMBEDDING_UNAVAILABLE_REQUEST_RESULT
+
+        # TODO(tgale): Relax these.
+        assert request.num_completions == 1
+        assert not request.echo_prompt
+        assert not request.stop_sequences
+        assert request.top_p == 1
+
+        # TODO(tgale): Handle log probabilities.
+        raw_request = {
+            "prompts": [request.prompt],
+            "tokens_to_generate": request.max_tokens,
+            "temperature": 1e-7 if request.temperature == 0 else request.temperature,
+            "top_k": request.top_k_per_token,
+        }
+
+        cache_key = Client.make_cache_key(raw_request, request)
+        response, cached = self.cache.get(cache_key, wrap_request_time(
+            lambda: self._send_request(raw_request)))
+
+        # Verify we got a single response for the prompt.
+        assert len(response["text"]) == 1
+
+        # NOTE: Megatron returns the response with the prompt included.
+        generated_text = response["text"][0]
+        if not request.echo_prompt:
+            generated_text = generated_text[len(request.prompt):]
+
+        # NOTE: Megatron returns the de-tokenized response. Re-tokenize.
+        tokens = self._tokenize_response(generated_text)
+        completion = Sequence(text=generated_text, logprob=0, tokens=tokens)
+        completion = truncate_sequence(completion, request, print_warning=True)
+
+        return RequestResult(
+            success=True,
+            cached=cached,
+            request_time=response["request_time"],
+            request_datetime=response.get("request_datetime"),
+            completions=[completion],
+            embedding=[])
+
+    def make_request(self, request: Request) -> RequestResult:
+        try:
+            return self._make_request(request)
+        except Exception as e:
+            print(f"EXCEPTION = {e}")
+            print(traceback.format_exc())
+            return RequestResult(
+                success=False,
+                cached=False,
+                error=f"MegatronClient Error: {e}",
+                completions=[],
+                embedding=[])

--- a/src/helm/proxy/clients/megatron_client.py
+++ b/src/helm/proxy/clients/megatron_client.py
@@ -11,8 +11,13 @@ from helm.proxy.clients.client import Client, wrap_request_time, truncate_sequen
 
 
 class MegatronClient(HuggingFaceClient):
-    def __init__(self, cache_config: CacheConfig):
-        super().__init__(cache_config)
+    """Client for remote Megatron-LM server.
+
+    This client expects an external Megatron-LM server to be run on localhost:5000. See the
+    Megatron-LM respository for documentation on starting a Megatron text generation server:
+
+    https://github.com/NVIDIA/Megatron-LM#gpt-text-generation
+    """
 
     def _send_request(self, raw_request: Dict[str, Any]) -> Dict[str, Any]:
         response = requests.request(
@@ -53,7 +58,7 @@ class MegatronClient(HuggingFaceClient):
         raw_request = {
             "prompts": [request.prompt],
             "tokens_to_generate": request.max_tokens,
-            "temperature": 1e-7 if request.temperature == 0 else request.temperature,
+            "temperature": request.temperature,
             "top_k": request.top_k_per_token,
         }
 

--- a/src/helm/proxy/clients/megatron_client.py
+++ b/src/helm/proxy/clients/megatron_client.py
@@ -3,7 +3,6 @@ import requests
 from typing import Any, Dict, List
 import traceback
 
-from helm.common.cache import CacheConfig
 from helm.common.request import EMBEDDING_UNAVAILABLE_REQUEST_RESULT, Request, RequestResult, Sequence, Token
 from helm.common.tokenization_request import TokenizationRequest
 from helm.proxy.clients.huggingface_client import HuggingFaceClient

--- a/src/helm/proxy/clients/megatron_client.py
+++ b/src/helm/proxy/clients/megatron_client.py
@@ -4,19 +4,13 @@ from typing import Any, Dict, List
 import traceback
 
 from helm.common.cache import CacheConfig
-from helm.common.request import (
-    EMBEDDING_UNAVAILABLE_REQUEST_RESULT,
-    Request,
-    RequestResult,
-    Sequence,
-    Token)
+from helm.common.request import EMBEDDING_UNAVAILABLE_REQUEST_RESULT, Request, RequestResult, Sequence, Token
 from helm.common.tokenization_request import TokenizationRequest
 from helm.proxy.clients.huggingface_client import HuggingFaceClient
 from helm.proxy.clients.client import Client, wrap_request_time, truncate_sequence
 
 
 class MegatronClient(HuggingFaceClient):
-
     def __init__(self, cache_config: CacheConfig):
         super().__init__(cache_config)
 
@@ -38,14 +32,10 @@ class MegatronClient(HuggingFaceClient):
         return out
 
     def _tokenize_response(self, text: str) -> List[Token]:
-        tokenized_text = self.tokenize(
-            TokenizationRequest(text, tokenizer="huggingface/gpt2"))
+        tokenized_text = self.tokenize(TokenizationRequest(text, tokenizer="huggingface/gpt2"))
 
         # TODO(tgale): Support logprobs.
-        tokens = [
-            Token(text=str(token), logprob=0, top_logprobs={})
-            for token in tokenized_text.raw_tokens
-        ]
+        tokens = [Token(text=str(token), logprob=0, top_logprobs={}) for token in tokenized_text.raw_tokens]
         return tokens
 
     def _make_request(self, request: Request) -> RequestResult:
@@ -68,8 +58,7 @@ class MegatronClient(HuggingFaceClient):
         }
 
         cache_key = Client.make_cache_key(raw_request, request)
-        response, cached = self.cache.get(cache_key, wrap_request_time(
-            lambda: self._send_request(raw_request)))
+        response, cached = self.cache.get(cache_key, wrap_request_time(lambda: self._send_request(raw_request)))
 
         # Verify we got a single response for the prompt.
         assert len(response["text"]) == 1
@@ -77,7 +66,7 @@ class MegatronClient(HuggingFaceClient):
         # NOTE: Megatron returns the response with the prompt included.
         generated_text = response["text"][0]
         if not request.echo_prompt:
-            generated_text = generated_text[len(request.prompt):]
+            generated_text = generated_text[len(request.prompt) :]
 
         # NOTE: Megatron returns the de-tokenized response. Re-tokenize.
         tokens = self._tokenize_response(generated_text)
@@ -90,7 +79,8 @@ class MegatronClient(HuggingFaceClient):
             request_time=response["request_time"],
             request_datetime=response.get("request_datetime"),
             completions=[completion],
-            embedding=[])
+            embedding=[],
+        )
 
     def make_request(self, request: Request) -> RequestResult:
         try:
@@ -101,4 +91,5 @@ class MegatronClient(HuggingFaceClient):
                 cached=False,
                 error=f"MegatronClient Error: {e}\n\n{traceback.format_exc()}",
                 completions=[],
-                embedding=[])
+                embedding=[],
+            )

--- a/src/helm/proxy/clients/megatron_client.py
+++ b/src/helm/proxy/clients/megatron_client.py
@@ -96,11 +96,9 @@ class MegatronClient(HuggingFaceClient):
         try:
             return self._make_request(request)
         except Exception as e:
-            print(f"EXCEPTION = {e}")
-            print(traceback.format_exc())
             return RequestResult(
                 success=False,
                 cached=False,
-                error=f"MegatronClient Error: {e}",
+                error=f"MegatronClient Error: {e}\n\n{traceback.format_exc()}",
                 completions=[],
                 embedding=[])

--- a/src/helm/proxy/models.py
+++ b/src/helm/proxy/models.py
@@ -866,6 +866,15 @@ ALL_MODELS = [
         "([paper](https://arxiv.org/pdf/2204.02311.pdf)).",
         tags=[TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG],
     ),
+    # Nvidia
+    Model(
+        group="megatron",
+        creator_organization="Nvidia",
+        name="megatron/gpt2",
+        display_name="GPT-2",
+        description="GPT-2",
+        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG, GPT2_TOKENIZER_TAG],
+    ),
     # For debugging
     Model(
         group="simple",

--- a/src/helm/proxy/models.py
+++ b/src/helm/proxy/models.py
@@ -868,12 +868,12 @@ ALL_MODELS = [
     ),
     # Nvidia
     Model(
-        group="megatron",
+        group="nvidia",
         creator_organization="Nvidia",
-        name="megatron/gpt2",
-        display_name="GPT-2",
-        description="GPT-2",
-        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG, GPT2_TOKENIZER_TAG],
+        name="nvidia/megatron-gpt2",
+        display_name="Megatron GPT-2",
+        description="GPT-2 implemented in Megatron-LM ([paper](https://arxiv.org/abs/1909.08053)).",
+        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG, GPT2_TOKENIZER_TAG, BUGGY_TEMP_0_TAG],
     ),
     # For debugging
     Model(


### PR DESCRIPTION
These changes add support for evaluating GPT2 models with a [Megatron-LM server](https://github.com/NVIDIA/Megatron-LM#gpt-text-generation). The client currently assumes that the server is running at `localhost:5000`.