### PR TITLE
Rename `large-model` to official name `starcoder`

### DIFF
--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -813,7 +813,7 @@ class TokenizerRunExpander(ScenarioSpecRunExpander):
         "AlephAlpha/luminous-supreme": ["AlephAlpha/luminous-supreme"],
         "AlephAlpha/luminous-world": ["AlephAlpha/luminous-world"],
         "huggingface/santacoder": ["bigcode/santacoder"],
-        "huggingface/large-model": ["bigcode/large-model"],
+        "huggingface/starcoder": ["bigcode/starcoder"],
     }
     model_tags_and_tokenizers = [
         (GPT2_TOKENIZER_TAG, "huggingface/gpt2"),

--- a/src/helm/benchmark/static/schema.yaml
+++ b/src/helm/benchmark/static/schema.yaml
@@ -132,7 +132,7 @@ models:
     creator_organization: BigCode
     access: open
   - name: huggingface/starcoder
-    display_name: Starcoder (15.5B)
+    display_name: StarCoder (15.5B)
     description: The StarCoder (15.5B parameter) model trained on 80+ programming languages from The Stack (v1.2) ([model card](https://huggingface.co/bigcode/starcoder)).
     creator_organization: BigCode
     access: open

--- a/src/helm/benchmark/static/schema.yaml
+++ b/src/helm/benchmark/static/schema.yaml
@@ -131,9 +131,9 @@ models:
     description: SantaCoder (1.1B parameters) model trained on the Python, Java, and JavaScript subset of The Stack (v1.1) ([model card](https://huggingface.co/bigcode/santacoder)).
     creator_organization: BigCode
     access: open
-  - name: huggingface/large-model
-    display_name: BigCode's Large Model (15.5B)
-    description: BigCode's Large Model (15.5B parameters) trained on The Stack (v1.2) ([model card](https://huggingface.co/bigcode/large-model)).
+  - name: huggingface/starcoder
+    display_name: Starcoder (15.5B)
+    description: The StarCoder (15.5B parameter) model trained on 80+ programming languages from The Stack (v1.2) ([model card](https://huggingface.co/bigcode/starcoder)).
     creator_organization: BigCode
     access: open
 

--- a/src/helm/benchmark/window_services/starcoder_window_service.py
+++ b/src/helm/benchmark/window_services/starcoder_window_service.py
@@ -2,7 +2,7 @@ from .local_window_service import LocalWindowService
 from .tokenizer_service import TokenizerService
 
 
-class BigCodeLargeModelWindowService(LocalWindowService):
+class StarCoderWindowService(LocalWindowService):
     def __init__(self, service: TokenizerService):
         super().__init__(service)
 
@@ -20,7 +20,7 @@ class BigCodeLargeModelWindowService(LocalWindowService):
 
     @property
     def tokenizer_name(self) -> str:
-        return "bigcode/large-model"
+        return "bigcode/starcoder"
 
     @property
     def prefix_token(self) -> str:

--- a/src/helm/benchmark/window_services/window_service_factory.py
+++ b/src/helm/benchmark/window_services/window_service_factory.py
@@ -31,7 +31,7 @@ from .bloom_window_service import BloomWindowService
 from .huggingface_window_service import HuggingFaceWindowService
 from .ice_window_service import ICEWindowService
 from .santacoder_window_service import SantaCoderWindowService
-from .bigcode_large_model_window_service import BigCodeLargeModelWindowService
+from .starcoder_window_service import StarCoderWindowService
 from .gpt2_window_service import GPT2WindowService
 from .gptj_window_service import GPTJWindowService
 from .gptneox_window_service import GPTNeoXWindowService
@@ -107,8 +107,8 @@ class WindowServiceFactory:
                 raise ValueError(f"Unhandled Writer model: {engine}")
         elif engine == "santacoder":
             window_service = SantaCoderWindowService(service)
-        elif engine == "large-model":
-            window_service = BigCodeLargeModelWindowService(service)
+        elif engine == "starcoder":
+            window_service = StarCoderWindowService(service)
         elif model_name == "huggingface/gpt2":
             window_service = GPT2WindowService(service)
         elif model_name == "together/bloom":

--- a/src/helm/proxy/models.py
+++ b/src/helm/proxy/models.py
@@ -418,9 +418,9 @@ ALL_MODELS = [
     Model(
         group="huggingface",
         creator_organization="BigCode",
-        name="huggingface/large-model",
-        display_name="BigCode's Large Model (15.5B)",
-        description="BigCode's Large Model (15.5B) trained on The Stack (v1.2)",
+        name="huggingface/starcoder",
+        display_name="StarCoder (15.5B)",
+        description="StarCoder (15.5B parameter) model trained on 80+ programming languages from The Stack (v1.2)",
         tags=[CODE_MODEL_TAG],
     ),
     # Google


### PR DESCRIPTION
Resolves #1532 