### PR TITLE
ScaleCritiqueClient improvements

### DIFF
--- a/src/helm/proxy/clients/auto_client.py
+++ b/src/helm/proxy/clients/auto_client.py
@@ -14,7 +14,8 @@ from helm.common.tokenization_request import (
     DecodeRequestResult,
 )
 from helm.proxy.retry import retry_request
-from .critique_client import CritiqueClient, RandomCritiqueClient, SurgeAICritiqueClient, ScaleCritiqueClient
+from .critique_client import CritiqueClient, RandomCritiqueClient, ScaleCritiqueClient
+from .surge_ai_critique_client import SurgeAICritiqueClient
 from .mechanical_turk_critique_client import MechanicalTurkCritiqueClient
 from .client import Client
 from .ai21_client import AI21Client
@@ -266,13 +267,13 @@ class AutoClient(Client):
 
         elif critique_type == "scale":
             scale_credentials = self.credentials.get("scaleApiKey")
-            scale_batch = self.credentials.get("scaleBatch", None)
-            if scale_batch is None:
-                raise ValueError("scaleBatch is required for ScaleCritiqueClient for now.")
+            scale_project = self.credentials.get("scaleProject", None)
+            if not scale_project:
+                raise ValueError("scaleProject is required for ScaleCritiqueClient.")
             if not scale_credentials:
