### PR TITLE
Support for request.messages for chat models in OpenAI

### DIFF
--- a/src/helm/common/request.py
+++ b/src/helm/common/request.py
@@ -54,6 +54,11 @@ class Request:
     """Used to control randomness. Expect different responses for the same
     request but with different values for `random`."""
 
+    messages: Optional[List[Dict[str, str]]] = None
+    """Used for chat models. (OpenAI only for now).
+    if messages is specified for a chat model, the prompt is ignored.
+    Otherwise, the client should convert the prompt into a message."""
+
     @property
     def model_organization(self) -> str:
         """Example: 'openai/davinci' => 'openai'"""

--- a/src/helm/proxy/clients/openai_client.py
+++ b/src/helm/proxy/clients/openai_client.py
@@ -6,6 +6,7 @@ import tiktoken
 
 from helm.common.cache import Cache, CacheConfig
 from helm.common.request import Request, RequestResult, Sequence, Token
+from helm.common.hierarchical_logger import hlog
 from helm.common.tokenization_request import (
     TokenizationRequest,
     TokenizationRequestResult,
@@ -62,6 +63,8 @@ class OpenAIClient(Client):
                 # Checks that the last role is "user"
                 if request.messages[-1]["role"] != "user":
                     raise ValueError("Last message must have role 'user'")
+                if request.prompt != "":
+                    hlog("WARNING: Since message is set, prompt will be ignored")
             else:
                 # Convert prompt into a single message
                 # For now, put the whole prompt in a single user message, and expect the response


### PR DESCRIPTION
To answer #1503
`Request` now supports `messages` that override `prompt` for OpenAI chat models.