### PR TITLE
SlurmRunner resources and bugfixes

### DIFF
--- a/src/helm/benchmark/slurm_jobs.py
+++ b/src/helm/benchmark/slurm_jobs.py
@@ -49,8 +49,6 @@ TERMINAL_SLURM_JOB_STATES: Set[str] = set([SlurmJobState.COMPLETED]) | FAILURE_S
 def submit_slurm_job(command: str, slurm_args: Mapping[str, Union[str, int]]) -> int:
     """Submit a Slurm job."""
     slurm = Slurm(**slurm_args)
-    # Uncomment this to get notification emails from Slurm for Slurm worker jobs.
-    # slurm.set_mail_user(os.getenv("USER"))
     return slurm.sbatch(command)
 
 

--- a/src/helm/benchmark/slurm_jobs.py
+++ b/src/helm/benchmark/slurm_jobs.py
@@ -1,7 +1,6 @@
-import os
 import re
 import subprocess
-from typing import Dict, Set, Union
+from typing import Mapping, Set, Union
 
 from simple_slurm import Slurm
 
@@ -46,24 +45,10 @@ FAILURE_SLURM_JOB_STATES: Set[str] = set(
 TERMINAL_SLURM_JOB_STATES: Set[str] = set([SlurmJobState.COMPLETED]) | FAILURE_SLURM_JOB_STATES
 """Slurm job terminal states."""
 
-# TODO: Make default Slurm arguments configurable.
-# TODO: Request more memory for MSMARCO runs and request GPUs for CUDA runs.
-_DEFAULT_SLURM_ARGS: Dict[str, Union[str, int]] = {
-    "account": "nlp",
-    "cpus_per_task": 2,
-    "mem": "8G",
-    "gres": "gpu:0",
-    "open_mode": "append",
-    "partition": "john",
-    "time": "14-0",
-    "mail_type": "END",
-}
 
-
-def submit_slurm_job(command: str, job_name: str, output_path: str) -> int:
+def submit_slurm_job(command: str, slurm_args: Mapping[str, Union[str, int]]) -> int:
     """Submit a Slurm job."""
-    slurm = Slurm(**_DEFAULT_SLURM_ARGS)
-    slurm.add_arguments(job_name=job_name, output=output_path, chdir=os.getcwd())
+    slurm = Slurm(**slurm_args)
     # Uncomment this to get notification emails from Slurm for Slurm worker jobs.
     # slurm.set_mail_user(os.getenv("USER"))
     return slurm.sbatch(command)

--- a/src/helm/benchmark/slurm_runner.py
+++ b/src/helm/benchmark/slurm_runner.py
@@ -192,14 +192,12 @@ class SlurmRunner(Runner):
         """Create a Slurm job for the RunSpec and return the Slurm job ID."""
         # Create a worker Slurm job that reads from the SlurmRunnerSpec and RunSpec files
         run_name = run_spec.name
-
         run_spec_json = json.dumps(asdict_without_nones(run_spec), indent=2)
         run_spec_path = os.path.join(self.run_specs_dir, f"{run_name}.json")
         hlog(f"Writing RunSpec for run {run_name} to {run_spec_path}")
         write(file_path=run_spec_path, content=run_spec_json)
 
         log_path = os.path.join(self.logs_dir, f"{run_name}.log")
-
         # Requires that SlurmRunnerSpec has already been written to self.slurm_runner_spec_path.
         # It should have been written at the start of self.run_all()
         command = (
@@ -227,7 +225,8 @@ class SlurmRunner(Runner):
         if "device=cuda" in run_spec.name:
             slurm_args["gres"] = "gpu:1"
             slurm_args["partition"] = "jag-hi"
-
+        # Uncomment this to get notification emails from Slurm for Slurm worker jobs.
+        # slurm.set_mail_user(os.getenv("USER"))
         hlog(f"Submitting worker Slurm job for run {run_name} with command: {command}")
         time.sleep(1)  # Delay to avoid overwhelming Slurm
         slurm_job_id = submit_slurm_job(command, slurm_args)


### PR DESCRIPTION
- Require more memory for runs with `msmarco` and GPU for runs with `device=cuda`
- Fixed Slurm job status query using wrong job ID
- Fixed JSON serialization failures