### PR TITLE
Filter overlap ids based on helm subset

### DIFF
--- a/scripts/data_overlap/light_scenario.py
+++ b/scripts/data_overlap/light_scenario.py
@@ -47,3 +47,14 @@ class LightScenario:
 
     instances: List[LightInstance]
     """Instances of this scenario"""
+
+
+@dataclass(frozen=True)
+class ScenarioSpecInstanceIds:
+    """
+    Instance ids associated with a scenario
+    """
+
+    scenario_spec: ScenarioSpec
+
+    instance_ids: List[str]

--- a/src/helm/benchmark/data_overlap/light_scenario.py
+++ b/src/helm/benchmark/data_overlap/light_scenario.py
@@ -48,6 +48,7 @@ class LightScenario:
     instances: List[LightInstance]
     """Instances of this scenario"""
 
+
 @dataclass(frozen=True)
 class ScenarioSpecInstanceIds:
     """

--- a/src/helm/benchmark/data_overlap/light_scenario.py
+++ b/src/helm/benchmark/data_overlap/light_scenario.py
@@ -47,3 +47,13 @@ class LightScenario:
 
     instances: List[LightInstance]
     """Instances of this scenario"""
+
+@dataclass(frozen=True)
+class ScenarioSpecInstanceIds:
+    """
+    Instance ids associated with a scenario
+    """
+
+    scenario_spec: ScenarioSpec
+
+    instance_ids: List[str]

--- a/src/helm/benchmark/presentation/run_display.py
+++ b/src/helm/benchmark/presentation/run_display.py
@@ -76,7 +76,7 @@ class DisplayRequest:
     most relevant request e.g. the request for the chosen cohice for multiple choice questions."""
 
 
-def _read_scenario_state(run_path: str) -> ScenarioState:
+def read_scenario_state(run_path: str) -> ScenarioState:
     scenario_state_path: str = os.path.join(run_path, "scenario_state.json")
     if not os.path.exists(scenario_state_path):
         raise ValueError(f"Could not load ScenarioState from {scenario_state_path}")
@@ -176,7 +176,7 @@ def write_run_display_json(run_path: str, run_spec: RunSpec, schema: Schema, ski
     ):
         hlog(f"Skipping writing display JSON for run {run_spec.name} because all output display JSON files exist.")
         return
-    scenario_state = _read_scenario_state(run_path)
+    scenario_state = read_scenario_state(run_path)
     per_instance_stats = _read_per_instance_stats(run_path)
 
     metric_names = _get_metric_names_for_groups(run_spec.groups, schema)

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -1105,8 +1105,8 @@ class Summarizer:
         If it doesn't exist, it will go through all the scenario_state files
         and parse the instance_ids and output it to the file for future uses
 
-        Only when the scenario_specs for the data overlap script change 
-        (or num_instances are different), will this need to be rerun. 
+        Only when the scenario_specs for the data overlap script change
+        (or num_instances are different), will this need to be rerun.
 
         In such cases, do not include the file as part of the data_overlap directory.
         """
@@ -1190,7 +1190,12 @@ def main():
         action="store_true",
         help="Skip write_run_display_json() for runs which already have all output display JSON files",
     )
-    parser.add_argument("-num-instances", type=int, help="Number of instance ids we're using; only for annotating scenario spec instance ids file", default=1000)
+    parser.add_argument(
+        "-num-instances",
+        type=int,
+        help="Number of instance ids we're using; only for annotating scenario spec instance ids file",
+        default=1000,
+    )
     args = parser.parse_args()
 
     # Output JSON files summarizing the benchmark results which will be loaded in the web interface

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -401,14 +401,14 @@ class Summarizer:
 
             scenario_spec_overlap_counts: Dict = dict()
             for data_overlap_stats in data_overlap_stats_list:
+                data_overlap_stats_key = data_overlap_stats.data_overlap_stats_key
+                n = data_overlap_stats_key.overlap_protocol_spec.n
                 if n == OVERLAP_N_COUNT:
-                    data_overlap_stats_key = data_overlap_stats.data_overlap_stats_key
                     light_scenario_key = data_overlap_stats_key.light_scenario_key
                     scenario_spec = light_scenario_key.scenario_spec
-                    n = data_overlap_stats_key.overlap_protocol_spec.n
-                    if scenario_spec in self._scenario_spec_instance_id_dict:
+                    if scenario_spec in self.scenario_spec_instance_id_dict:
                         # Get statistics based on the subset of instance_ids that HELM uses for a scenario
-                        instance_ids = self._scenario_spec_instance_id_dict[scenario_spec]
+                        instance_ids = self.scenario_spec_instance_id_dict[scenario_spec]
                         num_instances = len(instance_ids)
                         num_overlapping_inputs = len(
                             set(data_overlap_stats.instance_ids_with_overlapping_input) & set(instance_ids)
@@ -1110,7 +1110,7 @@ class Summarizer:
 
         In such cases, do not include the file as part of the data_overlap directory.
         """
