### PR TITLE
Fix response undefined in catching error of Anthropic

### DIFF
--- a/src/helm/proxy/clients/anthropic_client.py
+++ b/src/helm/proxy/clients/anthropic_client.py
@@ -140,7 +140,7 @@ class AnthropicClient(Client):
                     return RequestResult(
                         success=False,
                         cached=False,
-                        error=response["error"],
+                        error=str(error),
                         completions=[],
                         embedding=[],
                         error_flags=ErrorFlags(is_retriable=False, is_fatal=False),
@@ -149,7 +149,7 @@ class AnthropicClient(Client):
                     return RequestResult(
                         success=False,
                         cached=False,
-                        error=response["error"],
+                        error=str(error),
                         completions=[],
                         embedding=[],
                         error_flags=ErrorFlags(is_retriable=False, is_fatal=False),


### PR DESCRIPTION
Just discovered a bug in `antrhopic_client.py`. The catching of the exception was not working. This is a small fix.