### PR TITLE
Fix metadata for Llama 2 and other Together models

### DIFF
--- a/src/helm/benchmark/static/schema.yaml
+++ b/src/helm/benchmark/static/schema.yaml
@@ -443,21 +443,21 @@ models:
     num_parameters: 65000000000
     release_date: 2023-02-24
   - name: meta/llama-2-7b
-    display_name: LLaMA-2 (7B)
+    display_name: Llama 2 (7B)
     description: Llama 2 pretrained models are trained on 2 trillion tokens, and have double the context length than Llama 1.
     creator_organization: Meta
     access: open
     num_parameters: 7000000000
     release_date: 2023-07-18
   - name: meta/llama-2-13b
-    display_name: LLaMA-2 (13B)
+    display_name: Llama 2 (13B)
     description: Llama 2 pretrained models are trained on 2 trillion tokens, and have double the context length than Llama 1.
     creator_organization: Meta
     access: open
     num_parameters: 13000000000
     release_date: 2023-07-18
   - name: meta/llama-2-70b
-    display_name: LLaMA-2 (70B)
+    display_name: Llama 2 (70B)
     description: Llama 2 pretrained models are trained on 2 trillion tokens, and have double the context length than Llama 1.
     creator_organization: Meta
     access: open

--- a/src/helm/proxy/models.py
+++ b/src/helm/proxy/models.py
@@ -296,38 +296,38 @@ ALL_MODELS = [
     Model(
         group="together",
         name="eleutherai/pythia-1b-v0",
-        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
+        tags=[TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG],
     ),
     Model(
         group="together",
         name="eleutherai/pythia-2.8b-v0",
-        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
+        tags=[TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG],
     ),
     Model(
         group="together",
         name="eleutherai/pythia-6.9b",
-        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
+        tags=[TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG],
     ),
     Model(
         group="together",
         name="eleutherai/pythia-12b-v0",
-        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
+        tags=[TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG],
     ),
     # Meta
     Model(
         group="together",
         name="meta/llama-7b",
-        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
+        tags=[TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG],
     ),
     Model(
         group="together",
         name="meta/llama-13b",
-        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
+        tags=[TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG],
     ),
     Model(
         group="together",
         name="meta/llama-30b",
-        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
+        tags=[TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG],
     ),
     Model(
         group="together",


### PR DESCRIPTION
- Llama 2 is spelled as such, not as LLaMA-2.
- All new Together models don't provide logprobs (Pythia, LLaMA, Llama 2)