### PR TITLE
Change option values to integers (indices) when using Scale critique

### DIFF
--- a/src/helm/benchmark/metrics/summarization_critique_metrics.py
+++ b/src/helm/benchmark/metrics/summarization_critique_metrics.py
@@ -89,17 +89,26 @@ class SummarizationCritiqueMetric(Metric):
 
         for response in result.responses:
             for answer_name, answer in response.answers.items():
-                if not isinstance(answer, str):
-                    raise ValueError(f"Expected answer to {answer_name} be a string")
-                answer_value: float
+                if not isinstance(answer, (str, int)):
+                    raise ValueError(f"Expected answer to {answer_name} be str or int, got {type(answer)}")
                 if answer_name == _FAITHFULNESS_NAME:
-                    if answer == _YES_VALUE:
-                        answer_value = 1
-                    elif answer == _NO_VALUE:
-                        answer_value = 0
-                    else:
-                        raise ValueError(f"Unknown answer to {_FAITHFULNESS_NAME}: {answer}")
+                    answer_value: float
+                    if isinstance(answer, int):
+                        if answer == 1:
+                            # 1 represents the first option, `_YES_VALUE`
+                            answer_value = 1
+                        elif answer == 2:
+                            # 2 represents the second option, `_NO_VALUE`
+                            answer_value = 0
+                    elif isinstance(answer, str):
+                        if answer == _YES_VALUE:
+                            answer_value = 1
+                        elif answer == _NO_VALUE:
+                            answer_value = 0
+                        else:
+                            raise ValueError(f"Unknown answer to {_FAITHFULNESS_NAME}: {answer}")
                 else:
+                    # answer can be a string or int, e.g. "1" or 1, but the value should be the same.
                     answer_value = (int(answer) - 1) / 4
                 stats[answer_name].add(answer_value)
         return list(stats.values())

--- a/src/helm/benchmark/metrics/summarization_critique_metrics.py
+++ b/src/helm/benchmark/metrics/summarization_critique_metrics.py
@@ -89,26 +89,17 @@ class SummarizationCritiqueMetric(Metric):
 
         for response in result.responses:
             for answer_name, answer in response.answers.items():
-                if not isinstance(answer, (str, int)):
-                    raise ValueError(f"Expected answer to {answer_name} be str or int, got {type(answer)}")
+                if not isinstance(answer, str):
+                    raise ValueError(f"Expected answer to {answer_name} be a string")
+                answer_value: float
                 if answer_name == _FAITHFULNESS_NAME:
-                    answer_value: float
-                    if isinstance(answer, int):
-                        if answer == 1:
-                            # 1 represents the first option, `_YES_VALUE`
-                            answer_value = 1
-                        elif answer == 2:
-                            # 2 represents the second option, `_NO_VALUE`
-                            answer_value = 0
-                    elif isinstance(answer, str):
-                        if answer == _YES_VALUE:
-                            answer_value = 1
-                        elif answer == _NO_VALUE:
-                            answer_value = 0
-                        else:
-                            raise ValueError(f"Unknown answer to {_FAITHFULNESS_NAME}: {answer}")
+                    if answer == _YES_VALUE:
+                        answer_value = 1
+                    elif answer == _NO_VALUE:
+                        answer_value = 0
+                    else:
+                        raise ValueError(f"Unknown answer to {_FAITHFULNESS_NAME}: {answer}")
                 else:
-                    # answer can be a string or int, e.g. "1" or 1, but the value should be the same.
                     answer_value = (int(answer) - 1) / 4
                 stats[answer_name].add(answer_value)
         return list(stats.values())

--- a/src/helm/proxy/clients/scale_critique_client.py
+++ b/src/helm/proxy/clients/scale_critique_client.py
@@ -142,7 +142,8 @@ class ScaleCritiqueClient(CritiqueClient):
                 "field_id": question.name,  # This must be unique, so we use the question name
                 "title": question.name,
                 "description": self._interpolate_fields(question.text, fields),
-                "choices": [{"label": option, "value": option} for option in question.options],
+                # Scale's consensus function requires the values to be integers.
+                "choices": [{"label": question.options[i], "value": i + 1} for i in range(len(question.options))],
                 "min_choices": 0 if question.question_type == "checkbox" else 1,
                 "max_choices": len(question.options) if question.question_type == "checkbox" else 1,
             }

--- a/src/helm/proxy/clients/scale_critique_client.py
+++ b/src/helm/proxy/clients/scale_critique_client.py
@@ -1,7 +1,7 @@
 from hashlib import sha512
 import json
 import threading
-from typing import Dict, List, Union, Set, Tuple
+from typing import Dict, List, Union, Set, Any
 
 from cattrs import unstructure
 import scaleapi
@@ -233,7 +233,7 @@ class ScaleCritiqueClient(CritiqueClient):
         if task.status != TaskStatus.Completed.value:
             return []
         else:
-            annotations: Dict[str, List[str]] = task.response["annotations"]
+            annotations: Dict[str, Any] = task.response["annotations"]
             fields: List[dict] = task.response["params"]["fields"]
 
             # The format of annotations is:
@@ -278,9 +278,7 @@ class ScaleCritiqueClient(CritiqueClient):
             responses: List[CritiqueResponse] = []
             for respondent_index in range(num_respondents):
                 answers: Dict[str, Union[str, List[str]]] = {}
