### PR TITLE
Fix prediction rendering

### DIFF
--- a/src/helm/benchmark/static/benchmarking.css
+++ b/src/helm/benchmark/static/benchmarking.css
@@ -150,3 +150,7 @@ tbody .table-sort-column {
   font-style: italic;
   margin: 5px;
 }
+
+.prediction-text {
+  white-space: pre-wrap;
+}

--- a/src/helm/benchmark/static/benchmarking.js
+++ b/src/helm/benchmark/static/benchmarking.js
@@ -575,7 +575,7 @@ $(function () {
           \{trial {{prediction.train_trial_index~}} \}
         {{~/if~}}
       </a></strong>:
-      {{{predictedText}}}
+      <span class="prediction-text">{{{predictedText}}}</span>
     </div>
     <div class="request" style="display: none">Loading...</div>
   `);


### PR DESCRIPTION
Set white-space to "pre-wrap" for predictions so that newlines will be preserved.