### PR TITLE
Fix missing parenthesis in descriptions

### DIFF
--- a/src/helm/benchmark/static/schema.yaml
+++ b/src/helm/benchmark/static/schema.yaml
@@ -56,7 +56,7 @@ models:
   # TODO: add Luminous World when it's released
   - name: AlephAlpha/luminous-base
     display_name: Luminous Base (13B)
-    description: Luminous Base (13B parameters) ([docs](https://docs.aleph-alpha.com/docs/introduction/luminous/)
+    description: Luminous Base (13B parameters) ([docs](https://docs.aleph-alpha.com/docs/introduction/luminous/))
     creator_organization: Aleph Alpha
     access: limited
     num_parameters: 13000000000
@@ -64,14 +64,14 @@ models:
     release_date: 2022-01-01
   - name: AlephAlpha/luminous-extended
     display_name: Luminous Extended (30B)
-    description: Luminous Extended (30B parameters) ([docs](https://docs.aleph-alpha.com/docs/introduction/luminous/)
+    description: Luminous Extended (30B parameters) ([docs](https://docs.aleph-alpha.com/docs/introduction/luminous/))
     creator_organization: Aleph Alpha
     access: limited
     num_parameters: 30000000000
     release_date: 2022-01-01
   - name: AlephAlpha/luminous-supreme
     display_name: Luminous Supreme (70B)
-    description: Luminous Supreme (70B parameters) ([docs](https://docs.aleph-alpha.com/docs/introduction/luminous/)
+    description: Luminous Supreme (70B parameters) ([docs](https://docs.aleph-alpha.com/docs/introduction/luminous/))
     creator_organization: Aleph Alpha
     access: limited
     num_parameters: 70000000000


### PR DESCRIPTION
Fix missing parenthesis in descriptions

Links are rendered at `(docs` as opposed to `(docs)` due to missing final parenthesis.

* Add `)` to end of descriptions where missing