### PR TITLE
Make `SlurmRunner` skip creating Slurm jobs for completed runs

### DIFF
--- a/src/helm/benchmark/runner.py
+++ b/src/helm/benchmark/runner.py
@@ -112,6 +112,25 @@ class Runner:
         self.eval_cache_path: str = os.path.join(self.runs_path, "eval_cache")
         ensure_directory_exists(self.eval_cache_path)
 
+    def _is_run_completed(self, run_spec: RunSpec):
+        """Return whether the run was previously completed.
+
+        A run is completed if all of the expected output files exist."""
+        run_path: str = os.path.join(self.runs_path, run_spec.name)
+        if not os.path.isdir(run_path):
+            return False
+        output_paths = [
+            os.path.join(run_path, "run_spec.json"),
+            os.path.join(run_path, "scenario.json"),
+            os.path.join(run_path, "scenario_state.json"),
+            os.path.join(run_path, "stats.json"),
+            os.path.join(run_path, "per_instance_stats.json"),
+        ]
+        for output_path in output_paths:
+            if not os.path.exists(output_path):
+                return False
+        return True
+
     def run_all(self, run_specs: List[RunSpec]):
         failed_run_specs: List[RunSpec] = []
 
@@ -146,7 +165,7 @@ class Runner:
         run_path: str = os.path.join(self.runs_path, run_spec.name)
         ensure_directory_exists(run_path)
 
-        if self.skip_completed_runs and os.path.exists(os.path.join(run_path, "scenario_state.json")):
+        if self.skip_completed_runs and self._is_run_completed(run_spec):
             # If scenario_state.json exists, assume that all other output files exist
             # because scenario_state.json is the last output file to be written.
             hlog(f"Skipping run {run_spec.name} because run is completed and all output files exist.")

--- a/src/helm/benchmark/slurm_runner.py
+++ b/src/helm/benchmark/slurm_runner.py
@@ -115,22 +115,22 @@ class SlurmRunner(Runner):
 
         skipped_run_specs: List[RunSpec] = []
         queued_run_specs: List[RunSpec] = []
+        # When running with multiple models, sorting by RunSpec.name is a heuristic that tries to
+        # spread out the load evenly across multiple models, in order to avoid overloading any single model.
         for run_spec in sorted(run_specs, key=lambda run_spec: run_spec.name):
             if self.skip_completed_runs and self._is_run_completed(run_spec):
                 skipped_run_specs.append(run_spec)
             else:
                 queued_run_specs.append(run_spec)
 
-        skipped_run_specs_json = to_json([run_spec.name for run_spec in skipped_run_specs])
+        skipped_runs_json = to_json([run_spec.name for run_spec in skipped_run_specs])
         if skipped_run_specs:
-            hlog(
-                f"Skipped run specs with completed runs because --skip-completed-runs is set: {skipped_run_specs_json}"
-            )
-        skipped_run_specs_path = os.path.join(self.slurm_base_dir, "skipped_run_specs.json")
+            hlog("Skipped completed runs because --skip-completed-runs was set: " f"{skipped_runs_json}")
+        skipped_runs_path = os.path.join(self.slurm_base_dir, "skipped_runs.json")
         # Write skipped run specs file anyway even if empty.
         # This makes things more convenient for downstream status monitoring tools.
-        hlog(f"Writing skipped run specs to {skipped_run_specs_path}")
-        write(file_path=skipped_run_specs_path, content=skipped_run_specs_json)
+        hlog(f"Writing skipped runs to {skipped_runs_path}")
+        write(file_path=skipped_runs_path, content=skipped_runs_json)
 
         # Callback for cleaning up worker Slurm jobs
         def cancel_all_jobs():


### PR DESCRIPTION
Previously, if `--skip-completed-runs` was set, `SlurmRunner` would submit a Slurm job for each completed run. The Slurm job would then immediately exit without doing any work because the run was completed.

Now, if `--skip-completed-runs` was set, `SlurmRunner` will skip creating a Slurm job for 

Additionally, `SlurmRunner` will write the list of skipped RunSpec names to `skipped_runs.json`, even if the list is empty. This is for the convenience of downstream status monitoring tools.