### PR TITLE
Fix install error from latest version of repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
           key: pip-${{ hashFiles('requirements.txt') }}-${{ matrix.python-version }}
           restore-keys: |
             pip-
+      - run: pip install -e .
+      - run: crfm-helm -h
       - run: echo "Finished installation."
 
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,8 @@ jobs:
           restore-keys: |
             pip-
       - run: pip install -e .
-      - run: crfm-helm -h
+      - run: helm-run -h
+      - run: helm-summarize -h
       - run: echo "Finished installation."
 
   test:

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ tqdm~=4.64.1
 pyhocon~=0.3.59
 dacite~=1.6.0
 simple-slurm~=0.2.6
+typing_extensions<4.6.0  # Workaround for https://github.com/explosion/spaCy/issues/12659
 
 # Proxy
 aleph-alpha-client~=2.14.0
@@ -63,9 +64,7 @@ sacrebleu~=2.2.1
 # Work around https://github.com/p-lambda/verified_calibration/issues/11
 # TODO: Remove after this issue is resolved
 scikit-learn~=1.1.2
-spacy==3.2.4
-spacy-legacy==3.0.10
-spacy-loggers==1.0.3
+spacy~=3.2.4
 summ-eval~=0.892
 surge-api~=1.1.0
 # End users should install a CUDA version of PyTorch manually if needed

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ sacrebleu~=2.2.1
 # Work around https://github.com/p-lambda/verified_calibration/issues/11
 # TODO: Remove after this issue is resolved
 scikit-learn~=1.1.2
-spacy~=3.4
+spacy~=3.5.3
 summ-eval~=0.892
 surge-api~=1.1.0
 # End users should install a CUDA version of PyTorch manually if needed

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,9 @@ sacrebleu~=2.2.1
 # Work around https://github.com/p-lambda/verified_calibration/issues/11
 # TODO: Remove after this issue is resolved
 scikit-learn~=1.1.2
-spacy~=3.2.4
+spacy==3.2.4
+spacy-legacy==3.0.10
+spacy-loggers==1.0.3
 summ-eval~=0.892
 surge-api~=1.1.0
 # End users should install a CUDA version of PyTorch manually if needed

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ tqdm~=4.64.1
 pyhocon~=0.3.59
 dacite~=1.6.0
 simple-slurm~=0.2.6
-typing_extensions<4.6.0  # Workaround for https://github.com/explosion/spaCy/issues/12659
 
 # Proxy
 aleph-alpha-client~=2.14.0
@@ -64,7 +63,7 @@ sacrebleu~=2.2.1
 # Work around https://github.com/p-lambda/verified_calibration/issues/11
 # TODO: Remove after this issue is resolved
 scikit-learn~=1.1.2
-spacy~=3.2.4
+spacy~=3.4
 summ-eval~=0.892
 surge-api~=1.1.0
 # End users should install a CUDA version of PyTorch manually if needed

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,7 +72,7 @@ install_requires=
     # Work around https://github.com/p-lambda/verified_calibration/issues/11
     # TODO: Remove after this issue is resolved
     scikit-learn~=1.1.2
-    spacy~=3.2.4
+    spacy~=3.4
     summ-eval~=0.892
     surge-api~=1.1.0
     # End users should install a CUDA version of PyTorch manually if needed

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,9 +72,7 @@ install_requires=
     # Work around https://github.com/p-lambda/verified_calibration/issues/11
     # TODO: Remove after this issue is resolved
     scikit-learn~=1.1.2
-    spacy==3.2.4
-    spacy-legacy==3.0.10
-    spacy-loggers==1.0.3
+    spacy~=3.2.4
     summ-eval~=0.892
     surge-api~=1.1.0
     # End users should install a CUDA version of PyTorch manually if needed

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires=
     tqdm~=4.64.1
     pyhocon~=0.3.59
     dacite~=1.6.0
+    simple-slurm~=0.2.6
 
     # Proxy
     aleph-alpha-client~=2.14.0
@@ -43,7 +44,7 @@ install_requires=
     openai~=0.27.0
     tiktoken~=0.3.3
     transformers~=4.28.1
-    tokenizers~=0.13.2
+    tokenizers~=0.13.3
     icetk~=0.0.4
     protobuf~=3.20.2  # Can't use 4.21.0 due to backward incompatibility
     google-api-python-client~=2.64.0
@@ -71,7 +72,9 @@ install_requires=
     # Work around https://github.com/p-lambda/verified_calibration/issues/11
     # TODO: Remove after this issue is resolved
     scikit-learn~=1.1.2
-    spacy~=3.2.4
+    spacy==3.2.4
+    spacy-legacy==3.0.10
+    spacy-loggers==1.0.3
     summ-eval~=0.892
     surge-api~=1.1.0
     # End users should install a CUDA version of PyTorch manually if needed

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,7 +72,7 @@ install_requires=
     # Work around https://github.com/p-lambda/verified_calibration/issues/11
     # TODO: Remove after this issue is resolved
     scikit-learn~=1.1.2
-    spacy~=3.4
+    spacy~=3.5.3
     summ-eval~=0.892
     surge-api~=1.1.0
     # End users should install a CUDA version of PyTorch manually if needed


### PR DESCRIPTION
Fixes issue #1616.

This PR does the following:
1) Fix an error that would prevent users from being able to correctly install new releases of crfm-helm
2) Update Github Actions so that install errors are tested for.
3) Update setup.cfg so that `pip install -e .` works again. (It was missing `simple-slurm` and an update to the `tokenizers` version.)

Note on 1): The issue found in #1616 is documented on spaCy's repo [here](https://github.com/explosion/spaCy/issues/12659). In short, they have a temporary workaround to use `typing-extensions<4.6.0`, which is what I use here.