### PR TITLE
Fix `No such file or directory: 'proxy_api_key.txt'` when `--local` is not set

### DIFF
--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -271,7 +271,9 @@ def main():
         hlog("There were no RunSpecs or they got filtered out.")
         return
 
-    auth: Authentication = Authentication("") if args.skip_instances or args.local else create_authentication(args)
+    auth: Authentication = (
+        Authentication("") if args.skip_instances or not args.server_url else create_authentication(args)
+    )
 
     run_benchmarking(
         run_specs=run_specs,


### PR DESCRIPTION
Previously, `helm-run` would fail with `FileNotFoundError: [Errno 2] No such file or directory: 'proxy_api_key.txt'` if both `--local` and `--server-url` are unset, and `proxy_api_key.txt` does not exist. The intended behavior is to run locally and not require `proxy_api_key.txt`  to exist.