-                raise ValueError("scaleApiKey credentials are required for ScaleCritiqueClient")
+                raise ValueError("scaleApiKey is required for ScaleCritiqueClient")
             self.critique_client = ScaleCritiqueClient(
-                scale_credentials, self._build_cache_config("scale"), scale_batch
+                scale_credentials, self._build_cache_config("scale"), scale_project
             )
         else:
             raise ValueError(

--- a/src/helm/proxy/clients/critique_client.py
+++ b/src/helm/proxy/clients/critique_client.py
@@ -1,16 +1,12 @@
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from hashlib import sha512
 import json
 import random
 import threading
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Set
 
-# Surge AI
 from cattrs import unstructure
-import surge
-from surge import questions as surge_questions
-
-# Scale
 import scaleapi
 from scaleapi.tasks import TaskType, TaskStatus
 from scaleapi.exceptions import ScaleDuplicateResource
@@ -25,10 +21,6 @@ from helm.common.critique_request import (
     CritiqueResponse,
     QuestionType,
 )
-
-
-_surge_cache_lock = threading.Lock()
-_scale_cache_lock = threading.Lock()
 
 
 class CritiqueClient(ABC):
@@ -63,162 +55,86 @@ class RandomCritiqueClient(CritiqueClient):
         return CritiqueRequestResult(responses)
 
 
-class SurgeAICritiqueClient(CritiqueClient):
-    # TODO #1614: Move this to its own file
-    """A CritiqueClient that creates tasks for workers on Surge AI.
+class ScaleCritiqueClientError(Exception):
+    pass
 
-    Surge AI concepts:
 
-    - A **project** contains **instructions** and **questions**, which are templates that can contain
-      placeholders.
-    - A **task** is created in a project and contains **fields** that are interpolated into the
-      placeholders in the project's instructions and questions templates to instantiate the actual instructions
-      and questions in the task.
-    - A **task response** is a response to a task by a single worker and contains answers to all the questions
-      in the task.
+@dataclass(frozen=True)
+class _ScaleBatchKey:
+    project_name: str
+    batch_name: str
 
-    Mapping of HELM concepts to Surge AI concepts:
 
-    - A `CritiqueTaskTemplate` maps to a **project**.
-    - A `CritiqueQuestionTemplate` maps to a **question** template in a project.
-    - A `CritiqueRequest` maps to a **task**
-        - `CritiqueRequest.template` indicates which **project** the task should be created in.
-        - `CritiqueRequest.fields` provides the fields that are interpolated into the placeholders in the
-          projects' instructions and questions templates.
-    - A `CritiqueResponse` maps to a **task response**.
-    - A `CritiqueRequestResult` maps to a list of **task responses** across multiple workers for a task.
-    """
+_scale_projects_lock: threading.Lock = threading.Lock()
+_scale_projects: Set[str] = set()
 
-    def __init__(self, api_key: str, cache_config: CacheConfig):
-        surge.api_key = api_key
-        self._cache = Cache(cache_config)
 
-    def _to_surge_question(self, question: CritiqueQuestionTemplate) -> surge_questions.MultipleChoiceQuestion:
-        if question.question_type != "multiple_choice":
-            raise ValueError("Currently, only multiple_choice questions are supported")
-        return surge_questions.MultipleChoiceQuestion(
-            text=question.text,
-            options=question.options,
-        )
+def _ensure_project_exists(client: scaleapi.ScaleClient, project_name: str):
+    with _scale_projects_lock:
+        if project_name not in _scale_projects:
+            try:
+                client.create_project(
+                    project_name=project_name,
+                    task_type=TaskType.TextCollection,
+                    rapid=True,
+                    params={},
+                )
+                hlog(f"Created new Scale project: {project_name}")
+                hlog(
+                    "IMPORTANT: Run scripts/scale/create_and_setup_project.py to set up a "
+                    "calibration batch in your project."
+                )
+            except ScaleDuplicateResource:
+                existing_project = client.get_project(project_name=project_name)
+                if existing_project.type != TaskType.TextCollection.value:
+                    raise ScaleCritiqueClientError(
+                        f"The existing project with name '{project_name}' has a task type of "
+                        f"'{existing_project.type}' instead of '{TaskType.TextCollection.value}'. "
+                        "Rename the existing batch to a different name to allow HELM to create a new project "
+                        "with the correct task type."
+                    )
+                hlog(f"Reusing existing Scale project: {project_name}")
+            _scale_projects.add(project_name)
 
-    def _get_or_create_surge_project(self, template: CritiqueTaskTemplate) -> str:
-        """Get or create a project on Surge AI and return the Surge AI project ID.
 
-        Attempt to find a Surge AI project for the template from the cache. If one exists, reuse that project.
-        Otherwise, create a new project using the template and save it to the cache. Return the Surge AI project ID."""
+_scale_batches_lock: threading.Lock = threading.Lock()
+_scale_batches: Set[_ScaleBatchKey] = set()
 
-        def create_surge_project():
-            project = surge.Project.create(
-                name=template.name,
-                instructions=template.instructions,
-                questions=[self._to_surge_question(question) for question in template.questions],
-                num_workers_per_task=template.num_respondents,
-            )
-            return {"id": project.id}
 
-        with _surge_cache_lock:
-            # Example cache key:
-            # {
-            #   "template": {
-            #     # See CritiqueQuestionTemplate for complete schema
-            #     "name": "some_name",
-            #     "instructions": "some_instructions",
-            #     "num_respondents": 1,
-            #     "questions": []
-            #   }
-            # }
-            #
-            # Example cache value:
-            # {"id": "17e323f1-f7e4-427c-a2d5-456743aba8"}
-            #
-            # Note:
-            # We do not cache the additional fields returned by surge.Project.create()
-            # because they are mutable server-side, and server-side mutations may cause
-            # stale cache issues.
-            project_response, is_cached = self._cache.get({"template": unstructure(template)}, create_surge_project)
-        project_id = project_response["id"]
-        if is_cached:
-            hlog(f"Reusing existing Surge AI project: {project_id}")
-        else:
-            hlog(f"Creating new Surge AI project: {project_id}")
-        return project_id
+def _ensure_batch_exists(client: scaleapi.ScaleClient, project_name: str, batch_name: str) -> None:
+    _ensure_project_exists(client, project_name)
+    with _scale_batches_lock:
+        batch_key = _ScaleBatchKey(project_name, batch_name)
+        if batch_key not in _scale_batches:
+            try:
+                client.create_batch(
+                    project=project_name,
+                    batch_name=batch_name,
+                    calibration_batch=False,
+                    self_label_batch=False,
+                )
+                hlog(f"Created new Scale batch: {batch_name}")
+            except ScaleDuplicateResource:
+                existing_batch = client.get_batch(batch_name=batch_name)
+                if existing_batch.project != project_name:
+                    raise Exception(
+                        f"A batch named '{batch_name}' already exists in a project '{existing_batch.project}' "
+                        f"but credentials.conf has scaleProject set to a different project '{project_name}'. "
+                        "Either rename the existing batch to a different name to allow HELM to create a new batch, or "
+                        f"change scaleProject in credentials.conf to '{existing_batch.project}'. {existing_batch}"
+                    )
+                if existing_batch.status != "staging":
+                    raise Exception(
+                        f"New tasks cannot be added to the existing batch named '{batch_name}' because "
+                        "its status is '{existing_batch.status}' instead of 'staging'. "
+                        "Rename the existing batch to a different name to allow HELM to create a new batch."
+                    )
+                hlog(f"Reusing existing Scale batch: {batch_name}")
+            _scale_batches.add(batch_key)
 
-    def _get_or_create_task(self, project_id: str, fields: Dict[str, str]) -> str:
-        """Get or create a task on Surge AI and return the Surge AI project ID.
 
-        Attempt to find a Surge AI task inside this project for the fields from the cache.
-        If one exists, reuse that task. Otherwise, create a new task inside the project using the fields.
-        and save it to the cache. Return the Surge AI task ID."""
-        project = surge.Project.retrieve(project_id)
-
-        def create_surge_task():
-            tasks = project.create_tasks([fields], launch=False)  # TODO: Make launch parameter configurable
-            if len(tasks) != 1:
-                return RuntimeError(f"Expected one task in Surge response, but got {len(tasks)} tasks")
-            task = tasks[0]
-            return {"id": task.id}
-
-        with _surge_cache_lock:
-            # Example cache key:
-            # {
-            #   "project_id": "17e323f1-f7e4-427c-a2d5-456743aba8",
-            #   "fields": {
-            #     "some_field": "some_value"
-            #   }
-            # }
-            #
-            # Example cache value:
-            # {"id": "17e323f1-f7e4-427c-a2d5-456743aba8"}
-            #
-            # Note:
-            # We do not cache the additional fields returned by surge.Project.create()
-            # because they are mutable server-side, and server-side mutations may cause
-            # stale cache issues.
-            task_response, is_cached = self._cache.get({"project_id": project_id, "fields": fields}, create_surge_task)
-        task_id = task_response["id"]
-        if is_cached:
-            hlog(f"Reusing existing Surge AI task: {task_id}")
-        else:
-            hlog(f"Creating new Surge AI task: {task_id}")
-        return task_id
-
-    def _get_worker_responses(self, task_id: str, questions: List[CritiqueQuestionTemplate]) -> List[CritiqueResponse]:
-        task = surge.Task.retrieve(task_id)
-        return [
-            CritiqueResponse(
-                id=task_response.id,
-                respondent_id=task_response.worker_id,
-                answers={question.name: task_response.data[question.name] for question in questions},
-            )
-            for task_response in task.responses
-        ]
-
-    def make_critique_request(self, request: CritiqueRequest) -> CritiqueRequestResult:
-        """Create a task on Surge AI and fetch responses from Surge AI if available.
-
-        Returns CritiqueRequestResult if worker answers are complete, or None otherwise.
-        The intended use is to call it once to create the task, wait a while, and then call it
-        later to fetch answers.
-
-        First, attempt to find a Surge AI project for the template. If one exists, reuse that project.
-        Otherwise, create a new project using the template.
-
-        Second, attempt to find a Surge AI task inside this project for the fields. If one exists,
-        reuse that task. Otherwise, create a new task inside the project using the fields.
-
-        Finally, check if responses are available by checking if the number of workers who have responded
-        is equal to the requested number of workers. If so, return those responses.
-
-        This method is idempotent, because projects and tasks are not created if they already exist.
-
-        The cache will store the mappings from template to Surge AI Project ID and from fields to Surge AI
-        question ID. If the cache is deleted, the mappings will be lost, and this method will not be able
-        to fetch results from the previous projects and tasks, and will have to create new projects and tasks.
-        Note that worker responses are currently not cached."""
-        project_id = self._get_or_create_surge_project(request.template)
-        task_id = self._get_or_create_task(project_id, request.fields)
-        worker_responses = self._get_worker_responses(task_id, request.template.questions)
-        return CritiqueRequestResult(worker_responses)
+_scale_cache_lock: threading.Lock = threading.Lock()
+_SCALE_IMAGE_ATTACHMENT_KEY = "image_attachment"
 
 
 class ScaleCritiqueClient(CritiqueClient):
@@ -247,144 +163,11 @@ class ScaleCritiqueClient(CritiqueClient):
         self,
         api_key: str,
         cache_config: CacheConfig,
-        batch_name: str,
+        project_name: str,
     ):
         self._cache = Cache(cache_config)
         self._client = scaleapi.ScaleClient(api_key)
