### PR TITLE
Don't compute calibration metrics for models without logprobs

### DIFF
--- a/src/helm/benchmark/metrics/basic_metrics.py
+++ b/src/helm/benchmark/metrics/basic_metrics.py
@@ -827,7 +827,7 @@ class BasicMetric(Metric):
 
 
 def _has_non_zero_valued_logprobs(per_instance_stats: Dict[Instance, List[Stat]]) -> bool:
-    """Return whether the per instance stats contain non-zero-valued logprobs.
+    """Return whether the per-instance stats contain non-zero-valued logprobs.
 
     Some models have partial functionality and produce only zero-valued logprobs."""
     for instance_stats in per_instance_stats.values():
@@ -841,7 +841,7 @@ def compute_calibration_metrics(per_instance_stats: Dict[Instance, List[Stat]]) 
     max_probs = []
     correct = []
 
-    # If the model does not produce onn-zero-valued logprobs
+    # If the model does not produce non-zero-valued logprobs
     # then don't compute calibration metrics.
     if not _has_non_zero_valued_logprobs(per_instance_stats):
         return []

--- a/src/helm/benchmark/metrics/basic_metrics.py
+++ b/src/helm/benchmark/metrics/basic_metrics.py
@@ -840,6 +840,11 @@ def compute_calibration_metrics(per_instance_stats: Dict[Instance, List[Stat]]) 
             assert 0.0 <= cur_correct <= 1.0
             correct.append(int(cur_correct))
 
+    # If the model does not produce logprobs (i.e. max_prob is always 1.0)
+    # then don't compute calibration metrics.
+    if all([max_prob == 1.0 for max_prob in [max_probs]]):
+        return []
+
     stats: List[Stat] = []
     assert len(max_probs) == len(correct)
     if len(max_probs) > 0:

--- a/src/helm/benchmark/metrics/basic_metrics.py
+++ b/src/helm/benchmark/metrics/basic_metrics.py
@@ -832,7 +832,7 @@ def _has_non_zero_valued_logprobs(per_instance_stats: Dict[Instance, List[Stat]]
     Some models have partial functionality and produce only zero-valued logprobs."""
     for instance_stats in per_instance_stats.values():
         for stat in instance_stats:
-            if stat.name == "logprob" and stat.sum > 0:
+            if stat.name == "logprob" and stat.sum < 0:
                 return True
     return False
 
@@ -843,7 +843,7 @@ def compute_calibration_metrics(per_instance_stats: Dict[Instance, List[Stat]]) 
 
     # If the model does not produce onn-zero-valued logprobs
     # then don't compute calibration metrics.
-    if _has_non_zero_valued_logprobs(per_instance_stats):
+    if not _has_non_zero_valued_logprobs(per_instance_stats):
         return []
 
     for instance_stats in per_instance_stats.values():

--- a/src/helm/benchmark/metrics/basic_metrics.py
+++ b/src/helm/benchmark/metrics/basic_metrics.py
@@ -826,9 +826,26 @@ class BasicMetric(Metric):
         return derived_stats
 
 
+def _has_non_zero_valued_logprobs(per_instance_stats: Dict[Instance, List[Stat]]) -> bool:
+    """Return whether the per instance stats contain non-zero-valued logprobs.
+
+    Some models have partial functionality and produce only zero-valued logprobs."""
+    for instance_stats in per_instance_stats.values():
+        for stat in instance_stats:
+            if stat.name == "logprob" and stat.sum > 0:
+                return True
+    return False
+
+
 def compute_calibration_metrics(per_instance_stats: Dict[Instance, List[Stat]]) -> List[Stat]:
     max_probs = []
     correct = []
+
+    # If the model does not produce onn-zero-valued logprobs
+    # then don't compute calibration metrics.
+    if not _has_non_zero_valued_logprobs(per_instance_stats):
+        return []
+
     for instance_stats in per_instance_stats.values():
         max_prob_stat = get_unique_stat_by_name(instance_stats, "max_prob")
         correct_stat = get_unique_stat_by_name(instance_stats, "exact_match")
@@ -839,11 +856,6 @@ def compute_calibration_metrics(per_instance_stats: Dict[Instance, List[Stat]]) 
             cur_correct = float(correct_stat.mean)
             assert 0.0 <= cur_correct <= 1.0
             correct.append(int(cur_correct))
-
-    # If the model does not produce logprobs (i.e. max_prob is always 1.0)
-    # then don't compute calibration metrics.
-    if all([max_prob == 1.0 for max_prob in [max_probs]]):
-        return []
 
     stats: List[Stat] = []
     assert len(max_probs) == len(correct)

--- a/src/helm/benchmark/metrics/basic_metrics.py
+++ b/src/helm/benchmark/metrics/basic_metrics.py
@@ -843,7 +843,7 @@ def compute_calibration_metrics(per_instance_stats: Dict[Instance, List[Stat]]) 
 
     # If the model does not produce onn-zero-valued logprobs
     # then don't compute calibration metrics.
-    if not _has_non_zero_valued_logprobs(per_instance_stats):
+    if _has_non_zero_valued_logprobs(per_instance_stats):
         return []
 
     for instance_stats in per_instance_stats.values():


### PR DESCRIPTION
For models without logprobs, we currently treat the probability of each token to be 1.0, which means that the ECE 10-bin is trivially (1 - accuracy). We should skip computing calibration metrics for these models instead.