### PR TITLE
Handle NaN in Stat.bare_str()

### DIFF
--- a/src/helm/benchmark/metrics/statistic.py
+++ b/src/helm/benchmark/metrics/statistic.py
@@ -48,11 +48,15 @@ class Stat:
     def __repr__(self):
         return f"{self.name}[{self.bare_str()}]"
 
-    def bare_str(self):
-        def process(x: float):
+    def bare_str(self) -> str:
+        def process(x: Optional[float]) -> str:
+            if x is None:
+                return "None"
+            if math.isnan(x):
+                return "NaN"
             if int(x) == x:
-                return int(x)
-            return round(x, 3)
+                return str(int(x))
+            return str(round(x, 3))
 
         if self.count > 0:
             return (


### PR DESCRIPTION
`helm-summarize` crashes on the current run due to NaNs.