### PR TITLE
Adjust priorities of priority 1 and 2 entries in run_specs.conf

### DIFF
--- a/src/helm/benchmark/presentation/run_specs.conf
+++ b/src/helm/benchmark/presentation/run_specs.conf
@@ -104,7 +104,7 @@ entries: [
   ##### Sentiment Analysis #####
   # Scenarios: IMDB
 
-  {description: "imdb:model=text,data_augmentation=canonical", priority: 2}
+  {description: "imdb:model=text,data_augmentation=canonical", priority: 1}
 
 
   ##### (Miscellaneous) Text Classification #####
@@ -253,16 +253,16 @@ entries: [
 
   # For WikiFact, we sampled the following 10 relation types, which cover diverse topics
   # across general facts, humanities, social sciences and STEM.
-  {description: "wikifact:model=text,k=5,subject=plaintiff", priority: 2}
-  {description: "wikifact:model=text,k=5,subject=place_of_birth", priority: 2}
-  {description: "wikifact:model=text,k=5,subject=medical_condition_treated", priority: 2}
-  {description: "wikifact:model=text,k=5,subject=instance_of", priority: 2}
-  {description: "wikifact:model=text,k=5,subject=part_of", priority: 2}
-  {description: "wikifact:model=text,k=5,subject=currency", priority: 2}
-  {description: "wikifact:model=text,k=5,subject=position_held", priority: 2}
-  {description: "wikifact:model=text,k=5,subject=author", priority: 2}
-  {description: "wikifact:model=text,k=5,subject=discoverer_or_inventor", priority: 2}
-  {description: "wikifact:model=text,k=5,subject=symptoms_and_signs", priority: 2}
+  {description: "wikifact:model=text,k=5,subject=plaintiff", priority: 1}
+  {description: "wikifact:model=text,k=5,subject=place_of_birth", priority: 1}
+  {description: "wikifact:model=text,k=5,subject=medical_condition_treated", priority: 1}
+  {description: "wikifact:model=text,k=5,subject=instance_of", priority: 1}
+  {description: "wikifact:model=text,k=5,subject=part_of", priority: 1}
+  {description: "wikifact:model=text,k=5,subject=currency", priority: 1}
+  {description: "wikifact:model=text,k=5,subject=position_held", priority: 1}
+  {description: "wikifact:model=text,k=5,subject=author", priority: 1}
+  {description: "wikifact:model=text,k=5,subject=discoverer_or_inventor", priority: 1}
+  {description: "wikifact:model=text,k=5,subject=symptoms_and_signs", priority: 1}
   {description: "wikifact:model=text,k=5,subject=applies_to_jurisdiction", priority: 4}
   {description: "wikifact:model=text,k=5,subject=field_of_work", priority: 4}
   {description: "wikifact:model=text,k=5,subject=member_of_political_party", priority: 4}
@@ -527,8 +527,8 @@ entries: [
   {description: "entity_data_imputation:model=text,dataset=Restaurant", priority: 1}
 
   # Code
-  {description: "code:model=code,dataset=humaneval", priority: 1}
-  {description: "code:model=code,dataset=apps,timeout=3", priority: 1}
+  {description: "code:model=code,dataset=humaneval", priority: 2}
+  {description: "code:model=code,dataset=apps,timeout=3", priority: 2}
 
   {description: "big_bench:model=text,max_train_instances=big_bench_few_shot_setting,task=semantic_parsing_spider,subtask=", priority: 3}
 
@@ -590,7 +590,7 @@ entries: [
   ##### Robustness #####
 
   ## Contrast sets (these are separate runs since we will only consider Instances that have contrast sets
-  {description: "boolq:model=text,only_contrast=True,data_augmentation=contrast_sets", priority: 1, groups: ["robustness_contrast_sets"]}
+  {description: "boolq:model=text,only_contrast=True,data_augmentation=contrast_sets", priority: 2, groups: ["robustness_contrast_sets"]}
   {description: "imdb:model=text,only_contrast=True,data_augmentation=contrast_sets", priority: 2, groups: ["robustness_contrast_sets"]}
 
   ##### Instruction Following #####

--- a/src/helm/benchmark/presentation/run_specs.conf
+++ b/src/helm/benchmark/presentation/run_specs.conf
@@ -12,7 +12,7 @@ entries: [
   ## Reading comprehension
 
   {description: "boolq:model=text,data_augmentation=canonical", priority: 1}
-  {description: "narrative_qa:model=text,data_augmentation=canonical", priority: 2}
+  {description: "narrative_qa:model=text,data_augmentation=canonical", priority: 1}
   {description: "news_qa:model=text,data_augmentation=canonical", priority: 3}
   {description: "quac:model=text,data_augmentation=canonical", priority: 1}
 
@@ -26,19 +26,19 @@ entries: [
   {description: "commonsense:model=text,dataset=commonsenseqa,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 3}
   # Adaptation method is set to ADAPT_MULTIPLE_CHOICE_SEPARATE_CALIBRATED and echo=True
   {description: "commonsense:model=full_functionality_text,dataset=hellaswag,method=multiple_choice_separate_original,data_augmentation=canonical", priority: 1}
-  {description: "commonsense:model=full_functionality_text,dataset=openbookqa,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 2}
+  {description: "commonsense:model=full_functionality_text,dataset=openbookqa,method=multiple_choice_separate_calibrated,data_augmentation=canonical", priority: 1}
   {description: "truthful_qa:model=text,task=mc_single,data_augmentation=canonical", priority: 1}
 
-  {description: "mmlu:model=text,subject=abstract_algebra,data_augmentation=canonical", priority: 2}
+  {description: "mmlu:model=text,subject=abstract_algebra,data_augmentation=canonical", priority: 1}
   {description: "mmlu:model=text,subject=anatomy,data_augmentation=canonical", priority: 3}
-  {description: "mmlu:model=text,subject=college_chemistry,data_augmentation=canonical", priority: 2}
-  {description: "mmlu:model=text,subject=computer_security,data_augmentation=canonical", priority: 2}
-  {description: "mmlu:model=text,subject=econometrics,data_augmentation=canonical", priority: 2}
+  {description: "mmlu:model=text,subject=college_chemistry,data_augmentation=canonical", priority: 1}
+  {description: "mmlu:model=text,subject=computer_security,data_augmentation=canonical", priority: 1}
+  {description: "mmlu:model=text,subject=econometrics,data_augmentation=canonical", priority: 1}
   {description: "mmlu:model=text,subject=global_facts,data_augmentation=canonical", priority: 3}
   {description: "mmlu:model=text,subject=jurisprudence,data_augmentation=canonical", priority: 3}
   {description: "mmlu:model=text,subject=philosophy,data_augmentation=canonical", priority: 3}
   {description: "mmlu:model=text,subject=professional_medicine,data_augmentation=canonical", priority: 3}
-  {description: "mmlu:model=text,subject=us_foreign_policy,data_augmentation=canonical", priority: 2}
+  {description: "mmlu:model=text,subject=us_foreign_policy,data_augmentation=canonical", priority: 1}
   {description: "mmlu:model=text,subject=astronomy,data_augmentation=canonical", priority: 4}
   {description: "mmlu:model=text,subject=business_ethics,data_augmentation=canonical", priority: 4}
   {description: "mmlu:model=text,subject=clinical_knowledge,data_augmentation=canonical", priority: 4}
@@ -92,49 +92,49 @@ entries: [
   # Scenarios: MS Marco (Regular), MS MARCO (TREC)
 
   {description: "msmarco:model=full_functionality_text,data_augmentation=canonical,track=regular,valid_topk=30", priority: 2}
-  {description: "msmarco:model=full_functionality_text,data_augmentation=canonical,track=trec,valid_topk=30", priority: 1}
+  {description: "msmarco:model=full_functionality_text,data_augmentation=canonical,track=trec,valid_topk=30", priority: 2}
 
   ##### Summarization #####
   # Scenarios: XSUM, CNN/DM
 
-  {description: "summarization_cnndm:model=text,temperature=0.3,device=cpu", priority: 1}
-  {description: "summarization_xsum_sampled:model=text,temperature=0.3,device=cpu", priority: 1}
+  {description: "summarization_cnndm:model=text,temperature=0.3,device=cpu", priority: 2}
+  {description: "summarization_xsum_sampled:model=text,temperature=0.3,device=cpu", priority: 2}
 
 
   ##### Sentiment Analysis #####
   # Scenarios: IMDB
 
-  {description: "imdb:model=text,data_augmentation=canonical", priority: 1}
+  {description: "imdb:model=text,data_augmentation=canonical", priority: 2}
 
 
   ##### (Miscellaneous) Text Classification #####
   # Scenarios: RAFT
 
-  {description: "raft:subset=ade_corpus_v2,model=text,data_augmentation=canonical", priority: 2}
-  {description: "raft:subset=banking_77,model=text,data_augmentation=canonical", priority: 2}
-  {description: "raft:subset=neurips_impact_statement_risks,model=text,data_augmentation=canonical", priority: 2}
-  {description: "raft:subset=one_stop_english,model=text,data_augmentation=canonical", priority: 2}
-  {description: "raft:subset=overruling,model=text,data_augmentation=canonical", priority: 2}
-  {description: "raft:subset=semiconductor_org_types,model=text,data_augmentation=canonical", priority: 2}
-  {description: "raft:subset=tweet_eval_hate,model=text,data_augmentation=canonical", priority: 2}
-  {description: "raft:subset=twitter_complaints,model=text,data_augmentation=canonical", priority: 2}
-  {description: "raft:subset=systematic_review_inclusion,model=text,data_augmentation=canonical", priority: 2}
-  {description: "raft:subset=tai_safety_research,model=text,data_augmentation=canonical", priority: 2}
-  {description: "raft:subset=terms_of_service,model=text,data_augmentation=canonical", priority: 2}
+  {description: "raft:subset=ade_corpus_v2,model=text,data_augmentation=canonical", priority: 1}
+  {description: "raft:subset=banking_77,model=text,data_augmentation=canonical", priority: 1}
+  {description: "raft:subset=neurips_impact_statement_risks,model=text,data_augmentation=canonical", priority: 1}
+  {description: "raft:subset=one_stop_english,model=text,data_augmentation=canonical", priority: 1}
+  {description: "raft:subset=overruling,model=text,data_augmentation=canonical", priority: 1}
+  {description: "raft:subset=semiconductor_org_types,model=text,data_augmentation=canonical", priority: 1}
+  {description: "raft:subset=tweet_eval_hate,model=text,data_augmentation=canonical", priority: 1}
+  {description: "raft:subset=twitter_complaints,model=text,data_augmentation=canonical", priority: 1}
+  {description: "raft:subset=systematic_review_inclusion,model=text,data_augmentation=canonical", priority: 1}
+  {description: "raft:subset=tai_safety_research,model=text,data_augmentation=canonical", priority: 1}
+  {description: "raft:subset=terms_of_service,model=text,data_augmentation=canonical", priority: 1}
 
 
   ##### Toxicity Detection #####
   # Scenarios: CivilComments
 
   {description: "civil_comments:model=text,demographic=all,data_augmentation=canonical", priority: 1}
-  {description: "civil_comments:model=text,demographic=male,data_augmentation=canonical", priority: 2}
-  {description: "civil_comments:model=text,demographic=female,data_augmentation=canonical", priority: 2}
-  {description: "civil_comments:model=text,demographic=LGBTQ,data_augmentation=canonical", priority: 2}
-  {description: "civil_comments:model=text,demographic=christian,data_augmentation=canonical", priority: 2}
-  {description: "civil_comments:model=text,demographic=muslim,data_augmentation=canonical", priority: 2}
-  {description: "civil_comments:model=text,demographic=other_religions,data_augmentation=canonical", priority: 2}
-  {description: "civil_comments:model=text,demographic=black,data_augmentation=canonical", priority: 2}
-  {description: "civil_comments:model=text,demographic=white,data_augmentation=canonical", priority: 2}
+  {description: "civil_comments:model=text,demographic=male,data_augmentation=canonical", priority: 1}
+  {description: "civil_comments:model=text,demographic=female,data_augmentation=canonical", priority: 1}
+  {description: "civil_comments:model=text,demographic=LGBTQ,data_augmentation=canonical", priority: 1}
+  {description: "civil_comments:model=text,demographic=christian,data_augmentation=canonical", priority: 1}
+  {description: "civil_comments:model=text,demographic=muslim,data_augmentation=canonical", priority: 1}
+  {description: "civil_comments:model=text,demographic=other_religions,data_augmentation=canonical", priority: 1}
+  {description: "civil_comments:model=text,demographic=black,data_augmentation=canonical", priority: 1}
+  {description: "civil_comments:model=text,demographic=white,data_augmentation=canonical", priority: 1}
 
   ##### Machine Translation #####
   # Scenarios: WMT_14
@@ -200,8 +200,8 @@ entries: [
   {description: "the_pile:model=full_functionality_text,subset=Wikipedia (en)", priority: 2}
   {description: "the_pile:model=full_functionality_text,subset=YoutubeSubtitles", priority: 3}
 
-  {description: "twitter_aae:model=full_functionality_text,demographic=aa", priority: 1}
-  {description: "twitter_aae:model=full_functionality_text,demographic=white", priority: 1}
+  {description: "twitter_aae:model=full_functionality_text,demographic=aa", priority: 2}
+  {description: "twitter_aae:model=full_functionality_text,demographic=white", priority: 2}
 
   {description: "ice:model=full_functionality_text,subset=can", priority: 3}
   {description: "ice:model=full_functionality_text,subset=ea", priority: 2}
@@ -356,17 +356,17 @@ entries: [
   # {description: "numeracy:model=text_code,run_solver=False,relation_type=parabola,mode=function", priority: 4}
   # {description: "numeracy:model=text_code,run_solver=False,relation_type=paraboloid,mode=function", priority: 4}
 
-  {description: "synthetic_reasoning:model=text_code,mode=pattern_match", priority: 2}
-  {description: "synthetic_reasoning:model=text_code,mode=variable_substitution", priority: 2}
-  {description: "synthetic_reasoning:model=text_code,mode=induction", priority: 2}
+  {description: "synthetic_reasoning:model=text_code,mode=pattern_match", priority: 1}
+  {description: "synthetic_reasoning:model=text_code,mode=variable_substitution", priority: 1}
+  {description: "synthetic_reasoning:model=text_code,mode=induction", priority: 1}
 
-  {description: "synthetic_reasoning_natural:model=text_code,difficulty=easy", priority: 2}
-  {description: "synthetic_reasoning_natural:model=text_code,difficulty=hard", priority: 2}
+  {description: "synthetic_reasoning_natural:model=text_code,difficulty=easy", priority: 1}
+  {description: "synthetic_reasoning_natural:model=text_code,difficulty=hard", priority: 1}
 
-  {description: "babi_qa:model=text_code,task=all", priority: 2}
+  {description: "babi_qa:model=text_code,task=all", priority: 1}
   {description: "babi_qa:model=text_code,task=1", priority: 3}
   {description: "babi_qa:model=text_code,task=2", priority: 4}
-  {description: "babi_qa:model=text_code,task=3", priority: 2}
+  {description: "babi_qa:model=text_code,task=3", priority: 1}
   {description: "babi_qa:model=text_code,task=4", priority: 3}
   {description: "babi_qa:model=text_code,task=5", priority: 4}
   {description: "babi_qa:model=text_code,task=6", priority: 4}
@@ -378,26 +378,26 @@ entries: [
   {description: "babi_qa:model=text_code,task=12", priority: 4}
   {description: "babi_qa:model=text_code,task=13", priority: 4}
   {description: "babi_qa:model=text_code,task=14", priority: 4}
-  {description: "babi_qa:model=text_code,task=15", priority: 2}
+  {description: "babi_qa:model=text_code,task=15", priority: 1}
   {description: "babi_qa:model=text_code,task=16", priority: 4}
   {description: "babi_qa:model=text_code,task=17", priority: 4}
   {description: "babi_qa:model=text_code,task=18", priority: 4}
-  {description: "babi_qa:model=text_code,task=19", priority: 2}
+  {description: "babi_qa:model=text_code,task=19", priority: 1}
   {description: "babi_qa:model=text_code,task=20", priority: 4}
 
   {description: "dyck_language:model=text_code,num_parenthesis_pairs=2", priority: 4}
-  {description: "dyck_language:model=text_code,num_parenthesis_pairs=3", priority: 2}
+  {description: "dyck_language:model=text_code,num_parenthesis_pairs=3", priority: 1}
   {description: "dyck_language:model=text_code,num_parenthesis_pairs=4", priority: 4}
 
   ## Real
 
-  {description: "math:model=text_code,subject=number_theory,level=1,use_official_examples=True", priority: 2}
-  {description: "math:model=text_code,subject=intermediate_algebra,level=1,use_official_examples=True", priority: 2}
-  {description: "math:model=text_code,subject=algebra,level=1,use_official_examples=True", priority: 2}
-  {description: "math:model=text_code,subject=prealgebra,level=1,use_official_examples=True", priority: 2}
-  {description: "math:model=text_code,subject=geometry,level=1,use_official_examples=True", priority: 2}
-  {description: "math:model=text_code,subject=counting_and_probability,level=1,use_official_examples=True", priority: 2}
-  {description: "math:model=text_code,subject=precalculus,level=1,use_official_examples=True", priority: 2}
+  {description: "math:model=text_code,subject=number_theory,level=1,use_official_examples=True", priority: 1}
+  {description: "math:model=text_code,subject=intermediate_algebra,level=1,use_official_examples=True", priority: 1}
+  {description: "math:model=text_code,subject=algebra,level=1,use_official_examples=True", priority: 1}
+  {description: "math:model=text_code,subject=prealgebra,level=1,use_official_examples=True", priority: 1}
+  {description: "math:model=text_code,subject=geometry,level=1,use_official_examples=True", priority: 1}
+  {description: "math:model=text_code,subject=counting_and_probability,level=1,use_official_examples=True", priority: 1}
+  {description: "math:model=text_code,subject=precalculus,level=1,use_official_examples=True", priority: 1}
 
   {description: "math:model=text_code,subject=number_theory,level=2,use_official_examples=True", priority: 4}
   {description: "math:model=text_code,subject=intermediate_algebra,level=2,use_official_examples=True", priority: 4}
@@ -432,13 +432,13 @@ entries: [
   {description: "math:model=text_code,subject=precalculus,level=5,use_official_examples=True", priority: 3}
 
   # With chain-of-thought prompting:
-  {description: "math:model=text_code,subject=number_theory,level=1,use_chain_of_thought=True", priority: 2}
-  {description: "math:model=text_code,subject=intermediate_algebra,level=1,use_chain_of_thought=True", priority: 2}
-  {description: "math:model=text_code,subject=algebra,level=1,use_chain_of_thought=True", priority: 2}
-  {description: "math:model=text_code,subject=prealgebra,level=1,use_chain_of_thought=True", priority: 2}
-  {description: "math:model=text_code,subject=geometry,level=1,use_chain_of_thought=True", priority: 2}
-  {description: "math:model=text_code,subject=counting_and_probability,level=1,use_chain_of_thought=True", priority: 2}
-  {description: "math:model=text_code,subject=precalculus,level=1,use_chain_of_thought=True", priority: 2}
+  {description: "math:model=text_code,subject=number_theory,level=1,use_chain_of_thought=True", priority: 1}
+  {description: "math:model=text_code,subject=intermediate_algebra,level=1,use_chain_of_thought=True", priority: 1}
+  {description: "math:model=text_code,subject=algebra,level=1,use_chain_of_thought=True", priority: 1}
+  {description: "math:model=text_code,subject=prealgebra,level=1,use_chain_of_thought=True", priority: 1}
+  {description: "math:model=text_code,subject=geometry,level=1,use_chain_of_thought=True", priority: 1}
+  {description: "math:model=text_code,subject=counting_and_probability,level=1,use_chain_of_thought=True", priority: 1}
+  {description: "math:model=text_code,subject=precalculus,level=1,use_chain_of_thought=True", priority: 1}
 
   {description: "math:model=text_code,subject=number_theory,level=2,use_chain_of_thought=True", priority: 4}
   {description: "math:model=text_code,subject=intermediate_algebra,level=2,use_chain_of_thought=True", priority: 4}
@@ -472,12 +472,12 @@ entries: [
   {description: "math:model=text_code,subject=counting_and_probability,level=5,use_chain_of_thought=True", priority: 3}
   {description: "math:model=text_code,subject=precalculus,level=5,use_chain_of_thought=True", priority: 3}
 
-  {description: "gsm:model=text_code", priority: 2}
+  {description: "gsm:model=text_code", priority: 1}
 
   # Legal reasoning
-  {description: "legal_support:model=text_code", priority: 2}
+  {description: "legal_support:model=text_code", priority: 1}
 
-  {description: "lsat_qa:model=text_code,task=all", priority: 2}
+  {description: "lsat_qa:model=text_code,task=all", priority: 1}
   {description: "lsat_qa:model=text_code,task=grouping", priority: 3}
   {description: "lsat_qa:model=text_code,task=ordering", priority: 3}
   {description: "lsat_qa:model=text_code,task=assignment", priority: 3}
@@ -519,12 +519,12 @@ entries: [
 
   # Data processing
 
-  {description: "entity_matching:model=text,dataset=Beer", priority: 2}
-  {description: "entity_matching:model=text,dataset=Abt_Buy", priority: 2}
-  {description: "entity_matching:model=text,dataset=Dirty_iTunes_Amazon", priority: 2}
+  {description: "entity_matching:model=text,dataset=Beer", priority: 1}
+  {description: "entity_matching:model=text,dataset=Abt_Buy", priority: 1}
+  {description: "entity_matching:model=text,dataset=Dirty_iTunes_Amazon", priority: 1}
 
-  {description: "entity_data_imputation:model=text,dataset=Buy", priority: 2}
-  {description: "entity_data_imputation:model=text,dataset=Restaurant", priority: 2}
+  {description: "entity_data_imputation:model=text,dataset=Buy", priority: 1}
+  {description: "entity_data_imputation:model=text,dataset=Restaurant", priority: 1}
 
   # Code
   {description: "code:model=code,dataset=humaneval", priority: 1}
@@ -539,10 +539,10 @@ entries: [
 
   # Randomly sampled instances from the original BooksCorpus.
   # We expect data here to be less repeated in the pretraining corpus. This approximates the average case.
-  {description: "copyright:model=text,datatag=n_books_1000-extractions_per_book_1-prefix_length_125", priority: 1}
+  {description: "copyright:model=text,datatag=n_books_1000-extractions_per_book_1-prefix_length_125", priority: 2}
 
   # We expect data here to be repeated more in the pretraining corpus. This approximates the worst case.
-  {description: "copyright:model=text,datatag=popular_books-prefix_length_125.json", priority: 1}
+  {description: "copyright:model=text,datatag=popular_books-prefix_length_125.json", priority: 2}
 
   # Large and small codex models.
   {description: "copyright:model=code,datatag=prompt_num_line_1-min_lines_20.json", priority: 2}
@@ -551,9 +551,9 @@ entries: [
 
   ## Disinformation
 
-  {description: "disinformation:model=text,capability=reiteration,topic=climate", priority: 1}
-  {description: "disinformation:model=text,capability=reiteration,topic=covid", priority: 1}
-  {description: "disinformation:model=text,capability=wedging", priority: 1}
+  {description: "disinformation:model=text,capability=reiteration,topic=climate", priority: 2}
+  {description: "disinformation:model=text,capability=reiteration,topic=covid", priority: 2}
+  {description: "disinformation:model=text,capability=wedging", priority: 2}
 
   ## Bias
 
@@ -584,22 +584,22 @@ entries: [
 
   ##### Efficiency #####
 
-  {description: "synthetic_efficiency:model=text,tokenizer=default,num_prompt_tokens=default_sweep,num_output_tokens=default_sweep", priority: 1}
-  {description: "synthetic_efficiency:model=code,tokenizer=default,num_prompt_tokens=default_sweep,num_output_tokens=default_sweep", priority: 1}
+  {description: "synthetic_efficiency:model=text,tokenizer=default,num_prompt_tokens=default_sweep,num_output_tokens=default_sweep", priority: 2}
+  {description: "synthetic_efficiency:model=code,tokenizer=default,num_prompt_tokens=default_sweep,num_output_tokens=default_sweep", priority: 2}
 
   ##### Robustness #####
 
   ## Contrast sets (these are separate runs since we will only consider Instances that have contrast sets
-  {description: "boolq:model=text,only_contrast=True,data_augmentation=contrast_sets", priority: 2, groups: ["robustness_contrast_sets"]}
+  {description: "boolq:model=text,only_contrast=True,data_augmentation=contrast_sets", priority: 1, groups: ["robustness_contrast_sets"]}
   {description: "imdb:model=text,only_contrast=True,data_augmentation=contrast_sets", priority: 2, groups: ["robustness_contrast_sets"]}
 
   ##### Instruction Following #####
 
-  {description: "self_instruct:model=instruction_following,num_respondents=1", priority: 1}
-  {description: "grammar:path=src/helm/benchmark/scenarios/best_chatgpt_prompts.yaml,tags=,model=instruction_following,num_respondents=1", priority: 1}
-  {description: "open_assistant:language=en,model=instruction_following,num_respondents=1", priority: 1}
-  {description: "vicuna:model=instruction_following,num_respondents=1", priority: 1}
-  {description: "koala:model=instruction_following,num_respondents=1", priority: 1}
-  {description: "anthropic_hh_rlhf:subset=hh,model=instruction_following,num_respondents=1", priority: 1}
+  {description: "self_instruct:model=instruction_following,num_respondents=1", priority: 2}
+  {description: "grammar:path=src/helm/benchmark/scenarios/best_chatgpt_prompts.yaml,tags=,model=instruction_following,num_respondents=1", priority: 2}
+  {description: "open_assistant:language=en,model=instruction_following,num_respondents=1", priority: 2}
+  {description: "vicuna:model=instruction_following,num_respondents=1", priority: 2}
+  {description: "koala:model=instruction_following,num_respondents=1", priority: 2}
+  {description: "anthropic_hh_rlhf:subset=hh,model=instruction_following,num_respondents=1", priority: 2}
   {description: "anthropic_hh_rlhf:subset=red_team,model=instruction_following,num_respondents=1", priority: 3}
 ]


### PR DESCRIPTION
This changes some entries from priority 1 to priority 2, and some entries from priority 2 to priority 1.

When `helm-run` is run with `--priority 1`, the selected entries are those described by @rishibommasani i.e. those that we actually want to keep running on new models going forward.