### PR TITLE
Add `--use-slurm-runner` flag to `helm-run`

### DIFF
--- a/docs/huggingface_models.md
+++ b/docs/huggingface_models.md
@@ -1,5 +1,7 @@
 # Hugging Face Model Hub Integration
 
+Hello
+
 HELM can be used to evaluate `AutoModelForCausalLM` models (e.g. [`BioMedLM`](https://huggingface.co/stanford-crfm/BioMedLM)) on [Hugging Face Model Hub](https://huggingface.co/models).
 
 To use `AutoModelForCausalLM` models from Hugging Face Model Hub, add the Hugging Face model IDs to the `--enable-huggingface-models` flags to `helm-run`. This will make the corresponding Hugging Face models available to use in your run spec descriptions. In the run spec description, use the Hugging Face model ID as the model name.

--- a/docs/huggingface_models.md
+++ b/docs/huggingface_models.md
@@ -1,7 +1,5 @@
 # Hugging Face Model Hub Integration
 
-Hello
-
 HELM can be used to evaluate `AutoModelForCausalLM` models (e.g. [`BioMedLM`](https://huggingface.co/stanford-crfm/BioMedLM)) on [Hugging Face Model Hub](https://huggingface.co/models).
 
 To use `AutoModelForCausalLM` models from Hugging Face Model Hub, add the Hugging Face model IDs to the `--enable-huggingface-models` flags to `helm-run`. This will make the corresponding Hugging Face models available to use in your run spec descriptions. In the run spec description, use the Hugging Face model ID as the model name.

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -137,6 +137,7 @@ scikit-learn==1.1.2
 scipy==1.9.1
 selenium==4.8.0
 sentencepiece==0.1.97
+simple-slurm==0.2.6
 six==1.16.0
 sklearn==0.0
 smart-open==5.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ zstandard~=0.18.0
 tqdm~=4.64.1
 pyhocon~=0.3.59
 dacite~=1.6.0
+simple-slurm~=0.2.6
 
 # Proxy
 aleph-alpha-client~=2.14.0

--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -94,14 +94,14 @@ def run_benchmarking(
             hlog(run_spec)
     runner_cls = SlurmRunner if use_slurm_runner else Runner
     runner: Runner = runner_cls(
-        execution_spec=execution_spec,
-        output_path=output_path,
-        suite=suite,
-        skip_instances=skip_instances,
-        cache_instances=cache_instances,
-        cache_instances_only=cache_instances_only,
-        skip_completed_runs=skip_completed_runs,
-        exit_on_error=exit_on_error,
+        execution_spec,
+        output_path,
+        suite,
+        skip_instances,
+        cache_instances,
+        cache_instances_only,
+        skip_completed_runs,
+        exit_on_error,
     )
     runner.run_all(run_specs)
     return run_specs
@@ -237,13 +237,14 @@ def main():
         nargs="+",
         default=[],
         help="Experimental: Enable remote service models that are not available on the client. "
-        "The client will use RemoteWindowService for windowing. ",
+        "The client will use RemoteWindowService for windowing.",
     )
     parser.add_argument(
         "--use-slurm-runner",
         action="store_true",
         default=None,
-        help="Use Slurm runner for running on Slurm.",
+        help="Experimental: If set, each RunSpec will be run in a separate Slurm worker job. "
+        "Currently only works on the Stanford NLP cluster.",
     )
     add_run_args(parser)
     args = parser.parse_args()

--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -236,7 +236,7 @@ def main():
     parser.add_argument(
         "--use-slurm-runner",
         action="store_true",
-        help="Experimental: If set, each RunSpec will be run in a separate Slurm worker job. "
+        help="Experimental: If set, each RunSpec will be run in a separate worker Slurm job. "
         "Currently only works on the Stanford NLP cluster.",
     )
     add_run_args(parser)

--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -115,26 +115,22 @@ def add_run_args(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--skip-instances",
         action="store_true",
-        default=None,
         help="Skip creation of instances (basically do nothing but just parse everything).",
     )
     parser.add_argument(
         "--cache-instances",
         action="store_true",
-        default=None,
         help="Save generated instances input to model to disk. If already cached, read instances from file.",
     )
     parser.add_argument(
         "--cache-instances-only",
         action="store_true",
-        default=None,
         help="Generate and save instances for scenario ONLY (i.e. do not evaluate models on instances).",
     )
     parser.add_argument(
         "-d",
         "--dry-run",
         action="store_true",
-        default=None,
         help="Skip execution, only output scenario states and estimate token usage.",
     )
     parser.add_argument(
@@ -208,13 +204,11 @@ def main():
     parser.add_argument(
         "--exit-on-error",
         action="store_true",
-        default=None,
         help="Fail and exit immediately if a particular RunSpec fails.",
     )
     parser.add_argument(
         "--skip-completed-runs",
         action="store_true",
-        default=None,
         help="Skip RunSpecs that have completed i.e. output files exists.",
     )
     parser.add_argument(
@@ -242,7 +236,6 @@ def main():
     parser.add_argument(
         "--use-slurm-runner",
         action="store_true",
-        default=None,
         help="Experimental: If set, each RunSpec will be run in a separate Slurm worker job. "
         "Currently only works on the Stanford NLP cluster.",
     )
@@ -284,18 +277,18 @@ def main():
         run_specs=run_specs,
         auth=auth,
         url=args.server_url,
-        local=bool(args.local),
+        local=args.local,
         local_path=args.local_path,
         num_threads=args.num_threads,
         output_path=args.output_path,
         suite=args.suite,
-        dry_run=bool(args.dry_run),
-        skip_instances=bool(args.skip_instances),
-        cache_instances=bool(args.cache_instances),
-        cache_instances_only=bool(args.cache_instances_only),
-        skip_completed_runs=bool(args.skip_completed_runs),
-        exit_on_error=bool(args.exit_on_error),
-        use_slurm_runner=bool(args.use_slurm_runner),
+        dry_run=args.dry_run,
+        skip_instances=args.skip_instances,
+        cache_instances=args.cache_instances,
+        cache_instances_only=args.cache_instances_only,
+        skip_completed_runs=args.skip_completed_runs,
+        exit_on_error=args.exit_on_error,
+        use_slurm_runner=args.use_slurm_runner,
         mongo_uri=args.mongo_uri,
     )
 

--- a/src/helm/benchmark/slurm_jobs.py
+++ b/src/helm/benchmark/slurm_jobs.py
@@ -63,7 +63,9 @@ _DEFAULT_SLURM_ARGS: Dict[str, Union[str, int]] = {
 def submit_slurm_job(command: str, job_name: str, output_path: str) -> int:
     """Submit a Slurm job."""
     slurm = Slurm(**_DEFAULT_SLURM_ARGS)
-    slurm.add_arguments(job_name=job_name, output=output_path, mail_user=os.getenv("USER"), chdir=os.getcwd())
+    slurm.add_arguments(job_name=job_name, output=output_path, chdir=os.getcwd())
+    # Uncomment this to get notification emails from Slurm for Slurm worker jobs.
+    # slurm.set_mail_user(os.getenv("USER"))
     return slurm.sbatch(command)
 
 

--- a/src/helm/benchmark/slurm_jobs.py
+++ b/src/helm/benchmark/slurm_jobs.py
@@ -1,0 +1,90 @@
+import os
+import re
+import subprocess
+from typing import Dict, Set, Union
+
+from simple_slurm import Slurm
+
+
+class SlurmJobState:
+    # TODO: Convert to StrEnum after upgrading to Python 3.11
+    # Non-exhaustive list of Slurm job states.
+    # See: https://slurm.schedmd.com/squeue.html#SECTION_JOB-STATE-CODES
+
+    # Healthy non-terminal states
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    SUSPENDED = "SUSPENDED"
+    COMPLETING = "COMPLETING"
+
+    # Successful terminal state
+    COMPLETED = "COMPLETED"
+
+    # Failure terminal states
+    BOOT_FAIL = "BOOT_FAIL"
+    CANCELLED = "CANCELLED"
+    DEADLINE = "DEADLINE"
+    FAILED = "FAILED"
+    NODE_FAIL = "NODE_FAIL"
+    OUT_OF_MEMORY = "OUT_OF_MEMORY"
+    PREEMPTED = "PREEMPTED"
+
+
+FAILURE_SLURM_JOB_STATES: Set[str] = set(
+    [
+        SlurmJobState.BOOT_FAIL,
+        SlurmJobState.CANCELLED,
+        SlurmJobState.DEADLINE,
+        SlurmJobState.FAILED,
+        SlurmJobState.NODE_FAIL,
+        SlurmJobState.OUT_OF_MEMORY,
+        SlurmJobState.PREEMPTED,
+    ]
+)
+"""Slurm job failure terminal states."""
+
+TERMINAL_SLURM_JOB_STATES: Set[str] = set([SlurmJobState.COMPLETED]) | FAILURE_SLURM_JOB_STATES
+"""Slurm job terminal states."""
+
+# TODO: Make default Slurm arguments configurable.
+# TODO: Request more memory for MSMARCO runs and request GPUs for CUDA runs.
+_DEFAULT_SLURM_ARGS: Dict[str, Union[str, int]] = {
+    "account": "nlp",
+    "cpus_per_task": 2,
+    "mem": "8G",
+    "gres": "gpu:0",
+    "open_mode": "append",
+    "partition": "john",
+    "time": "14-0",
+    "mail_type": "END",
+}
+
+
+def submit_slurm_job(command: str, job_name: str, output_path: str) -> int:
+    """Submit a Slurm job."""
+    slurm = Slurm(**_DEFAULT_SLURM_ARGS)
+    slurm.add_arguments(job_name=job_name, output=output_path, mail_user=os.getenv("USER"), chdir=os.getcwd())
+    return slurm.sbatch(command)
+
+
+def get_slurm_job_state(job_id: int) -> str:
+    """Get the state of a Slurm job."""
+    try:
+        scontrol_output = subprocess.check_output(f"scontrol show job {job_id}", stderr=subprocess.STDOUT, shell=True)
+    except subprocess.CalledProcessError as e:
+        # Default CalledProcessError message doesn't have output, so re-raise here to include the output.
+        raise Exception(f"{str(e)} output: {e.output}")
+    search_result = re.search("JobState=(\w+)", scontrol_output.decode())
+    if not search_result:
+        raise Exception(f"Could not extract JobState from scontrol: {scontrol_output.decode()}")
+    return search_result.group(1)
+
+
+def cancel_slurm_job(job_id: int) -> None:
+    """Cancel a Slurm job."""
+    try:
+        # Note: scancel will execute successfully on any existing job, even if the job is already terminated.
+        subprocess.check_output(f"scancel {job_id}", stderr=subprocess.STDOUT, shell=True)
+    except subprocess.CalledProcessError as e:
+        # Default CalledProcessError message doesn't have output, so re-raise here to include the output.
+        raise Exception(f"{str(e)} output: {e.output}")

--- a/src/helm/benchmark/slurm_runner.py
+++ b/src/helm/benchmark/slurm_runner.py
@@ -10,6 +10,7 @@ import sys
 
 import dacite
 
+from helm.common.general import write
 from helm.benchmark.executor import ExecutionSpec
 from helm.benchmark.runner import Runner, RunSpec, RunnerError
 from helm.benchmark.slurm_jobs import (
@@ -21,7 +22,7 @@ from helm.benchmark.slurm_jobs import (
     FAILURE_SLURM_JOB_STATES,
 )
 from helm.common.general import ensure_directory_exists, asdict_without_nones
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hlog, htrack_block
 
 
 @dataclass
@@ -41,8 +42,18 @@ class SlurmRunnerSpec:
         return {field.name: getattr(self, field.name) for field in dataclasses.fields(self)}
 
 
+@dataclass
+class _SlurmJobInfo:
+    """Slurm job information tracked by Slurm Runner."""
+
+    id: int
+    state: str
+
+
 class SlurmRunner(Runner):
-    """Runner that runs the entire benchmark on Slurm."""
+    """Runner that runs the entire benchmark on Slurm.
+
+    See the documentation of `run_all()` for more details."""
 
     def __init__(
         self,
@@ -72,8 +83,21 @@ class SlurmRunner(Runner):
     def run_all(self, run_specs: List[RunSpec]):
         """Run the entire benchmark on Slurm, where each RunSpec is run in its own Slurm job.
 
-        This functions as a "manager" job that submits a Slurm worker job via sbatch for each RunSpec,
-        and then monitors all the Slurm worker."""
+        This process functions as a manager job that does the following:
+
+        1. Write SlurmRunnerSpec to a file.
+        2. For each RunSpec:
+            a. Write the RunSpec to a file.
+            b. Submit a worker Slurm job via sbatch.
+            c. The worker Slurm job will read the SlurmRunnerSpec and RunSpec from the files
+               and run the RunSpec.
+        3. Monitor all the worker jobs:
+            a. If skip_completed_runs is True, terminate and cancel all the worker Slurm jobs
+               if any worker Slurm job fails.
+            b. If skip_completed_runs is False, terminate when all worker Slurm jobs are completed.
+        4. If the manager job is terminated or encounters an exception,
+           cancel all the worker jobs upon exiting. (best-effort)
+        """
         # This directory will be used for coordinating with workers
         ensure_directory_exists(self.slurm_base_dir)
 
@@ -81,104 +105,99 @@ class SlurmRunner(Runner):
         slurm_runner_spec_json = json.dumps(asdict_without_nones(self.slurm_runner_spec), indent=2)
         slurm_runner_spec_path = os.path.join(self.slurm_base_dir, "slurm_runner_spec.json")
         hlog(f"Writing SlurmRunnerSpec to {slurm_runner_spec_path}")
-        with open(slurm_runner_spec_path, "w") as f:
-            f.write(slurm_runner_spec_json)
+        write(file_path=slurm_runner_spec_path, content=slurm_runner_spec_json)
 
         # Set up directories for RunSpecs and logs
         run_specs_dir = os.path.join(self.slurm_base_dir, "run_specs")
         ensure_directory_exists(run_specs_dir)
         logs_dir = os.path.join(self.slurm_base_dir, "logs")
         ensure_directory_exists(logs_dir)
-        run_name_to_slurm_job_id: Dict[str, int] = {}
-        run_name_to_slurm_job_state: Dict[str, str] = {}
+        run_name_to_slurm_job_info: Dict[str, _SlurmJobInfo] = {}
 
-        # Callback for cleaning up Slurm worker jobs
+        # Callback for cleaning up worker Slurm jobs
         def cancel_all_jobs():
-            """Cancels all submitted Slurm worker jobs that are in a non-terminal state."""
-            hlog("Cleaning up by cancelling all Slurm worker jobs")
-            for run_name, slurm_job_state in run_name_to_slurm_job_state.items():
-                if slurm_job_state not in TERMINAL_SLURM_JOB_STATES:
-                    slurm_job_id = run_name_to_slurm_job_id[run_name]
-                    hlog(f"Cancelling Slurm worker job run {run_name} with Slurm job ID {slurm_job_id}")
-                    cancel_slurm_job(slurm_job_id)
+            """Cancels all submitted worker Slurm jobs that are in a non-terminal state."""
+            with htrack_block("Cleaning up by cancelling all worker Slurm jobs"):
+                # TODO: Cancel multiple jobs in a single call to Slurm
+                for run_name, slurm_job_info in run_name_to_slurm_job_info.items():
+                    if slurm_job_info.state not in TERMINAL_SLURM_JOB_STATES:
+                        hlog(f"Cancelling worker Slurm job run {run_name} with Slurm job ID {slurm_job_info.id}")
+                        cancel_slurm_job(slurm_job_info.id)
 
         try:
             # Submit a Slurm job for each RunSpec.
-            # TODO: If skip_completed_runs is set and the run is completed, skip creating the Slurm worker job
-            for run_spec in run_specs:
-                # Write the RunSpec to a file
-                run_name = run_spec.name
-                run_spec_json = json.dumps(asdict_without_nones(run_spec), indent=2)
-                run_spec_path = os.path.join(run_specs_dir, f"{run_spec.name}.json")
-                hlog(f"Writing RunSpec for run {run_name} to {run_spec_path}")
-                with open(run_spec_path, "w") as f:
-                    f.write(run_spec_json)
+            # TODO: If skip_completed_runs is set and the run is completed, skip creating the worker Slurm job
+            with htrack_block("Submitting worker Slurm jobs"):
+                for run_spec in run_specs:
+                    # Write the RunSpec to a file
+                    run_name = run_spec.name
+                    run_spec_json = json.dumps(asdict_without_nones(run_spec), indent=2)
+                    run_spec_path = os.path.join(run_specs_dir, f"{run_spec.name}.json")
+                    hlog(f"Writing RunSpec for run {run_name} to {run_spec_path}")
+                    write(file_path=run_spec_path, content=run_spec_json)
 
-                # Create a Slurm worker job that reads from the SlurmRunnerSpec and RunSpec files
-                log_path = os.path.join(logs_dir, f"{run_spec.name}.log")
-                command = (
-                    f"{sys.executable}"
-                    f" -m {SlurmRunner.__module__}"
-                    f" --slurm-runner-spec-path {slurm_runner_spec_path}"
-                    f" --run-spec-path {run_spec_path}"
-                )
-                hlog(f"Submitting Slurm worker job for run {run_name} with command: {command}")
-                slurm_job_id = submit_slurm_job(command=command, job_name=run_name, output_path=log_path)
-                time.sleep(0.1)  # Delay to avoid overwhelming Slurm
-                hlog(f"Slurm worker job submitted for run {run_name} with Slurm job ID: {slurm_job_id}")
-                run_name_to_slurm_job_id[run_name] = slurm_job_id
-                run_name_to_slurm_job_state[run_name] = SlurmJobState.PENDING
+                    # Create a worker Slurm job that reads from the SlurmRunnerSpec and RunSpec files
+                    log_path = os.path.join(logs_dir, f"{run_spec.name}.log")
+                    command = (
+                        f"{sys.executable}"
+                        f" -m {SlurmRunner.__module__}"
+                        f" --slurm-runner-spec-path {slurm_runner_spec_path}"
+                        f" --run-spec-path {run_spec_path}"
+                    )
+                    hlog(f"Submitting worker Slurm job for run {run_name} with command: {command}")
+                    time.sleep(1)  # Delay to avoid overwhelming Slurm
+                    slurm_job_id = submit_slurm_job(command=command, job_name=run_name, output_path=log_path)
+                    hlog(f"Worker Slurm job submitted for run {run_name} with Slurm job ID: {slurm_job_id}")
+                    run_name_to_slurm_job_info[run_name] = _SlurmJobInfo(id=slurm_job_id, state=SlurmJobState.PENDING)
+
+            worker_slurm_jobs_path = os.path.join(self.slurm_base_dir, "worker_slurm_jobs.json")
+            run_name_to_slurm_job_info_json = json.dumps(run_name_to_slurm_job_info, indent=2)
+            hlog(f"Worker Slurm jobs: {run_name_to_slurm_job_info_json}")
+            hlog(f"Writing worker Slurm job IDs to {worker_slurm_jobs_path}")
+            write(file_path=worker_slurm_jobs_path, content=run_name_to_slurm_job_info_json)
 
             # Monitor submitted Slurm jobs for RunSpecs until an exit condition is triggered.
-            slurm_job_ids_path = os.path.join(self.slurm_base_dir, "slurm_job_ids.json")
-            slurm_job_states_path = os.path.join(self.slurm_base_dir, "slurm_job_states.json")
-            hlog(f"Slurm job IDs of all Slurm worker jobs: {json.dumps(run_name_to_slurm_job_id, indent=2)}")
-            hlog(f"Writing Slurm worker job IDs to {slurm_job_ids_path}")
-            with open(slurm_job_ids_path, "w") as f:
-                f.write(json.dumps(run_name_to_slurm_job_id, indent=2))
-            hlog("Entering Slurm worker job monitoring loop")
+            with htrack_block("Monitoring worker Slurm jobs"):
+                while True:
+                    hlog("Getting states of worker Slurm jobs")
+                    # TODO: Get the states of multiple jobs in a single call to Slurm
+                    for run_name, slurm_job_info in run_name_to_slurm_job_info.items():
+                        slurm_job_info.state = get_slurm_job_state(slurm_job_id)
+                    run_name_to_slurm_job_info_json = json.dumps(run_name_to_slurm_job_info, indent=2)
+                    hlog(f"Worker Slurm jobs: {run_name_to_slurm_job_info_json}")
+                    hlog(f"Writing worker Slurm job states to {worker_slurm_jobs_path}")
+                    write(file_path=worker_slurm_jobs_path, content=run_name_to_slurm_job_info_json)
 
-            while True:
-                hlog("Getting states of Slurm worker jobs")
-                for run_name, slurm_job_id in run_name_to_slurm_job_id.items():
-                    run_name_to_slurm_job_state[run_name] = get_slurm_job_state(slurm_job_id)
-                    time.sleep(0.1)  # Delay to avoid overwhelming Slurm
-                hlog(f"States of all Slurm worker jobs: {json.dumps(run_name_to_slurm_job_state, indent=2)}")
-                hlog(f"Writing Slurm worker job states to {slurm_job_states_path}")
-                with open(slurm_job_states_path, "w") as f:
-                    f.write(json.dumps(run_name_to_slurm_job_state, indent=2))
+                    # Check termination conditions
+                    if self.exit_on_error and any(
+                        [
+                            slurm_job_info.state in FAILURE_SLURM_JOB_STATES
+                            for slurm_job_info in run_name_to_slurm_job_info.values()
+                        ]
+                    ):
+                        hlog("Some worker Slurm job failed and --exit_on_error was set.")
+                        break
+                    if all(
+                        [
+                            slurm_job_info.state in TERMINAL_SLURM_JOB_STATES
+                            for slurm_job_info in run_name_to_slurm_job_info.values()
+                        ]
+                    ):
+                        hlog("All worker Slurm jobs completed.")
+                        break
 
-                # Check termination conditions
-                if self.exit_on_error and any(
-                    [
-                        slurm_job_state in FAILURE_SLURM_JOB_STATES
-                        for slurm_job_state in run_name_to_slurm_job_state.values()
-                    ]
-                ):
-                    hlog("Some Slurm worker job failed and --exit_on_error was set, exiting Slurm job monitoring loop.")
-                    break
-                if all(
-                    [
-                        slurm_job_state in TERMINAL_SLURM_JOB_STATES
-                        for slurm_job_state in run_name_to_slurm_job_state.values()
-                    ]
-                ):
-                    hlog("All Slurm worker jobs completed, exiting Slurm job monitoring loop.")
-                    break
-
-                # Refresh every minute
-                # TODO: Make this period configurable
-                time.sleep(60)
+                    # Refresh every minute
+                    # TODO: Make this period configurable
+                    time.sleep(60)
         finally:
             # Cleanup by cancelling all jobs during program termination or if an exception is raised.
-            hlog("Exiting Slurm worker job monitoring loop")
             cancel_all_jobs()
 
         # Raise exception for failed runs, if any.
         failed_run_names = [
             run_name
-            for run_name, slurm_job_state in run_name_to_slurm_job_state.items()
-            if slurm_job_state in FAILURE_SLURM_JOB_STATES
+            for run_name, slurm_job_info in run_name_to_slurm_job_info.items()
+            if slurm_job_info.state in FAILURE_SLURM_JOB_STATES
         ]
         if failed_run_names:
             failed_runs_str = ", ".join([f'"{run_name}"' for run_name in failed_run_names])

--- a/src/helm/benchmark/slurm_runner.py
+++ b/src/helm/benchmark/slurm_runner.py
@@ -95,7 +95,7 @@ class SlurmRunner(Runner):
             a. If skip_completed_runs is True, terminate and cancel all the worker Slurm jobs
                if any worker Slurm job fails.
             b. If skip_completed_runs is False, terminate when all worker Slurm jobs are completed.
-        4. If the manager job is terminated or encounters an exception,
+        4. If the manager job has terminated or encounters an exception,
            cancel all the worker jobs upon exiting. (best-effort)
         """
         # This directory will be used for coordinating with workers

--- a/src/helm/benchmark/slurm_runner.py
+++ b/src/helm/benchmark/slurm_runner.py
@@ -1,0 +1,200 @@
+import dataclasses
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, List
+import argparse
+import json
+import os
+import sys
+
+import dacite
+
+from helm.benchmark.executor import ExecutionSpec
+from helm.benchmark.runner import Runner, RunSpec, RunnerError
+from helm.benchmark.slurm_jobs import (
+    submit_slurm_job,
+    cancel_slurm_job,
+    get_slurm_job_state,
+    SlurmJobState,
+    TERMINAL_SLURM_JOB_STATES,
+    FAILURE_SLURM_JOB_STATES,
+)
+from helm.common.general import ensure_directory_exists, asdict_without_nones
+from helm.common.hierarchical_logger import hlog
+
+
+@dataclass
+class SlurmRunnerSpec:
+    """Arguments to instantiate a SlurmRunner."""
+
+    execution_spec: ExecutionSpec
+    output_path: str
+    suite: str
+    skip_instances: bool
+    cache_instances: bool
+    cache_instances_only: bool
+    skip_completed_runs: bool
+    exit_on_error: bool
+
+    def to_kwargs(self):
+        return {field.name: getattr(self, field.name) for field in dataclasses.fields(self)}
+
+
+class SlurmRunner(Runner):
+    """Runner that runs the entire benchmark on Slurm."""
+
+    def __init__(
+        self,
+        execution_spec: ExecutionSpec,
+        output_path: str,
+        suite: str,
+        skip_instances: bool,
+        cache_instances: bool,
+        cache_instances_only: bool,
+        skip_completed_runs: bool,
+        exit_on_error: bool,
+    ):
+        self.slurm_runner_spec = SlurmRunnerSpec(
+            execution_spec=execution_spec,
+            output_path=output_path,
+            suite=suite,
+            skip_instances=skip_instances,
+            cache_instances=cache_instances,
+            cache_instances_only=cache_instances_only,
+            skip_completed_runs=skip_completed_runs,
+            exit_on_error=exit_on_error,
+        )
+        # Extra validation: Check that SlurmRunnerSpec can be used to initialize Runner.
+        super().__init__(**self.slurm_runner_spec.to_kwargs())
+        self.slurm_base_dir = os.path.join("slurm", datetime.now().isoformat(timespec="seconds"))
+
+    def run_all(self, run_specs: List[RunSpec]):
+        """Run the entire benchmark on Slurm, where each RunSpec is run in its own Slurm job.
+
+        This functions as a "manager" job that submits a Slurm worker job via sbatch for each RunSpec,
+        and then monitors all the Slurm worker."""
+        # This directory will be used for coordinating with workers
+        ensure_directory_exists(self.slurm_base_dir)
+
+        # Write the config to the directory
+        slurm_runner_spec_json = json.dumps(asdict_without_nones(self.slurm_runner_spec), indent=2)
+        slurm_runner_spec_path = os.path.join(self.slurm_base_dir, "slurm_runner_spec.json")
+        hlog(f"Writing SlurmRunnerSpec to {slurm_runner_spec_path}")
+        with open(slurm_runner_spec_path, "w") as f:
+            f.write(slurm_runner_spec_json)
+
+        # Write the run specs to the directory
+        run_specs_dir = os.path.join(self.slurm_base_dir, "run_specs")
+        ensure_directory_exists(run_specs_dir)
+        logs_dir = os.path.join(self.slurm_base_dir, "logs")
+        ensure_directory_exists(logs_dir)
+        run_name_to_slurm_job_id: Dict[str, int] = {}
+        run_name_to_slurm_job_state: Dict[str, str] = {}
+
+        # Cleanup by cancelling all jobs during program termination or if an exception is raised.
+        def cancel_all_jobs():
+            """Cancels all submitted Slurm jobs that are in a non-terminal state."""
+            for run_name, slurm_job_state in run_name_to_slurm_job_state.values():
+                if slurm_job_state not in TERMINAL_SLURM_JOB_STATES:
+                    cancel_slurm_job(run_name_to_slurm_job_id[run_name])
+
+        try:
+            # Submit a Slurm job for each RunSpecs.
+            for run_spec in run_specs:
+                # TODO: If skip_completed_runs is set and the run is completed, skip creating the Slurm worker job
+                run_name = run_spec.name
+                run_spec_json = json.dumps(asdict_without_nones(run_spec), indent=2)
+                run_spec_path = os.path.join(run_specs_dir, f"{run_spec.name}.json")
+                hlog(f"Writing RunSpec for run {run_name} to {run_spec_path}")
+                with open(run_spec_path, "w") as f:
+                    f.write(run_spec_json)
+                log_path = os.path.join(logs_dir, f"{run_spec.name}.log")
+                command = (
+                    f"{sys.executable}"
+                    f" -m {SlurmRunner.__module__}"
+                    f" --slurm-runner-spec-path {slurm_runner_spec_path}"
+                    f" --run-spec-path {run_spec_path}"
+                )
+                hlog(f"Submitting Slurm worker job for run {run_name} with command: {command}")
+                slurm_job_id = submit_slurm_job(command=command, job_name=run_name, output_path=log_path)
+                hlog(f"Slurm worker job submitted for run {run_name} with Slurm job ID: {slurm_job_id}")
+                run_name_to_slurm_job_id[run_name] = slurm_job_id
+                run_name_to_slurm_job_state[run_name] = SlurmJobState.PENDING
+
+            # Monitor submitted Slurm jobs for RunSpecs until an exit condition is triggered.
+            slurm_job_ids_path = os.path.join(self.slurm_base_dir, "slurm_job_ids.json")
+            slurm_job_states_path = os.path.join(self.slurm_base_dir, "slurm_job_states.json")
+            hlog(f"Slurm job IDs of all Slurm worker jobs: {json.dumps(run_name_to_slurm_job_id, indent=2)}")
+            hlog(f"Writing Slurm worker job IDs to {slurm_job_ids_path}")
+            with open(slurm_job_ids_path, "w") as f:
+                f.write(json.dumps(run_name_to_slurm_job_id, indent=2))
+            hlog("Entering Slurm worker job monitoring loop")
+            while True:
+                hlog("Getting states of Slurm worker jobs")
+                for run_name, slurm_job_id in run_name_to_slurm_job_id.items():
+                    run_name_to_slurm_job_state[run_name] = get_slurm_job_state(slurm_job_id)
+                hlog(f"States of all Slurm worker jobs: {json.dumps(run_name_to_slurm_job_state, indent=2)}")
+                hlog(f"Writing Slurm worker job states to {slurm_job_states_path}")
+                with open(slurm_job_states_path, "w") as f:
+                    f.write(json.dumps(run_name_to_slurm_job_state, indent=2))
+                if self.exit_on_error and any(
+                    [
+                        slurm_job_state in FAILURE_SLURM_JOB_STATES
+                        for slurm_job_state in run_name_to_slurm_job_state.values()
+                    ]
+                ):
+                    hlog("Some Slurm worker job failed and --exit_on_error was set, exiting Slurm job monitoring loop.")
+                    break
+                if all(
+                    [
+                        slurm_job_state in TERMINAL_SLURM_JOB_STATES
+                        for slurm_job_state in run_name_to_slurm_job_state.values()
+                    ]
+                ):
+                    hlog("All Slurm worker jobs completed, exiting Slurm job monitoring loop.")
+                    break
+        finally:
+            cancel_all_jobs()
+        failed_run_names = [
+            run_name
+            for run_name, slurm_job_state in run_name_to_slurm_job_state.items()
+            if slurm_job_state in FAILURE_SLURM_JOB_STATES
+        ]
+        if failed_run_names:
+            failed_runs_str = ", ".join([f'"{run_name}"' for run_name in failed_run_names])
+            raise RunnerError(f"Failed runs: [{failed_runs_str}]")
+
+
+def run_as_worker(slurm_runner_spec_path: str, run_spec_path: str):
+    """Deserialize SlurmRunner and RunSpec from the given files, then run the RunSpec with the SlurmRunner.
+
+    Used by the worker Slurm jobs only."""
+    with open(slurm_runner_spec_path, "r") as f:
+        slurm_runner_spec = dacite.from_dict(SlurmRunnerSpec, json.load(f))
+    with open(run_spec_path, "r") as f:
+        run_spec = dacite.from_dict(RunSpec, json.load(f))
+    slurm_runner = SlurmRunner(**slurm_runner_spec.to_kwargs())
+    slurm_runner.run_one(run_spec)
+
+
+def main():
+    """Entry point for the worker Slurm jobs that run a single RunSpec."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--slurm-runner-spec-path",
+        type=str,
+        help="Path to the SlurmRunnerSpec JSON file",
+        required=True,
+    )
+    parser.add_argument(
+        "--run-spec-path",
+        type=str,
+        help="Path to the RunSpec JSON file",
+        required=True,
+    )
+    args = parser.parse_args()
+    run_as_worker(slurm_runner_spec_path=args.slurm_runner_spec_path, run_spec_path=args.run_spec_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
If the `--use-slurm-runner` flag is set in `helm-run`, each RunSpec will be run in a separate worker Slurm job. Currently only works on the Stanford NLP cluster.