-        self._batch_name = batch_name
-
-    # def _get_or_create_scale_project_and_batch(self, template: CritiqueTaskTemplate) -> Tuple[str, str]:
-    #     """Get or create a project and a batch associated to it on Scale and return the
-    #     Scale project name and batch name.
-
-    #     If the project_name was specified in the credentials, use it (should already exist).
-    #     In order to send tasks, the project needs to already have a calibration batch.
-    #     Otherwise, create a new project using the template name.
-    #     If the project is created, there will be no calibration batch so the batch will be set
-    #     as self-labeling.
-
-    #     If the batch_name was specified in the credentials, use it (does not necessarily need to exist).
-    #     Otherwise, create a new batch using the project name and the template name.
-
-    #     This is using Scale Rapid.
-
-    #     Attempt to find a Scale project for the template. If one exists, reuse that project.
-    #     Otherwise, create a new project using the template. Return the Scale project name.
-    #     Same for the batch."""
-
-    #     project_was_created: bool = self._project_name is None
-    #     project_name: Optional[str] = None
-    #     batch_name: Optional[str] = None
-
-    #     def create_scale_project():
-    #         try:
-    #             project = self._client.create_project(
-    #                 project_name=template.name,
-    #                 task_type=TaskType.TextCollection,
-    #                 rapid=True,
-    #                 params={},
-    #             )
-    #         except ScaleDuplicateResource as err:
-    #             hlog(f"ScaleDuplicateResource when creating project: {template.name}. Error: {err.message}")
-    #             # Get the existing project and checks that it has the same params
-    #             # NOTE: This should not happen with the cache but in case the cache is deleted
-    #             # we want to make sure we don't create a new project with the same name
-    #             project = self._client.get_project(template.name)
-    #             if project.type != TaskType.TextCollection.value:
-    #                 raise RuntimeError(
-    #                     f"Project {template.name} already exists with different task_type: "
-    #                     f"'{project.type}' instead of '{TaskType.TextCollection.value}'"
-    #                 ) from err
-    #         return {"project_name": project.name}
-
-    #     def create_scale_batch():
-    #         if project_name is None:
-    #             raise RuntimeError("Trying to create a batch without a project name.")
-    #         try:
-    #             batch_name: str = f"{project_name}-HELMBatch"
-    #             batch = self._client.create_batch(
-    #                 project=project_name,
-    #                 batch_name=batch_name,
-    #                 calibration_batch=False,
-    #                 # If the project was created, there is no calibration batch so we set it as self-labeling
-    #                 # otherwise the API will return an error.
-    #                 self_label_batch=True,  # project_was_created,
-    #             )
-    #         except ScaleDuplicateResource as err:
-    #             hlog(
-    #                 f"ScaleDuplicateResource when creating batch: '{batch_name}' in project: "
-    #                 f"{project_name}. Error: {err.message}"
-    #             )
-    #             # Get the existing batch and checks that it has the same project
-    #             # NOTE: This should not happen with the cache but in case the cache is deleted
-    #             # we want to make sure we don't create a new batch with the same name
-    #             batch = self._client.get_batch(batch_name)
-    #             if batch.project != project.name:
-    #                 raise RuntimeError(
-    #                     f"Batch {batch_name} already exists with different project: " f"{batch.project}"
-    #                 ) from err
-    #         return {"batch_name": batch.name}
-
-    #     # Check if a project_name was specified in the credentials
-    #     if self._project_name is not None:
-    #         project_name = self._project_name
-    #         hlog(f"Using existing Scale project: {project_name} (defined in credentials)")
-    #         # Checks that the project exists
-    #         try:
-    #             project = self._client.get_project(project_name)
-    #             project_name = project.name
-    #         except Exception as err:
-    #             raise RuntimeError(f"Project {project_name} does not exist") from err
-
-    #         # Check if a batch_name was specified in the credentials
-    #         if self._batch_name is not None:
-    #             batch_name = self._batch_name
-    #             hlog(f"Using existing Scale batch: {batch_name} (defined in credentials)")
-    #             # Checks that the batch exists
-    #             try:
-    #                 batch = self._client.get_batch(batch_name)
-    #             except Exception as err:
-    #                 raise RuntimeError(f"Batch {batch_name} does not exist") from err
-    #             # Checks that the batch is in the project
-    #             if batch.project != project_name:
-    #                 raise RuntimeError(
-    #                     f"Batch {batch_name} is not in project {project_name}. "
-    #                     f"It is in project {batch.project} instead."
-    #                 )
-    #             return project_name, batch_name
-
-    #         # If we reach here it means that a project_name was specified but not a batch_name
-    #         # Create a new batch using the template name
-    #         with _scale_cache_lock:
-    #             batch_response, is_cached = self._cache.get(
-    #                 {"testing": True, "project": project_name, "template": template.name}, create_scale_batch
-    #             )
-    #         batch_name = batch_response["batch_name"]
-    #     else:
-    #         # If we reach here it means that no project_name was specified
-    #         # Create a new project using the template name
-    #         # Create a new batch using the project name and the template name
-
-    #         with _scale_cache_lock:
-    #             project_response, is_cached = self._cache.get({"template": template.name}, create_scale_project)
-    #         project_name = project_response["project_name"]
-    #         if is_cached:
-    #             hlog(f"Reusing existing Scale project: {project_name}")
-    #         else:
-    #             hlog(f"Creating new Scale project: {project_name}")
-
-    #         with _scale_cache_lock:
-    #             batch_response, is_cached = self._cache.get(
-    #                 {"testing": True, "project": project_name, "template": template.name}, create_scale_batch
-    #             )
-    #         batch_name = batch_response["batch_name"]
-
-    #     if is_cached:
-    #         hlog(f"Reusing existing Scale batch: {batch_name}")
-    #     else:
-    #         hlog(f"Creating new Scale batch: {batch_name}")
-
-    #     return project_name, batch_name
+        self._project_name = project_name
 
     def _interpolate_fields(self, text: str, fields: Dict[str, str]) -> str:
         for field_name, field_value in fields.items():
