### PR TITLE
Ensure indexes exist on MongoDB collections

### DIFF
--- a/src/helm/common/cache.py
+++ b/src/helm/common/cache.py
@@ -200,6 +200,7 @@ class _MongoKeyValueStore(KeyValueStore):
         self._mongodb_client: MongoClient = MongoClient(uri)
         self._database = self._mongodb_client.get_default_database()
         self._collection = self._database.get_collection(collection_name)
+        self._collection.create_index(self._REQUEST_KEY, unique=True)
         super().__init__()
 
     def __enter__(self) -> "_MongoKeyValueStore":


### PR DESCRIPTION
Previously, we needed to manually create the index through `mongosh`. If a new organisation cache was used in HELM without doing so, then the cache would be very slow.

This change creates the index if it does not exist, eliminating the need to manually create the index, and avoiding accidentally using slow caches.