### PR TITLE
[Adds Dependency] Add test for schema.yml

### DIFF
--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -66,6 +66,7 @@ Jinja2==3.1.2
 jmespath==1.0.1
 joblib==1.2.0
 jsonlines==3.1.0
+jsonschema==4.17.3
 kiwisolver==1.4.4
 langcodes==3.3.0
 llvmlite==0.39.1

--- a/src/helm/benchmark/schema_schema.json
+++ b/src/helm/benchmark/schema_schema.json
@@ -26,7 +26,8 @@
             "type": "string"
           },
           "access": {
-            "type": "string"
+            "type": "string",
+            "enum": ["open", "limited", "closed"]
           },
           "num_parameters": {
             "type": "number"

--- a/src/helm/benchmark/schema_schema.json
+++ b/src/helm/benchmark/schema_schema.json
@@ -1,0 +1,251 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "type": "object",
+  "required": [
+    "models",
+    "adapter",
+    "perturbations",
+    "metric_groups",
+    "run_groups"
+  ],
+  "properties": {
+
+    "models": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "creator_organization": {
+            "type": "string"
+          },
+          "access": {
+            "type": "string"
+          },
+          "num_parameters": {
+            "type": "number"
+          },
+          "description": {
+            "type": "string"
+          },
+          "release_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "todo": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name",
+          "display_name",
+          "creator_organization",
+          "access",
+          "description"
+        ]
+      }
+    },
+
+    "adapter": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "description"
+              ],
+              "minItems": 1
+            }
+          }
+        },
+        "required": [
+          "name",
+          "description"
+        ]
+      }
+    },
+
+    "perturbations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "short_description_name": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "description",
+          "display_name"
+        ]
+      }
+    },
+
+    "metric_groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "metrics": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "split": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "split"
+              ]
+            },
+            "minItems": 1
+          }
+        },
+        "required": [
+          "name",
+          "display_name",
+          "metrics"
+        ]
+      }
+    },
+
+    "run_groups": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "display_name": {
+                "type": "string"
+              },
+              "category": {
+                "type": "string"
+              },
+              "visibility": {
+                "type": "string"
+              },
+              "subgroups": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "uniqueItems": true
+              }
+            },
+            "required": [
+              "name",
+              "description",
+              "display_name",
+              "category"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "display_name": {
+                "type": "string"
+              },
+              "metric_groups": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "environment": {
+                "type": "object",
+                "properties": {
+                  "main_name": {
+                    "type": "string"
+                  },
+                  "main_split": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "main_split"
+                ]
+              },
+              "taxonomy": {
+                "type": "object",
+                "properties": {
+                  "task": {
+                    "type": "string"
+                  },
+                  "what": {
+                    "type": "string"
+                  },
+                  "who": {
+                    "type": "string"
+                  },
+                  "when": {
+                    "type": "string"
+                  },
+                  "language": {
+                    "type": "string"
+                  }
+                },
+                "required": []
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/helm/benchmark/schema_schema.json
+++ b/src/helm/benchmark/schema_schema.json
@@ -4,6 +4,7 @@
   "required": [
     "models",
     "adapter",
+    "metrics",
     "perturbations",
     "metric_groups",
     "run_groups"
@@ -41,6 +42,7 @@
             "type": "boolean"
           }
         },
+        "additionalProperties": false,
         "required": [
           "name",
           "display_name",
@@ -74,6 +76,7 @@
                   "type": "string"
                 }
               },
+              "additionalProperties": false,
               "required": [
                 "name",
                 "description"
@@ -82,9 +85,40 @@
             }
           }
         },
+        "additionalProperties": false,
         "required": [
           "name",
           "description"
+        ]
+      }
+    },
+
+    "metrics": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "short_display_name": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "lower_is_better": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "description",
+          "display_name"
         ]
       }
     },
@@ -100,13 +134,14 @@
           "description": {
             "type": "string"
           },
-          "short_description_name": {
+          "short_display_name": {
             "type": "string"
           },
           "display_name": {
             "type": "string"
           }
         },
+        "additionalProperties": false,
         "required": [
           "name",
           "description",
@@ -123,6 +158,9 @@
           "name": {
             "type": "string"
           },
+          "display_name": {
+            "type": "string"
+          },
           "description": {
             "type": "string"
           },
@@ -136,8 +174,11 @@
                 },
                 "split": {
                   "type": "string"
+                },
+                "perturbation_name": {
                 }
               },
+              "additionalProperties": false,
               "required": [
                 "name",
                 "split"
@@ -146,6 +187,7 @@
             "minItems": 1
           }
         },
+        "additionalProperties": false,
         "required": [
           "name",
           "display_name",
@@ -185,6 +227,7 @@
                 "uniqueItems": true
               }
             },
+            "additionalProperties": false,
             "required": [
               "name",
               "description",
@@ -240,6 +283,7 @@
                     "type": "string"
                   }
                 },
+                "additionalProperties": false,
                 "required": []
               }
             }

--- a/src/helm/benchmark/test_schema.py
+++ b/src/helm/benchmark/test_schema.py
@@ -1,0 +1,22 @@
+import os
+import pytest
+import yaml
+import json
+from jsonschema import validate, FormatChecker
+from jsonschema.exceptions import ValidationError
+
+
+class TestSchema:
+    def setup_method(self, method):
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        with open(os.path.join(dir_path, "static", "schema.yaml"), "r") as stream:
+            # This is to remove the YAML conversion to a Python date object
+            self.instance = json.loads(json.dumps(yaml.safe_load(stream), default=str))
+        with open(os.path.join(dir_path, "schema_schema.json"), "r") as stream:
+            self.schema = json.load(stream)
+
+    def test_models(self):
+        try:
+            validate(instance=self.instance, schema=self.schema, format_checker=FormatChecker())
+        except ValidationError as err:
+            pytest.fail(f"{err}")


### PR DESCRIPTION
[Adds Dependency] Add test for schema.yml

Add validation for schema.yaml to make sure any malformed or incorrectly typed data is not added to the schema.

Reduces friction to the addtion in the future conditions and requirements.

_Note:_ Add dependency of `jsonschema==4.17.3`. Version `4.17.3` is explicitly selected as versions `>=4.18.0` have a dependency conflict as they require [attrs==23.1.0](https://github.com/python-jsonschema/jsonschema/blob/f79bad5fcd1baf5ac2fcd979dbd31616f913febd/docs/requirements.txt#L11)