-                field_name_answers: List[Tuple[str, list]] = list(annotations.items())
-                for i in range(len(field_name_answers)):
-                    field_name, field_answers = field_name_answers[i]
+                for i, (field_name, field_answers) in enumerate(annotations.items()):
                     if fields[i]["type"] == "category":
                         # We need to convert the answer from an index to the actual value
                         assert isinstance(field_answers[respondent_index], int)

--- a/src/helm/proxy/clients/scale_critique_client.py
+++ b/src/helm/proxy/clients/scale_critique_client.py
@@ -287,6 +287,9 @@ class ScaleCritiqueClient(CritiqueClient):
                     elif fields[i]["type"] == "checkbox":
                         raise NotImplementedError("Checkbox fields are not supported yet")
                     else:
+                        hlog("Warning: The current logic is very problematic. If the response is a string,"
+                             "the program will return a character as the answer. Also, we should"
+                             "not be using the `annatation` field. We plan to fix this soon.")
                         answers[field_name] = field_answers[respondent_index]
                 responses.append(
                     CritiqueResponse(id=str(respondent_index), respondent_id=str(respondent_index), answers=answers)

--- a/src/helm/proxy/clients/scale_critique_client.py
+++ b/src/helm/proxy/clients/scale_critique_client.py
@@ -234,7 +234,7 @@ class ScaleCritiqueClient(CritiqueClient):
             return []
         else:
             annotations: Dict[str, Any] = task.response["annotations"]
-            fields: List[dict] = task.response["params"]["fields"]
+            fields: List[dict] = task.params["fields"]
 
             # The format of annotations is:
             # {

--- a/src/helm/proxy/clients/scale_critique_client.py
+++ b/src/helm/proxy/clients/scale_critique_client.py
@@ -143,7 +143,7 @@ class ScaleCritiqueClient(CritiqueClient):
                 "title": question.name,
                 "description": self._interpolate_fields(question.text, fields),
                 # Scale's consensus function requires the values to be a number.
-                "choices": [{"label": question.options[i], "value": i + 1} for i in range(len(question.options))],
+                "choices": [{"label": question.options[i], "value": i} for i in range(len(question.options))],
                 "min_choices": 0 if question.question_type == "checkbox" else 1,
                 "max_choices": len(question.options) if question.question_type == "checkbox" else 1,
             }
@@ -283,7 +283,7 @@ class ScaleCritiqueClient(CritiqueClient):
                         # We need to convert the answer from an index to the actual value
                         assert isinstance(field_answers[respondent_index], int)
                         value: int = field_answers[respondent_index]
-                        answers[field_name] = fields[i]["choices"][value - 1]["label"]
+                        answers[field_name] = fields[i]["choices"][value]["label"]
                     elif fields[i]["type"] == "checkbox":
                         raise NotImplementedError("Checkbox fields are not supported yet")
                     else:

--- a/src/helm/proxy/clients/scale_critique_client.py
+++ b/src/helm/proxy/clients/scale_critique_client.py
@@ -286,9 +286,10 @@ class ScaleCritiqueClient(CritiqueClient):
                         assert isinstance(field_answers[respondent_index], int)
                         value: int = field_answers[respondent_index]
                         answers[field_name] = fields[i]["choices"][value - 1]["label"]
+                    elif fields[i]["type"] == "checkbox":
+                        raise NotImplementedError("Checkbox fields are not supported yet")
                     else:
                         answers[field_name] = field_answers[respondent_index]
-                    # TODO: type == "checkbox" may need special handling, too.
                 responses.append(
                     CritiqueResponse(id=str(respondent_index), respondent_id=str(respondent_index), answers=answers)
                 )

--- a/src/helm/proxy/clients/scale_critique_client.py
+++ b/src/helm/proxy/clients/scale_critique_client.py
@@ -142,7 +142,7 @@ class ScaleCritiqueClient(CritiqueClient):
                 "field_id": question.name,  # This must be unique, so we use the question name
                 "title": question.name,
                 "description": self._interpolate_fields(question.text, fields),
-                # Scale's consensus function requires the values to be integers.
+                # Scale's consensus function requires the values to be a number.
                 "choices": [{"label": question.options[i], "value": i + 1} for i in range(len(question.options))],
                 "min_choices": 0 if question.question_type == "checkbox" else 1,
                 "max_choices": len(question.options) if question.question_type == "checkbox" else 1,

--- a/src/helm/proxy/clients/scale_critique_client.py
+++ b/src/helm/proxy/clients/scale_critique_client.py
@@ -287,9 +287,11 @@ class ScaleCritiqueClient(CritiqueClient):
                     elif fields[i]["type"] == "checkbox":
                         raise NotImplementedError("Checkbox fields are not supported yet")
                     else:
-                        hlog("Warning: The current logic is very problematic. If the response is a string,"
-                             "the program will return a character as the answer. Also, we should"
-                             "not be using the `annatation` field. We plan to fix this soon.")
+                        hlog(
+                            "Warning: The current logic is very problematic. If the response is a string,"
+                            "the program will return a character as the answer. Also, we should"
+                            "not be using the `annatation` field. We plan to fix this soon."
+                        )
                         answers[field_name] = field_answers[respondent_index]
                 responses.append(
                     CritiqueResponse(id=str(respondent_index), respondent_id=str(respondent_index), answers=answers)


### PR DESCRIPTION
Scale's consensus function requires the value of each option to be "a number".