### PR TITLE
Minor docs improvements on new scenario and credentials.conf

### DIFF
--- a/docs/code.md
+++ b/docs/code.md
@@ -79,13 +79,12 @@ In order to implement new scenarios:
    `name` corresponding to the scenario name and any patterns to match in 
    curly braces, a `scenario_spec`, an `adapter_spec`, `metric_specs`, 
    and `groups`. 
-12. Add the scenario to `__init__.py`
+12. Add the scenario to `src/helm/benchmark/__init__.py`
 13. Attempt to run your task with
     `venv/bin/helm-run -r yourscenarioname:arg=value` where 
     `yourscenarioname` matches the `name` specified in YourScenario
-14. Add the spec to dictionary `CANONICAL_RUN_SPEC_FUNCS` in `run_specs.py`.
+14. Add the spec to dictionary `CANONICAL_RUN_SPEC_FUNCS` in `src/helm/benchmark/run_specs.py`.
 15. Update `src/helm/proxy/static/contamination.yaml` with models that we trained on your scenario (i.e. contaminated).
-
 16. Add a schema to `src/helm/benchmark/static/schema.yaml` and add the scenario to `subgroups` as needed.
 
 ## Adding new metrics

--- a/docs/code.md
+++ b/docs/code.md
@@ -86,6 +86,7 @@ In order to implement new scenarios:
 14. Add the spec to dictionary `CANONICAL_RUN_SPEC_FUNCS` in `run_specs.py`.
 15. Update `src/helm/proxy/static/contamination.yaml` with models that we trained on your scenario (i.e. contaminated).
 
+16. Add a schema to `src/helm/benchmark/static/schema.yaml` and add the scenario to `subgroups` as needed.
 
 ## Adding new metrics
 

--- a/docs/code.md
+++ b/docs/code.md
@@ -90,6 +90,7 @@ In order to implement new scenarios:
 ## Adding new metrics
 
 To add a new metric:
+
 1. If the metric is task-specific, create a new `yourtask_metrics.py` file. 
    Otherwise, if the metric is generic and likely to be widely used, add it
    to `basic_metrics.py`.

--- a/docs/proxy-server.md
+++ b/docs/proxy-server.md
@@ -14,8 +14,10 @@ To use the REST API, see [demo.py](https://github.com/stanford-crfm/benchmarking
 Create `prod_env/credentials.conf` to contain the API keys for any language
 models you have access to.
 
-    openaiApiKey: ...
-    ai21ApiKey: ...
+    {
+        openaiApiKey: "...",
+        ai21ApiKey: "..."
+    }
 
 To start a local server (go to `http://localhost:1959` to try it out):
 


### PR DESCRIPTION
Tried to create a new scenario and spotted a few points in the docs that would have saved me some time:

1. Prepended path to the right `__init__.py` file
2. Added instruction to add schema for the new scenario
3. Minor formatting fix in the metrics section that's preventing the bullet rendering
4. Add proper template for `credentials.conf`