### PR TITLE
Fix error caching with PalmyraClient

### DIFF
--- a/src/helm/proxy/clients/palmyra_client.py
+++ b/src/helm/proxy/clients/palmyra_client.py
@@ -3,6 +3,7 @@ import requests
 from typing import Any, Dict, List
 
 from helm.common.cache import Cache, CacheConfig
+from helm.common.hierarchical_logger import hlog
 from helm.common.request import Request, RequestResult, Sequence, Token, ErrorFlags
 from helm.common.tokenization_request import (
     DecodeRequest,
@@ -100,6 +101,7 @@ class PalmyraClient(Client):
                 return RequestResult(success=False, cached=False, error=error, completions=[], embedding=[])
 
             if _is_content_moderation_failure(response):
+                hlog(f"Returning empty request for {request.model} due to content moderation filter")
                 return RequestResult(
                     success=False,
                     cached=False,

--- a/src/helm/proxy/clients/palmyra_client.py
+++ b/src/helm/proxy/clients/palmyra_client.py
@@ -100,7 +100,6 @@ class PalmyraClient(Client):
                 return RequestResult(success=False, cached=False, error=error, completions=[], embedding=[])
 
             if _is_content_moderation_failure(response):
-                print("[debug:yifanmai] Content moderation failure (outside)")
                 return RequestResult(
                     success=False,
                     cached=False,

--- a/src/helm/proxy/clients/palmyra_client.py
+++ b/src/helm/proxy/clients/palmyra_client.py
@@ -101,7 +101,7 @@ class PalmyraClient(Client):
                 return RequestResult(success=False, cached=False, error=error, completions=[], embedding=[])
 
             if _is_content_moderation_failure(response):
-                hlog(f"Returning empty request for {request.model} due to content moderation filter")
+                hlog(f"WARNING: Returning empty request for {request.model} due to content moderation filter")
                 return RequestResult(
                     success=False,
                     cached=False,


### PR DESCRIPTION
Currently, `PalmyraClient` is caching failing requests, causing future requests to also fail. This prevents failures from being cached, except for content moderation failures, which should be cached.