### PR TITLE
Safer MongoDB Auth

### DIFF
--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -184,13 +184,14 @@ def validate_args(args):
     if args.cache_instances_only:
         assert args.cache_instances, "If --cache-instances-only is set, --cache-instances must also be set."
 
-    parsed_mongo_uri: Dict[str, Any] = uri_parser.parse_uri(args.mongo_uri)
-    assert (
-        not parsed_mongo_uri["username"] and not parsed_mongo_uri["password"]
-    ), "MongoDB username and password should not be supplied in connection string."
-    assert ("HELM_MONGODB_USERNAME" in os.environ and "HELM_MONGODB_PASSWORD" in os.environ) or (
-        "HELM_MONGODB_USERNAME" not in os.environ and "HELM_MONGODB_PASSWORD" not in os.environ
-    ), "If HELM_MONGODB_USERNAME is non-empty, then HELM_MONGODB_PASSWORD must also be non-empty."
+    if args.mongo_uri:
+        parsed_mongo_uri: Dict[str, Any] = uri_parser.parse_uri(args.mongo_uri)
+        assert (
+            not parsed_mongo_uri["username"] and not parsed_mongo_uri["password"]
+        ), "MongoDB username and password should not be supplied in connection string."
+        assert ("HELM_MONGODB_USERNAME" in os.environ and "HELM_MONGODB_PASSWORD" in os.environ) or (
+            "HELM_MONGODB_USERNAME" not in os.environ and "HELM_MONGODB_PASSWORD" not in os.environ
+        ), "If HELM_MONGODB_USERNAME is non-empty, then HELM_MONGODB_PASSWORD must also be non-empty."
 
 
 @htrack(None)

--- a/src/helm/proxy/clients/auto_client.py
+++ b/src/helm/proxy/clients/auto_client.py
@@ -53,7 +53,7 @@ class AutoClient(Client):
         huggingface_cache_config = self._build_cache_config("huggingface")
         self.huggingface_client = HuggingFaceClient(huggingface_cache_config)
         hlog(f"AutoClient: cache_path = {cache_path}")
-        hlog(f"AutoClient: mongo_uri = {mongo_uri}")
+        hlog(f"AutoClient: mongo_uri (without credentials) = {mongo_uri}")
 
     def _build_cache_config(self, organization: str) -> CacheConfig:
         if self.mongo_uri:


### PR DESCRIPTION
Currently, using the `mongo-uri` argument for a collection which requires username/password authentication requires that the user specify those credentials in the URI passed in. This has two security risks:
- The credentials are present in the user's shell's history.
- The credentials are [logged verbatim](https://github.com/stanford-crfm/helm/blob/main/src/helm/proxy/clients/auto_client.py#L56).

We propose to change this by having the user supply the MongoDB connection URI _without_ credentials in the`mongo-uri` argument and to instead read those credentials from environment variables.