### PR TITLE
Reduce number of request retries from 8 to 5

### DIFF
--- a/src/helm/proxy/retry.py
+++ b/src/helm/proxy/retry.py
@@ -83,5 +83,5 @@ def retry_if_request_failed(result: Union[RequestResult, TokenizationRequestResu
 
 
 retry_request: Callable = get_retry_decorator(
-    "Request", max_attempts=8, wait_exponential_multiplier_seconds=5, retry_on_result=retry_if_request_failed
+    "Request", max_attempts=5, wait_exponential_multiplier_seconds=5, retry_on_result=retry_if_request_failed
 )


### PR DESCRIPTION
8 retries is too high and causes too long of a wait when there are permanent failures.