### PR TITLE
Remove stats with NaN values

### DIFF
--- a/src/helm/benchmark/metrics/metric.py
+++ b/src/helm/benchmark/metrics/metric.py
@@ -1,11 +1,10 @@
 from abc import ABC
 from dataclasses import dataclass, replace
 from collections import defaultdict
-import math
 from typing import List, Dict, Tuple, Optional, Iterable, Set
 
 from helm.common.object_spec import ObjectSpec, create_object
-from helm.common.general import hlog, singleton, parallel_map
+from helm.common.general import singleton, parallel_map
 from helm.benchmark.augmentations.perturbation_description import (
     PerturbationDescription,
     PERTURBATION_ORIGINAL,
@@ -88,19 +87,6 @@ class Processor:
                     self.adapter_spec, references_states, self.metric_service, self.eval_cache_path
                 )
             )
-
-        # Drop any instance stats that contain NaN, because Python's stdlib json.dumps()
-        # will produce invalid JSON when serializing a NaN. See:
-        # - https://github.com/stanford-crfm/helm/issues/1765
-        # - https://bugs.python.org/issue40633
-        # - https://docs.python.org/3/library/json.html#infinite-and-nan-number-values
-        non_nan_instance_stats: List[Stat] = []
-        for stat in instance_stats:
-            if math.isnan(stat.sum):
-                hlog(f"WARNING: Removing stat {stat.name.name} because its value is NaN")
-                continue
-            non_nan_instance_stats.append(stat)
-        instance_stats = non_nan_instance_stats
 
         # Add instance-related context (e.g., split, perturbation) to the metrics
         for i, stat in enumerate(instance_stats):

--- a/src/helm/benchmark/metrics/metric.py
+++ b/src/helm/benchmark/metrics/metric.py
@@ -1,10 +1,11 @@
 from abc import ABC
 from dataclasses import dataclass, replace
 from collections import defaultdict
+import math
 from typing import List, Dict, Tuple, Optional, Iterable, Set
 
 from helm.common.object_spec import ObjectSpec, create_object
-from helm.common.general import singleton, parallel_map
+from helm.common.general import hlog, singleton, parallel_map
 from helm.benchmark.augmentations.perturbation_description import (
     PerturbationDescription,
     PERTURBATION_ORIGINAL,
@@ -87,6 +88,19 @@ class Processor:
                     self.adapter_spec, references_states, self.metric_service, self.eval_cache_path
                 )
             )
+
+        # Drop any instance stats that contain NaN, because Python's stdlib json.dumps()
+        # will produce invalid JSON when serializing a NaN. See:
+        # - https://github.com/stanford-crfm/helm/issues/1765
+        # - https://bugs.python.org/issue40633
+        # - https://docs.python.org/3/library/json.html#infinite-and-nan-number-values
+        non_nan_instance_stats: List[Stat] = []
+        for stat in instance_stats:
+            if math.isnan(stat.sum):
+                hlog(f"WARNING: Removing stat {stat.name.name} because its value is NaN")
+                continue
+            non_nan_instance_stats.append(stat)
+        instance_stats = non_nan_instance_stats
 
         # Add instance-related context (e.g., split, perturbation) to the metrics
         for i, stat in enumerate(instance_stats):

--- a/src/helm/benchmark/runner.py
+++ b/src/helm/benchmark/runner.py
@@ -74,9 +74,9 @@ class RunSpec:
 
 def remove_stats_nans(stats: List[Stat]) -> List[Stat]:
     """Return a new list of stats with stats with NaNs removed.
-    
+
     Python's stdlib json.dumps() will produce invalid JSON when serializing a NaN. See:
-    
+
     - https://github.com/stanford-crfm/helm/issues/1765
     - https://bugs.python.org/issue40633
     - https://docs.python.org/3/library/json.html#infinite-and-nan-number-values"""
