### PR TITLE
Fix markdown in schema for YaLM

### DIFF
--- a/src/helm/benchmark/static/schema.yaml
+++ b/src/helm/benchmark/static/schema.yaml
@@ -819,7 +819,7 @@ models:
   # Yandex
   - name: together/yalm
     display_name: YaLM (100B)
-    description: YaLM (100B parameters) is an autoregressive language model trained on English and Russian text ([GitHub](From https://github.com/yandex/YaLM-100B)).
+    description: YaLM (100B parameters) is an autoregressive language model trained on English and Russian text ([GitHub](https://github.com/yandex/YaLM-100B)).
     creator_organization: Yandex
     access: open
     num_parameters: 100000000000


### PR DESCRIPTION
Fix markdown in schema description for YaLM

* Remove `From` from link as this prevented markdown parser from converting to HTML link