### PR TITLE
Widen PyTorch dependency version to allow PyTorch 2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -79,8 +79,8 @@ install_requires=
     # Models and Metrics Extras
     transformers~=4.28.1  # For anthropic_client, huggingface_client, huggingface_tokenizer, test_openai_token_cost_estimator, model_summac (via summarization_metrics)
     # TODO: Upgrade torch
-    torch>=1.12.1  # For huggingface_client, yalm_tokenizer, model_summac (via summarization_metrics)
-    torchvision>=0.13.1  # For huggingface_client, yalm_tokenizer, model_summac (via summarization_metrics)
+    torch>=1.12.1,<3.0.0  # For huggingface_client, yalm_tokenizer, model_summac (via summarization_metrics)
+    torchvision>=0.13.1,<3.0.0  # For huggingface_client, yalm_tokenizer, model_summac (via summarization_metrics)
 
     # Metrics Extras
     google-api-python-client~=2.64.0  # For perspective_api_client via toxicity_metrics

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,8 +79,8 @@ install_requires=
     # Models and Metrics Extras
     transformers~=4.28.1  # For anthropic_client, huggingface_client, huggingface_tokenizer, test_openai_token_cost_estimator, model_summac (via summarization_metrics)
     # TODO: Upgrade torch
-    torch~=1.12.1  # For huggingface_client, yalm_tokenizer, model_summac (via summarization_metrics)
-    torchvision~=0.13.1  # For huggingface_client, yalm_tokenizer, model_summac (via summarization_metrics)
+    torch>=1.12.1  # For huggingface_client, yalm_tokenizer, model_summac (via summarization_metrics)
+    torchvision>=0.13.1  # For huggingface_client, yalm_tokenizer, model_summac (via summarization_metrics)
 
     # Metrics Extras
     google-api-python-client~=2.64.0  # For perspective_api_client via toxicity_metrics


### PR DESCRIPTION
This allows users to use PyTorch 2.

PyTorch 2 is at the users own risk; this has not been thoroughly tested by HELM maintainers yet.

Addresses #1745