### PR TITLE
Together client fixes

### DIFF
--- a/src/helm/proxy/clients/together_client.py
+++ b/src/helm/proxy/clients/together_client.py
@@ -169,7 +169,7 @@ class TogetherClient(Client):
                     )
                 if "error" in retrieve_response_json["output"]:
                     error_message = retrieve_response_json["output"]["error"]
-                    raise TogetherClientError(f"Together request failed with error: {error_message}")
+                    raise TogetherClientError(f"Together request (job_id={job_id}) failed with error: {error_message}")
                 return retrieve_response_json["output"]
 
             def do_it_async() -> Dict[Any, Any]:

--- a/src/helm/proxy/clients/together_client.py
+++ b/src/helm/proxy/clients/together_client.py
@@ -16,6 +16,7 @@ from .client import Client, wrap_request_time, truncate_sequence
 
 _ASYNC_MODELS: Set[str] = {
     "alpaca-7b",
+    "llama-7b",
     "mpt-7b",
     "pythia-7b",
     "redpajama-incite-base-3b-v1",
@@ -41,6 +42,7 @@ MODEL_ALIASES: Dict[str, str] = {
     # alpaca-7b-full-precision is full-precision
     "alpaca-7b": "alpaca-7b-full-precision",
     "llama-7b": "llama-7b-full-precision",
+    "mpt-7b": "mpt-7b-full-precision",
     "pythia-7b": "pythia-7b-full-precision",
     "vicuna-13b": "vicuna-13b-full-precision",
 }


### PR DESCRIPTION
Fixes for running LLaMA and other models:

- Use async requests for more models
- Use full-precision models instead of half-precision models by adding a suffix
- Display a more useful error message for error responses