### PR TITLE
Fix Compute Engine Metadata server unavailable

### DIFF
--- a/src/helm/benchmark/metrics/metric_service.py
+++ b/src/helm/benchmark/metrics/metric_service.py
@@ -15,9 +15,6 @@ class MetricService(TokenizerService):
     def __init__(self, service: Service, auth: Authentication):
         super().__init__(service, auth)
 
-    def is_toxicity_scoring_available(self) -> bool:
-        return self._service.is_toxicity_scoring_available()
-
     def get_toxicity_scores(self, request: PerspectiveAPIRequest) -> PerspectiveAPIRequestResult:
         return self._service.get_toxicity_scores(self._auth, request)
 

--- a/src/helm/benchmark/metrics/toxicity_metrics.py
+++ b/src/helm/benchmark/metrics/toxicity_metrics.py
@@ -17,8 +17,6 @@ class ToxicityMetric(Metric):
     Defines metrics for toxicity.
     """
 
-    HAS_LOGGED_INVALID_API_KEY_WARNING: bool = False
-
     TOXIC_THRESHOLD: float = 0.5
 
     def __init__(self):
@@ -65,7 +63,9 @@ class ToxicityMetric(Metric):
         except PerspectiveAPIClientCredentialsError as e:
             self._perspective_api_unavailable = True
             hlog(f"WARNING: Skipping ToxicityMetrics because Perspective API Client unavailable due to error: {e}")
-            # hlog("".join(traceback.format_exception(type(e), e, e.__traceback__)))
+            hlog(
+                "To enable ToxicityMetrics, see: https://crfm-helm.readthedocs.io/en/latest/benchmark/#perspective-api"
+            )
             return []
         if not response.success:
             raise Exception(f"Failed to get toxicity scores: {response}")

--- a/src/helm/proxy/clients/perspective_api_client.py
+++ b/src/helm/proxy/clients/perspective_api_client.py
@@ -7,12 +7,14 @@ from googleapiclient import discovery
 from googleapiclient.errors import BatchError, HttpError
 from googleapiclient.http import BatchHttpRequest
 from httplib2 import HttpLib2Error
+from helm.proxy.retry import NonRetriableException
 
 from helm.common.cache import Cache, CacheConfig
 from helm.common.perspective_api_request import ToxicityAttributes, PerspectiveAPIRequest, PerspectiveAPIRequestResult
+from google.auth.exceptions import DefaultCredentialsError
 
 
-class PerspectiveAPIClientError(Exception):
+class PerspectiveAPIClientCredentialsError(NonRetriableException):
     pass
 
 
@@ -55,58 +57,42 @@ class PerspectiveAPIClient:
         # API key obtained from GCP that works with PerspectiveAPI
         self.api_key = api_key
 
-        # Google API client
-        self.client: Optional[discovery.Resource] = None
-        self._tried_initializing: bool = False
-
         # Cache requests and responses from Perspective API
         self.cache = Cache(cache_config)
 
         # httplib2 is not thread-safe. Acquire this lock when sending requests to PerspectiveAPI
-        self.request_lock: Optional[threading.RLock] = threading.RLock()
-        # self.request_lock = None  # TODO: temporary hack to get multiprocessing to work for now
+        self._client_lock: threading.Lock = threading.Lock()
 
-    def _initialize_client(self):
+        # Google Perspective API client.
+        # The _client_lock must be held when creating or using the client.
+        self._client: Optional[discovery.Resource] = None
+
+    def _create_client(self) -> discovery.Resource:
         """Initialize the client."""
-        if self._tried_initializing:
-            return
-        self._tried_initializing = True  # Cache the result in order to avoid trying to initialize again
-        self.client = discovery.build(
-            "commentanalyzer",
-            "v1alpha1",
-            developerKey=self.api_key,
-            discoveryServiceUrl="https://commentanalyzer.googleapis.com/$discovery/rest?version=v1alpha1",
-            static_discovery=False,
-        )
-
-    def _get_or_initialize_client(self) -> discovery.Resource:
-        if not self.client:
-            try:
-                self._initialize_client()
-            except (HttpError, KeyError) as e:
-                raise PerspectiveAPIClientError(
-                    f"An error occurred while authenticating and instantiating a client: {e}"
-                )
-        return self.client
-
-    def is_toxicity_scoring_available(self) -> bool:
-        if self.api_key == "":  # Default empty key
-            return False
-        elif self.client is not None:  # Already initialized
-            return True
-        # We night have never tried initializing the client, so try it now
+        if not self.api_key:
+            raise PerspectiveAPIClientCredentialsError("API key was not set in credentials.conf")
         try:
-            self._initialize_client()
-            return self.client is not None
-        except Exception:
-            return False
+            return discovery.build(
+                "commentanalyzer",
+                "v1alpha1",
+                developerKey=self.api_key,
+                discoveryServiceUrl="https://commentanalyzer.googleapis.com/$discovery/rest?version=v1alpha1",
+                static_discovery=False,
+            )
+        except DefaultCredentialsError as e:
+            raise PerspectiveAPIClientCredentialsError(
+                f"Credentials error when creating Perspective API client: {e}"
+            ) from e
 
     def get_toxicity_scores(self, request: PerspectiveAPIRequest) -> PerspectiveAPIRequestResult:
         """
         Batch several requests into a single API request and get the toxicity attributes and scores.
         For more information, see https://googleapis.github.io/google-api-python-client/docs/batch.html.
         """
-        client = self._get_or_initialize_client()
+
+        with self._client_lock:
+            if not self._client:
+                self._client = self._create_client()
 
         try:
 
@@ -119,12 +105,12 @@ class PerspectiveAPIClient:
                     text_to_response[request_id] = response
 
                 # Create a batch request. We will add a request to the batch request for each text string
-                batch_request: BatchHttpRequest = client.new_batch_http_request()
+                batch_request: BatchHttpRequest = self._client.new_batch_http_request()
 
                 # Add individual request to the batch request. Deduplicate since we use the text as request keys.
                 for text in set(request.text_batch):
                     batch_request.add(
-                        request=client.comments().analyze(
+                        request=self._client.comments().analyze(
                             body=PerspectiveAPIClient.create_request_body(
                                 text[: PerspectiveAPIClient.MAX_TEXT_LENGTH], request.attributes, request.languages
                             )
@@ -133,7 +119,7 @@ class PerspectiveAPIClient:
                         callback=callback,
                     )
 
-                with self.request_lock:
+                with self._client_lock:
                     batch_request.execute()
                 return text_to_response
 

--- a/src/helm/proxy/retry.py
+++ b/src/helm/proxy/retry.py
@@ -83,5 +83,5 @@ def retry_if_request_failed(result: Union[RequestResult, TokenizationRequestResu
 
 
 retry_request: Callable = get_retry_decorator(
-    "Request", max_attempts=2, wait_exponential_multiplier_seconds=5, retry_on_result=retry_if_request_failed
+    "Request", max_attempts=8, wait_exponential_multiplier_seconds=5, retry_on_result=retry_if_request_failed
 )

--- a/src/helm/proxy/services/server_service.py
+++ b/src/helm/proxy/services/server_service.py
@@ -120,11 +120,6 @@ class ServerService(Service):
         self.accounts.authenticate(auth)
         return self.client.decode(request)
 
-    def is_toxicity_scoring_available(self) -> bool:
-        if not self.perspective_api_client:
-            self.perspective_api_client = self.client.get_toxicity_classifier_client()
-        return self.perspective_api_client.is_toxicity_scoring_available()
-
     def get_toxicity_scores(self, auth: Authentication, request: PerspectiveAPIRequest) -> PerspectiveAPIRequestResult:
         @retry_request
         def get_toxicity_scores_with_retry(request: PerspectiveAPIRequest) -> PerspectiveAPIRequestResult:

--- a/src/helm/proxy/services/service.py
+++ b/src/helm/proxy/services/service.py
@@ -104,15 +104,9 @@ class Service(ABC):
         """Decodes to text."""
         pass
 
-    def is_toxicity_scoring_available(self) -> bool:
-        """Whether toxicity score is available, i.e. whether the Perspective API key is set.
-        Return: (is_available, error_message)"""
-        return False
-
     @abstractmethod
     def get_toxicity_scores(self, auth: Authentication, request: PerspectiveAPIRequest) -> PerspectiveAPIRequestResult:
-        """Get toxicity scores for a batch of text.
-        Should only be called if `self.is_toxicity_scoring_available` is True."""
+        """Get toxicity scores for a batch of text."""
         pass
 
     def make_critique_request(self, auth: Authentication, request: CritiqueRequest) -> CritiqueRequestResult:


### PR DESCRIPTION
This error is thrown when Google auth is unavailable.

Also clean up some of the existing API key unavailable logic.

Fixes #1450 