### PR TITLE
Create a `latest` symlink to the given results

### DIFF
--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -1000,7 +1000,7 @@ def main():
     if not args.skip_write_run_display_json:
         summarizer.write_run_display_json()
 
-    symlink_latest()
+    symlink_latest(args.output_path, args.suite)
     hlog("Done.")
 
 


### PR DESCRIPTION
Running `helm_summarize` was raising an exception when running `helm-summarize.

```
  Traceback (most recent call last):
    File "/Users/csris/miniconda3/envs/crfm-helm/bin/helm-summarize", line 8, in <module>
      sys.exit(main())
    File "/Users/csris/src/github.com/stanford-crfm/helm/src/helm/common/hierarchical_logger.py", line 104, in wrapper
      return fn(*args, **kwargs)
    File "/Users/csris/src/github.com/stanford-crfm/helm/src/helm/benchmark/presentation/summarize.py", line 1003, in main
      symlink_latest()
  TypeError: symlink_latest() missing 2 required positional arguments: 'output_path' and 'suite'
```

After this fix, `helm-summarize` will create a `latest` symlink that points at the the `output_path` and `suite` passed in the command-line arguments.

This was introduced by commit 45a9832fd30dfdb4023ea208f047cb15975d941b.