-        self._scenario_spec_instance_id_dict: Dict[ScenarioSpec, List[str]] = dict()
+        self.scenario_spec_instance_id_dict: Dict[ScenarioSpec, List[str]] = dict()
         scenario_spec_instance_ids_json = os.path.join(
             self.run_suite_path, "data_overlap", f"scenario_spec_instance_ids_{num_instances}.json"
         )
@@ -1124,7 +1124,7 @@ class Summarizer:
             for scenario_spec_instance_ids_json in scenario_spec_instance_ids_jsons:
                 scenario_spec_instance_ids_dict = json.loads(scenario_spec_instance_ids_json)
                 scenario_spec_instance_ids = cattrs.structure(scenario_spec_instance_ids_dict, ScenarioSpecInstanceIds)
-                self._scenario_spec_instance_id_dict[
+                self.scenario_spec_instance_id_dict[
                     scenario_spec_instance_ids.scenario_spec
                 ] = scenario_spec_instance_ids.instance_ids
 
@@ -1132,18 +1132,18 @@ class Summarizer:
         for run in self.runs:
             run_spec = run.run_spec
             scenario_spec = run_spec.scenario_spec
-            if scenario_spec in self._scenario_spec_instance_id_dict:
+            if scenario_spec in self.scenario_spec_instance_id_dict:
                 continue
-            self._scenario_spec_instance_id_dict[scenario_spec] = list()
+            self.scenario_spec_instance_id_dict[scenario_spec] = list()
 
             run_path = run.run_path
             scenario_state = read_scenario_state(run_path)
 
             for request_state in scenario_state.request_states:
                 if request_state.instance.id:
-                    self._scenario_spec_instance_id_dict[scenario_spec].append(request_state.instance.id)
+                    self.scenario_spec_instance_id_dict[scenario_spec].append(request_state.instance.id)
         all_scenario_spec_instance_ids = []
-        for scenario_spec, instance_ids in self._scenario_spec_instance_id_dict.items():
+        for scenario_spec, instance_ids in self.scenario_spec_instance_id_dict.items():
             scenario_spec_instance_ids = ScenarioSpecInstanceIds(scenario_spec=scenario_spec, instance_ids=instance_ids)
             all_scenario_spec_instance_ids.append(scenario_spec_instance_ids)
 

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -401,21 +401,21 @@ class Summarizer:
 
             scenario_spec_overlap_counts: Dict = dict()
             for data_overlap_stats in data_overlap_stats_list:
-                data_overlap_stats_key = data_overlap_stats.data_overlap_stats_key
-                light_scenario_key = data_overlap_stats_key.light_scenario_key
-                scenario_spec = light_scenario_key.scenario_spec
-                n = data_overlap_stats_key.overlap_protocol_spec.n
-                if scenario_spec in self.scenario_spec_instance_id_dict:
-                    # Get statistics based on the subset of instance_ids that HELM uses for a scenario
-                    instance_ids = self.scenario_spec_instance_id_dict[scenario_spec]
-                    num_instances = len(instance_ids)
-                    num_overlapping_inputs = len(
-                        set(data_overlap_stats.instance_ids_with_overlapping_input) & set(instance_ids)
-                    )
-                    num_overlapping_references = len(
-                        set(data_overlap_stats.instance_ids_with_overlapping_reference) & set(instance_ids)
-                    )
-                    if n == OVERLAP_N_COUNT:
+                if n == OVERLAP_N_COUNT:
+                    data_overlap_stats_key = data_overlap_stats.data_overlap_stats_key
+                    light_scenario_key = data_overlap_stats_key.light_scenario_key
+                    scenario_spec = light_scenario_key.scenario_spec
+                    n = data_overlap_stats_key.overlap_protocol_spec.n
+                    if scenario_spec in self._scenario_spec_instance_id_dict:
+                        # Get statistics based on the subset of instance_ids that HELM uses for a scenario
+                        instance_ids = self._scenario_spec_instance_id_dict[scenario_spec]
+                        num_instances = len(instance_ids)
+                        num_overlapping_inputs = len(
+                            set(data_overlap_stats.instance_ids_with_overlapping_input) & set(instance_ids)
+                        )
+                        num_overlapping_references = len(
+                            set(data_overlap_stats.instance_ids_with_overlapping_reference) & set(instance_ids)
+                        )
                         scenario_spec_overlap_counts[scenario_spec] = (
                             num_instances,
                             num_overlapping_inputs,
@@ -1110,7 +1110,7 @@ class Summarizer:
 
         In such cases, do not include the file as part of the data_overlap directory.
         """
-        self.scenario_spec_instance_id_dict: Dict[ScenarioSpec, List[str]] = dict()
+        self._scenario_spec_instance_id_dict: Dict[ScenarioSpec, List[str]] = dict()
         scenario_spec_instance_ids_json = os.path.join(
             self.run_suite_path, "data_overlap", f"scenario_spec_instance_ids_{num_instances}.json"
         )
@@ -1124,7 +1124,7 @@ class Summarizer:
             for scenario_spec_instance_ids_json in scenario_spec_instance_ids_jsons:
                 scenario_spec_instance_ids_dict = json.loads(scenario_spec_instance_ids_json)
                 scenario_spec_instance_ids = cattrs.structure(scenario_spec_instance_ids_dict, ScenarioSpecInstanceIds)
-                self.scenario_spec_instance_id_dict[
+                self._scenario_spec_instance_id_dict[
                     scenario_spec_instance_ids.scenario_spec
                 ] = scenario_spec_instance_ids.instance_ids
 
@@ -1132,18 +1132,18 @@ class Summarizer:
         for run in self.runs:
             run_spec = run.run_spec
             scenario_spec = run_spec.scenario_spec
-            if scenario_spec in self.scenario_spec_instance_id_dict:
+            if scenario_spec in self._scenario_spec_instance_id_dict:
                 continue
-            self.scenario_spec_instance_id_dict[scenario_spec] = list()
+            self._scenario_spec_instance_id_dict[scenario_spec] = list()
 
             run_path = run.run_path
             scenario_state = read_scenario_state(run_path)
 
             for request_state in scenario_state.request_states:
                 if request_state.instance.id:
-                    self.scenario_spec_instance_id_dict[scenario_spec].append(request_state.instance.id)
+                    self._scenario_spec_instance_id_dict[scenario_spec].append(request_state.instance.id)
         all_scenario_spec_instance_ids = []
-        for scenario_spec, instance_ids in self.scenario_spec_instance_id_dict.items():
+        for scenario_spec, instance_ids in self._scenario_spec_instance_id_dict.items():
             scenario_spec_instance_ids = ScenarioSpecInstanceIds(scenario_spec=scenario_spec, instance_ids=instance_ids)
             all_scenario_spec_instance_ids.append(scenario_spec_instance_ids)
 

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -405,6 +405,7 @@ class Summarizer:
                 scenario_spec = light_scenario_key.scenario_spec
                 n = data_overlap_stats_key.overlap_protocol_spec.n
                 if scenario_spec in self.scenario_spec_instance_id_dict:
+                    # Get statistics based on the subset of instance_ids that HELM uses for a scenario
                     instance_ids = self.scenario_spec_instance_id_dict[scenario_spec]
                     num_instances = len(instance_ids)
                     num_overlapping_inputs = len(
@@ -1093,7 +1094,7 @@ class Summarizer:
 
         parallel_map(process, self.runs, parallelism=self.num_threads)
 
-    def get_scenario_spec_instance_ids(self) -> None:
+    def read_scenario_spec_instance_ids(self) -> None:
         self.scenario_spec_instance_id_dict: Dict[ScenarioSpec, Set[str]] = dict()
         for run in self.runs:
             run_spec = run.run_spec
@@ -1153,7 +1154,7 @@ def main():
         suite=args.suite, output_path=args.output_path, verbose=args.debug, num_threads=args.num_threads
     )
     summarizer.read_runs()
-    summarizer.get_scenario_spec_instance_ids()
+    summarizer.read_scenario_spec_instance_ids()
     summarizer.read_overlap_stats()
     summarizer.check_metrics_defined()
 


### PR DESCRIPTION
This PR depends on https://github.com/stanford-crfm/helm/pull/1747

Instead of taking num_instances and overlapping_ids as all the instances for a given scenario, we get the subset of scenarios in a helm run via scenario_state, and take the intersection of these and the overlapping scenarios