@@ -405,12 +188,13 @@ class ScaleCritiqueClient(CritiqueClient):
         else:
             raise ValueError(f"Unsupported question type {question.question_type}")
 
-    def _get_or_create_scale_task(self, batch_name: str, template: CritiqueTaskTemplate, fields: Dict[str, str]) -> str:
+    def _get_or_create_scale_task(self, template: CritiqueTaskTemplate, fields: Dict[str, str]) -> str:
         """Get or create a task on Scale and return the Scale task ID."""
+        batch_name = template.name
+        _ensure_batch_exists(client=self._client, project_name=self._project_name, batch_name=batch_name)
 
         # Used both for the cache key and the task unique_id
         cache_key = {
-            "testing": True,
             "batch": batch_name,
             "task": unstructure(template),
             "fields": fields,
@@ -426,7 +210,7 @@ class ScaleCritiqueClient(CritiqueClient):
             # It contains the same information as the task itself (like the cache key)
             # This is redundant with the cache but it's a good safety net
             # NOTE: Technically, sha512 could have collisions but it's unlikely.
-            unique_id: str = sha512(str(json.dumps(cache_key, sort_keys=True)).encode()).hexdigest()
+            unique_id: str = sha512(json.dumps(cache_key, sort_keys=True).encode()).hexdigest()
             instructions: str = self._interpolate_fields(template.instructions, fields)
             attachments: List[Dict[str, str]] = [
                 {
@@ -434,13 +218,13 @@ class ScaleCritiqueClient(CritiqueClient):
                     "content": instructions,
                 }
             ]
-            if "image" in fields:
+            if _SCALE_IMAGE_ATTACHMENT_KEY in fields:
                 # We add the image as the first attachment so that it is displayed first
                 # (Usually the instructions are not as important when an image is present)
                 attachments = [
                     {
                         "type": "image",
-                        "content": fields["image"],
+                        "content": fields[_SCALE_IMAGE_ATTACHMENT_KEY],
                     }
                 ] + attachments
             payload = dict(
@@ -457,15 +241,7 @@ class ScaleCritiqueClient(CritiqueClient):
                 return {"id": task.id}
             except ScaleDuplicateResource as err:
                 hlog(f"ScaleDuplicateResource when creating task: {unique_id}. Error: {err.message}")
-                # Get the existing task and checks that it has the same content (attachments and fields)
-                # NOTE: This should not happen with the cache but in case the cache is deleted
-                # we want to make sure we don't create a new task with the same content
                 task = self._client.get_task(unique_id)
-                if task.params["attachments"] != payload["attachments"]:
-                    raise RuntimeError(
-                        f"Task {unique_id} already exists with different attachments: " f"{task.params['attachments']}"
-                    ) from err
-                # No need to check for fields, project_name and instructions because they are part of the unique_id
                 return {"id": task.id}
 
         with _scale_cache_lock:
@@ -569,6 +345,6 @@ class ScaleCritiqueClient(CritiqueClient):
 
         # _, batch_name = self._get_or_create_scale_project_and_batch(request.template)
         # self._batch_name = batch_name
-        task_id: str = self._get_or_create_scale_task(self._batch_name, request.template, request.fields)
+        task_id: str = self._get_or_create_scale_task(request.template, request.fields)
         worker_responses: List[CritiqueResponse] = self._get_worker_responses(task_id)
         return CritiqueRequestResult(worker_responses)

--- a/src/helm/proxy/clients/mechanical_turk_critique_importer.py
+++ b/src/helm/proxy/clients/mechanical_turk_critique_importer.py
@@ -23,7 +23,7 @@ class _MechanicalTurkRequestImporter:
     """Exports critique request results.
 
     The request results will be imported from all files matching
-    turk/{template.name}/Batch_{batch_number}_batch_results.csv"""
+    mturk/{template.name}/Batch_{batch_number}_batch_results.csv"""
 
     def __init__(self, template: CritiqueTaskTemplate):
         self._template: CritiqueTaskTemplate = template

--- a/src/helm/proxy/clients/surge_ai_critique_client.py
+++ b/src/helm/proxy/clients/surge_ai_critique_client.py
@@ -1,0 +1,177 @@
+from cattrs import unstructure
+import threading
+from typing import Dict, List
+
+import surge
+from surge import questions as surge_questions
+
+from helm.common.cache import Cache, CacheConfig
+from helm.common.critique_request import (
+    CritiqueQuestionTemplate,
+    CritiqueRequest,
+    CritiqueRequestResult,
+    CritiqueResponse,
+    CritiqueTaskTemplate,
+)
+from helm.common.hierarchical_logger import hlog
+from helm.proxy.clients.critique_client import CritiqueClient
+
+
+_surge_cache_lock = threading.Lock()
+
+
+class SurgeAICritiqueClient(CritiqueClient):
+    """A CritiqueClient that creates tasks for workers on Surge AI.
+
+    Surge AI concepts:
+
+    - A **project** contains **instructions** and **questions**, which are templates that can contain
+      placeholders.
+    - A **task** is created in a project and contains **fields** that are interpolated into the
+      placeholders in the project's instructions and questions templates to instantiate the actual instructions
+      and questions in the task.
+    - A **task response** is a response to a task by a single worker and contains answers to all the questions
+      in the task.
+
+    Mapping of HELM concepts to Surge AI concepts:
+
+    - A `CritiqueTaskTemplate` maps to a **project**.
+    - A `CritiqueQuestionTemplate` maps to a **question** template in a project.
+    - A `CritiqueRequest` maps to a **task**
+        - `CritiqueRequest.template` indicates which **project** the task should be created in.
+        - `CritiqueRequest.fields` provides the fields that are interpolated into the placeholders in the
+          projects' instructions and questions templates.
+    - A `CritiqueResponse` maps to a **task response**.
+    - A `CritiqueRequestResult` maps to a list of **task responses** across multiple workers for a task.
+    """
+
+    def __init__(self, api_key: str, cache_config: CacheConfig):
+        surge.api_key = api_key
+        self._cache = Cache(cache_config)
+
+    def _to_surge_question(self, question: CritiqueQuestionTemplate) -> surge_questions.MultipleChoiceQuestion:
+        if question.question_type != "multiple_choice":
+            raise ValueError("Currently, only multiple_choice questions are supported")
+        return surge_questions.MultipleChoiceQuestion(
+            text=question.text,
+            options=question.options,
+        )
+
+    def _get_or_create_surge_project(self, template: CritiqueTaskTemplate) -> str:
+        """Get or create a project on Surge AI and return the Surge AI project ID.
+
+        Attempt to find a Surge AI project for the template from the cache. If one exists, reuse that project.
+        Otherwise, create a new project using the template and save it to the cache. Return the Surge AI project ID."""
+
+        def create_surge_project():
+            project = surge.Project.create(
+                name=template.name,
+                instructions=template.instructions,
+                questions=[self._to_surge_question(question) for question in template.questions],
+                num_workers_per_task=template.num_respondents,
+            )
+            return {"id": project.id}
+
+        with _surge_cache_lock:
+            # Example cache key:
+            # {
+            #   "template": {
+            #     # See CritiqueQuestionTemplate for complete schema
+            #     "name": "some_name",
+            #     "instructions": "some_instructions",
+            #     "num_respondents": 1,
+            #     "questions": []
+            #   }
+            # }
+            #
+            # Example cache value:
+            # {"id": "17e323f1-f7e4-427c-a2d5-456743aba8"}
+            #
+            # Note:
+            # We do not cache the additional fields returned by surge.Project.create()
+            # because they are mutable server-side, and server-side mutations may cause
+            # stale cache issues.
+            project_response, is_cached = self._cache.get({"template": unstructure(template)}, create_surge_project)
+        project_id = project_response["id"]
+        if is_cached:
+            hlog(f"Reusing existing Surge AI project: {project_id}")
+        else:
+            hlog(f"Creating new Surge AI project: {project_id}")
+        return project_id
+
+    def _get_or_create_task(self, project_id: str, fields: Dict[str, str]) -> str:
+        """Get or create a task on Surge AI and return the Surge AI project ID.
+
+        Attempt to find a Surge AI task inside this project for the fields from the cache.
+        If one exists, reuse that task. Otherwise, create a new task inside the project using the fields.
+        and save it to the cache. Return the Surge AI task ID."""
+        project = surge.Project.retrieve(project_id)
+
+        def create_surge_task():
+            tasks = project.create_tasks([fields], launch=False)  # TODO: Make launch parameter configurable
+            if len(tasks) != 1:
+                return RuntimeError(f"Expected one task in Surge response, but got {len(tasks)} tasks")
+            task = tasks[0]
+            return {"id": task.id}
+
+        with _surge_cache_lock:
+            # Example cache key:
+            # {
+            #   "project_id": "17e323f1-f7e4-427c-a2d5-456743aba8",
+            #   "fields": {
+            #     "some_field": "some_value"
+            #   }
+            # }
+            #
+            # Example cache value:
+            # {"id": "17e323f1-f7e4-427c-a2d5-456743aba8"}
+            #
+            # Note:
+            # We do not cache the additional fields returned by surge.Project.create()
+            # because they are mutable server-side, and server-side mutations may cause
+            # stale cache issues.
+            task_response, is_cached = self._cache.get({"project_id": project_id, "fields": fields}, create_surge_task)
+        task_id = task_response["id"]
+        if is_cached:
+            hlog(f"Reusing existing Surge AI task: {task_id}")
+        else:
+            hlog(f"Creating new Surge AI task: {task_id}")
+        return task_id
+
+    def _get_worker_responses(self, task_id: str, questions: List[CritiqueQuestionTemplate]) -> List[CritiqueResponse]:
+        task = surge.Task.retrieve(task_id)
+        return [
+            CritiqueResponse(
+                id=task_response.id,
+                respondent_id=task_response.worker_id,
+                answers={question.name: task_response.data[question.name] for question in questions},
+            )
+            for task_response in task.responses
+        ]
+
+    def make_critique_request(self, request: CritiqueRequest) -> CritiqueRequestResult:
+        """Create a task on Surge AI and fetch responses from Surge AI if available.
+
+        Returns CritiqueRequestResult if worker answers are complete, or None otherwise.
+        The intended use is to call it once to create the task, wait a while, and then call it
+        later to fetch answers.
+
+        First, attempt to find a Surge AI project for the template. If one exists, reuse that project.
+        Otherwise, create a new project using the template.
+
+        Second, attempt to find a Surge AI task inside this project for the fields. If one exists,
+        reuse that task. Otherwise, create a new task inside the project using the fields.
+
+        Finally, check if responses are available by checking if the number of workers who have responded
+        is equal to the requested number of workers. If so, return those responses.
+
+        This method is idempotent, because projects and tasks are not created if they already exist.
+
+        The cache will store the mappings from template to Surge AI Project ID and from fields to Surge AI
+        question ID. If the cache is deleted, the mappings will be lost, and this method will not be able
+        to fetch results from the previous projects and tasks, and will have to create new projects and tasks.
+        Note that worker responses are currently not cached."""
+        project_id = self._get_or_create_surge_project(request.template)
+        task_id = self._get_or_create_task(project_id, request.fields)
+        worker_responses = self._get_worker_responses(task_id, request.template.questions)
+        return CritiqueRequestResult(worker_responses)


### PR DESCRIPTION
- Only require a Scale project (rather than a Scale batch) to be specified, which simplifies the user workflow
- Rename special field key for image attachments
- Disable self-labeling
- Move `SurgeAICritiqueClient` its own module

Addresses #1614 