### PR TITLE
Remove incorrect quotes from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ classifiers =
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.8
     License :: OSI Approved :: Apache Software License
-url = "https://github.com/stanford-crfm/helm"
+url = https://github.com/stanford-crfm/helm
 
 [options]
 python_requires = ~=3.8


### PR DESCRIPTION
This causes a "Invalid URI" error pushing to PyPI.