### PR TITLE
Fix HF token decoding

### DIFF
--- a/src/helm/proxy/clients/huggingface_client.py
+++ b/src/helm/proxy/clients/huggingface_client.py
@@ -95,6 +95,13 @@ class HuggingFaceServer:
 
         # TODO: Get rid of the extra tokenization?
         all_tokens = [self.tokenizer.convert_ids_to_tokens(sequence) for sequence in sequences]
+        all_tokens = [
+            [
+                self.tokenizer.convert_tokens_to_string([token])
+                for token in sequence_tokens
+            ]
+            for sequence_tokens in all_tokens
+        ]
         all_decoded_text = self.tokenizer.batch_decode(sequences)
 
         completions = []

--- a/src/helm/proxy/clients/huggingface_client.py
+++ b/src/helm/proxy/clients/huggingface_client.py
@@ -96,10 +96,7 @@ class HuggingFaceServer:
         # TODO: Get rid of the extra tokenization?
         all_tokens = [self.tokenizer.convert_ids_to_tokens(sequence) for sequence in sequences]
         all_tokens = [
-            [
-                self.tokenizer.convert_tokens_to_string([token])
-                for token in sequence_tokens
-            ]
+            [self.tokenizer.convert_tokens_to_string([token]) for token in sequence_tokens]
             for sequence_tokens in all_tokens
         ]
         all_decoded_text = self.tokenizer.batch_decode(sequences)


### PR DESCRIPTION
In huggingface, `tokenizer.encode` and `tokenizer.convert_ids_to_tokens` are not inverses -- you have to additionally call `tokenizer.convert_tokens_to_string` to get the original token back. This was causing some problems with [`truncate_sequence`](https://github.com/stanford-crfm/helm/blob/356a6b25b8b4bb46b7fae9f0d1db07345db300a4/src/helm/proxy/clients/client.py#L57) since this function expects the last token(s) to have text that starts with one of the `stop_sequences`.