@@ -91,9 +91,9 @@ def remove_stats_nans(stats: List[Stat]) -> List[Stat]:
 
 def remove_per_instance_stats_nans(per_instance_stats_list: List[PerInstanceStats]) -> List[PerInstanceStats]:
     """Return a new list of PerInstanceStats with stats with NaNs removed.
-    
+
     Python's stdlib json.dumps() will produce invalid JSON when serializing a NaN. See:
-    
+
     - https://github.com/stanford-crfm/helm/issues/1765
     - https://bugs.python.org/issue40633
     - https://docs.python.org/3/library/json.html#infinite-and-nan-number-values"""
@@ -290,7 +290,8 @@ class Runner:
         write(os.path.join(run_path, "scenario_state.json"), json.dumps(asdict_without_nones(scenario_state), indent=2))
 
         write(
-            os.path.join(run_path, "stats.json"), json.dumps([asdict_without_nones(stat) for stat in remove_stats_nans(stats)], indent=2)
+            os.path.join(run_path, "stats.json"),
+            json.dumps([asdict_without_nones(stat) for stat in remove_stats_nans(stats)], indent=2),
         )
         write(
             os.path.join(run_path, "per_instance_stats.json"),

--- a/src/helm/benchmark/runner.py
+++ b/src/helm/benchmark/runner.py
@@ -1,9 +1,11 @@
 import dacite
 import json
+import math
 import os
 import traceback
 import typing
 from collections import Counter
+import dataclasses
 from dataclasses import dataclass, field
 from typing import Any, Dict, List
 
@@ -68,6 +70,37 @@ class RunSpec:
         """
         # TODO: Don't mutate name! clean this up before passing it into the constructor here
         object.__setattr__(self, "name", self.name.replace(os.path.sep, "_"))
+
+
+def remove_stats_nans(stats: List[Stat]) -> List[Stat]:
+    """Return a new list of stats with stats with NaNs removed.
+    
+    Python's stdlib json.dumps() will produce invalid JSON when serializing a NaN. See:
+    
+    - https://github.com/stanford-crfm/helm/issues/1765
+    - https://bugs.python.org/issue40633
+    - https://docs.python.org/3/library/json.html#infinite-and-nan-number-values"""
+    result: List[Stat] = []
+    for stat in stats:
+        if math.isnan(stat.sum):
+            hlog(f"WARNING: Removing stat {stat.name.name} because its value is NaN")
+            continue
+        result.append(stat)
+    return result
+
+
+def remove_per_instance_stats_nans(per_instance_stats_list: List[PerInstanceStats]) -> List[PerInstanceStats]:
+    """Return a new list of PerInstanceStats with stats with NaNs removed.
+    
+    Python's stdlib json.dumps() will produce invalid JSON when serializing a NaN. See:
+    
+    - https://github.com/stanford-crfm/helm/issues/1765
+    - https://bugs.python.org/issue40633
+    - https://docs.python.org/3/library/json.html#infinite-and-nan-number-values"""
+    result: List[PerInstanceStats] = []
+    for per_instance_stats in per_instance_stats_list:
+        result.append(dataclasses.replace(per_instance_stats, stats=remove_stats_nans(per_instance_stats.stats)))
+    return result
 
 
 class Runner:
@@ -257,11 +290,11 @@ class Runner:
         write(os.path.join(run_path, "scenario_state.json"), json.dumps(asdict_without_nones(scenario_state), indent=2))
 
         write(
-            os.path.join(run_path, "stats.json"), json.dumps([asdict_without_nones(stat) for stat in stats], indent=2)
+            os.path.join(run_path, "stats.json"), json.dumps([asdict_without_nones(stat) for stat in remove_stats_nans(stats)], indent=2)
         )
         write(
             os.path.join(run_path, "per_instance_stats.json"),
-            json.dumps(list(map(asdict_without_nones, per_instance_stats)), indent=2),
+            json.dumps(list(map(asdict_without_nones, remove_per_instance_stats_nans(per_instance_stats))), indent=2),
         )
 
         cache_stats.print_status()


### PR DESCRIPTION
Drop any instance stats that contain `NaN`, because Python's stdlib `json.dumps()` will produce invalid JSON when serializing a `NaN`.

See:

- https://bugs.python.org/issue40633
- https://docs.python.org/3/library/json.html#infinite-and-nan-number-values

Addresses #1765