### PR TITLE
Fix GitHub source link in scenario.json

### DIFF
--- a/src/helm/benchmark/scenarios/scenario.py
+++ b/src/helm/benchmark/scenarios/scenario.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, replace
 from typing import List, Optional, Tuple
-import re
+from pathlib import PurePath
 import inspect
 
 from helm.common.object_spec import ObjectSpec, create_object
@@ -200,10 +200,14 @@ class Scenario(ABC):
     """Where the scenario subclass for `self` is defined."""
 
     def __post_init__(self) -> None:
-        # Assume `/.../src/helm/benchmark/...`
-        path = inspect.getfile(type(self))
-        # Strip out prefix in absolute path and replace with GitHub link.
-        self.definition_path = re.sub(r"^.*\/src/", "https://github.com/stanford-crfm/helm/blob/main/src/", path)
+        parts = list(PurePath(inspect.getfile(type(self))).parts)
+        path = parts.pop()
+        parts.reverse()
+        for part in parts:
+            path = part + "/" + path
+            if part == "helm":
+                break
+        self.definition_path = "https://github.com/stanford-crfm/helm/blob/main/src/" + path
 
     @abstractmethod
     def get_instances(self) -> List[Instance]:

--- a/src/helm/benchmark/scenarios/test_scenario.py
+++ b/src/helm/benchmark/scenarios/test_scenario.py
@@ -35,6 +35,12 @@ class TestScenario:
             "}",
         ]
 
+    def test_definition_path(self):
+        assert (
+            self.scenario.definition_path
+            == "https://github.com/stanford-crfm/helm/blob/main/src/helm/benchmark/scenarios/simple_scenarios.py"
+        )
+
 
 def test_input_equality():
     input1 = Input(text="input1")


### PR DESCRIPTION
Fix GitHub source link in scenario.json

If the file system does not have `/src/` in the path, the local file path of the system performing the build will be output in the `definition_path` field of `scenario.json` instead of the GitHub link. This is because there is a regex substitution that relies on the existence of `/src/`

* Update logic to walk back towards the path root until encountering a `helm` directory as opposed to a regex looking for `src`.

_Note:_ Future potential issue could be if a new `helm` directory was created above `/src/helm/`