### PR TITLE
Fix adaptation for multiple references

### DIFF
--- a/src/helm/benchmark/adaptation/adapter_spec.py
+++ b/src/helm/benchmark/adaptation/adapter_spec.py
@@ -90,4 +90,4 @@ class AdapterSpec:
 
     # If true, for instances with multiple correct reference, the gold answer should be considered
     # to be all of the correct references rather than any of the correct references.
-    multi_label: Optional[bool] = None
+    multi_label: bool = False

--- a/src/helm/benchmark/adaptation/adapter_spec.py
+++ b/src/helm/benchmark/adaptation/adapter_spec.py
@@ -87,3 +87,7 @@ class AdapterSpec:
 
     # Random string (used concretely to bypass cache / see diverse results)
     random: Optional[str] = None
+
+    # If true, for instances with multiple correct reference, the gold answer should be considered
+    # to be all of the correct references rather than any of the correct references.
+    multi_label: Optional[bool] = None

--- a/src/helm/benchmark/adaptation/adapters/in_context_learning_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/in_context_learning_adapter.py
@@ -227,17 +227,24 @@ class InContextLearningAdapter(Adapter, ABC):
         # References (optionally) and output
         output: str
 
-        delimiter = ","
-        if reference_index is None:
+        delimiter = ", "
+        no_correct_references = "n/a"
+        if reference_index is not None:
+            reference = instance.references[reference_index]
+            output = reference.output.text
             # Put only the correct reference as the output
+        elif self.adapter_spec.multi_label:
             correct_references: List[Reference] = instance.all_correct_references
             if not correct_references:
-                output = "n/a"
+                output = no_correct_references
             else:
                 output = delimiter.join([correct_reference.output.text for correct_reference in correct_references])
         else:
-            reference = instance.references[reference_index]
-            output = reference.output.text
+            first_correct_reference: Optional[Reference] = instance.first_correct_reference
+            if not first_correct_reference:
+                output = no_correct_references
+            else:
+                output = first_correct_reference.output.text
 
         if include_output:
             result += self.adapter_spec.output_prefix + output + self.adapter_spec.output_suffix

--- a/src/helm/benchmark/adaptation/adapters/multiple_choice_joint_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/multiple_choice_joint_adapter.py
@@ -80,12 +80,19 @@ class MultipleChoiceJointAdapter(InContextLearningAdapter):
         result: str = self.adapter_spec.input_prefix + instance.input.text + self.adapter_spec.input_suffix
 
         # Include the references
-        output = "n/a"
+        delimiter = ", "
+        no_correct_references = "n/a"
+        output = no_correct_references
         for reference_index, reference in enumerate(instance.references):
             prefix = self.get_reference_prefix(self.adapter_spec.reference_prefix, reference_index)
             result += prefix + reference.output.text + self.adapter_spec.reference_suffix
-            if reference.is_correct and output == "n/a":
-                output = self.get_reference_prefix("A", reference_index)
+            if reference.is_correct:
+                if output == no_correct_references:
+                    output = self.get_reference_prefix("A", reference_index)
+                else:
+                    if self.adapter_spec.multi_label:
+                        output += delimiter
+                        output += self.get_reference_prefix("A", reference_index)
 
         if include_output:
             result += self.adapter_spec.output_prefix + output + self.adapter_spec.output_suffix

--- a/src/helm/benchmark/adaptation/adapters/multiple_choice_joint_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/multiple_choice_joint_adapter.py
@@ -89,10 +89,9 @@ class MultipleChoiceJointAdapter(InContextLearningAdapter):
             if reference.is_correct:
                 if output == no_correct_references:
                     output = self.get_reference_prefix("A", reference_index)
-                else:
-                    if self.adapter_spec.multi_label:
-                        output += delimiter
-                        output += self.get_reference_prefix("A", reference_index)
+                elif self.adapter_spec.multi_label:
+                    output += delimiter
+                    output += self.get_reference_prefix("A", reference_index)
 
         if include_output:
             result += self.adapter_spec.output_prefix + output + self.adapter_spec.output_suffix

--- a/src/helm/benchmark/adaptation/adapters/test_multiple_choice_joint_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/test_multiple_choice_joint_adapter.py
@@ -42,3 +42,105 @@ class TestMultipleChoiceJointAdapter(TestAdapter):
 
         examples = adapter.sample_examples(all_train_instances, seed=0)
         assert len(examples) == 3
+
+    def test_multiple_correct_reference(self):
+        adapter_spec = AdapterSpec(method=ADAPT_MULTIPLE_CHOICE_JOINT, model="openai/ada", max_train_instances=10)
+        adapter = AdapterFactory.get_adapter(adapter_spec, self.tokenizer_service)
+        adapter.train_instances = [
+            Instance(
+                Input(text="Second reference is correct"),
+                references=[
+                    Reference(Output(text="First"), tags=[]),
+                    Reference(Output(text="Second"), tags=[CORRECT_TAG]),
+                    Reference(Output(text="Third"), tags=[]),
+                ],
+            ),
+            Instance(
+                Input(text="First and second references are correct"),
+                references=[
+                    Reference(Output(text="First"), tags=[CORRECT_TAG]),
+                    Reference(Output(text="Second"), tags=[CORRECT_TAG]),
+                    Reference(Output(text="Third"), tags=[]),
+                ],
+            ),
+        ]
+        adapter.train_trial_index = 0
+        eval_instance = Instance(
+            Input(text="First reference is correct"),
+            references=[
+                Reference(Output(text="First"), tags=[CORRECT_TAG]),
+                Reference(Output(text="Second"), tags=[]),
+                Reference(Output(text="Third"), tags=[]),
+            ],
+        )
+        actual_instances = adapter.generate_requests(eval_instance)
+        assert len(actual_instances) == 1
+        assert actual_instances[0].request.prompt == (
+            "Input: Second reference is correct\n"
+            "A. First\n"
+            "B. Second\n"
+            "C. Third\n"
+            "Output: B\n\n"
+            "Input: First and second references are correct\n"
+            "A. First\n"
+            "B. Second\n"
+            "C. Third\n"
+            "Output: A\n\n"
+            "Input: First reference is correct\n"
+            "A. First\n"
+            "B. Second\n"
+            "C. Third\n"
+            "Output:"
+        )
+
+    def test_multiple_correct_reference_multi_label(self):
+        adapter_spec = AdapterSpec(
+            method=ADAPT_MULTIPLE_CHOICE_JOINT, model="openai/ada", max_train_instances=10, multi_label=True
+        )
+        adapter = AdapterFactory.get_adapter(adapter_spec, self.tokenizer_service)
+        adapter.train_instances = [
+            Instance(
+                Input(text="Second reference is correct"),
+                references=[
+                    Reference(Output(text="First"), tags=[]),
+                    Reference(Output(text="Second"), tags=[CORRECT_TAG]),
+                    Reference(Output(text="Third"), tags=[]),
+                ],
+            ),
+            Instance(
+                Input(text="First and second references are correct"),
+                references=[
+                    Reference(Output(text="First"), tags=[CORRECT_TAG]),
+                    Reference(Output(text="Second"), tags=[CORRECT_TAG]),
+                    Reference(Output(text="Third"), tags=[]),
+                ],
+            ),
+        ]
+        adapter.train_trial_index = 0
+        eval_instance = Instance(
+            Input(text="First reference is correct"),
+            references=[
+                Reference(Output(text="First"), tags=[CORRECT_TAG]),
+                Reference(Output(text="Second"), tags=[]),
+                Reference(Output(text="Third"), tags=[]),
+            ],
+        )
+        actual_instances = adapter.generate_requests(eval_instance)
+        assert len(actual_instances) == 1
+        assert actual_instances[0].request.prompt == (
+            "Input: Second reference is correct\n"
+            "A. First\n"
+            "B. Second\n"
+            "C. Third\n"
+            "Output: B\n\n"
+            "Input: First and second references are correct\n"
+            "A. First\n"
+            "B. Second\n"
+            "C. Third\n"
+            "Output: A, B\n\n"
+            "Input: First reference is correct\n"
+            "A. First\n"
+            "B. Second\n"
+            "C. Third\n"
+            "Output:"
+        )

--- a/src/helm/benchmark/run_specs.py
+++ b/src/helm/benchmark/run_specs.py
@@ -271,6 +271,7 @@ def get_generation_adapter_spec(
     max_tokens: int = 5,
     stop_sequences: Optional[List] = None,  # default value of `stop_sequences` is ["\n"]
     temperature: float = 0.0,
+    multi_label: Optional[bool] = None,
 ) -> AdapterSpec:
     """
     [instructions]
@@ -311,6 +312,7 @@ def get_generation_adapter_spec(
         max_tokens=max_tokens,
         temperature=temperature,
         stop_sequences=stop_sequences,
+        multi_label=multi_label,
     )
 
 
@@ -452,7 +454,8 @@ def get_f1_metric_specs() -> List[MetricSpec]:
     return get_basic_metric_specs(["exact_match", "quasi_exact_match", "f1_score"])
 
 
-def get_classification_metric_specs(delimiter: Optional[str] = None) -> List[MetricSpec]:
+def get_classification_metric_specs(multi_label: bool = False) -> List[MetricSpec]:
+    delimiter = ", " if multi_label else None
     return [
         MetricSpec(
             class_name="helm.benchmark.metrics.classification_metrics.ClassificationMetric",
@@ -1892,16 +1895,10 @@ def get_pubmed_qa_spec() -> RunSpec:
     )
 
 
-def build_classification_metrics(task_type):
-    if task_type in [TaskType.QA, TaskType.SLTC]:
-        return get_classification_metric_specs(delimiter=None)
-    elif task_type == TaskType.MLTC:
-        return get_classification_metric_specs(delimiter=",")
-    return []
-
-
 @run_spec_function("lextreme")
 def get_lextreme_spec(subset: str) -> RunSpec:
+    task_type = get_lextreme_task_type(subset)
+
     scenario_spec = ScenarioSpec(
         class_name="helm.benchmark.scenarios.lextreme_scenario.LEXTREMEScenario",
         args={"subset": subset},
@@ -1913,19 +1910,28 @@ def get_lextreme_spec(subset: str) -> RunSpec:
         output_noun="Answer",
         max_tokens=get_lextreme_max_tokens(subset),
         max_train_instances=get_lextreme_max_train_instances(subset),  # in some subsets the input is very long
+        multi_label=True if task_type == TaskType.MLTC else None,
     )
+
+    metric_specs = get_basic_metric_specs([])
+    if task_type == TaskType.MLTC:
+        metric_specs += get_classification_metric_specs(multi_label=True)
+    elif task_type == TaskType.SLTC:
+        metric_specs += get_classification_metric_specs(multi_label=False)
 
     return RunSpec(
         name=f"lextreme:subset={subset}",
         scenario_spec=scenario_spec,
         adapter_spec=adapter_spec,
-        metric_specs=build_classification_metrics(get_lextreme_task_type(subset)),
+        metric_specs=metric_specs,
         groups=["lextreme"],
     )
 
 
 @run_spec_function("lex_glue")
 def get_lex_glue_spec(subset: str) -> RunSpec:
+    task_type = get_lex_glue_task_type(subset)
+
     scenario_spec = ScenarioSpec(
         class_name="helm.benchmark.scenarios.lex_glue_scenario.LexGLUEScenario",
         args={"subset": subset},
@@ -1937,13 +1943,20 @@ def get_lex_glue_spec(subset: str) -> RunSpec:
         output_noun="Answer",
         max_tokens=get_lex_glue_max_tokens(subset),
         max_train_instances=get_lex_glue_max_train_instances(subset),  # in some subsets the input is very long
+        multi_label=True if task_type == TaskType.MLTC else None,
     )
+
+    metric_specs = get_basic_metric_specs([])
+    if task_type == TaskType.MLTC:
+        metric_specs += get_classification_metric_specs(multi_label=True)
+    elif task_type == TaskType.SLTC:
+        metric_specs += get_classification_metric_specs(multi_label=False)
 
     return RunSpec(
         name=f"lex_glue:subset={subset}",
         scenario_spec=scenario_spec,
         adapter_spec=adapter_spec,
-        metric_specs=build_classification_metrics(get_lex_glue_task_type(subset)),
+        metric_specs=metric_specs,
         groups=["lex_glue"],
     )
 

--- a/src/helm/benchmark/run_specs.py
+++ b/src/helm/benchmark/run_specs.py
@@ -454,8 +454,7 @@ def get_f1_metric_specs() -> List[MetricSpec]:
     return get_basic_metric_specs(["exact_match", "quasi_exact_match", "f1_score"])
 
 
-def get_classification_metric_specs(multi_label: bool = False) -> List[MetricSpec]:
-    delimiter = ", " if multi_label else None
+def get_classification_metric_specs(delimiter: Optional[str] = None) -> List[MetricSpec]:
     return [
         MetricSpec(
             class_name="helm.benchmark.metrics.classification_metrics.ClassificationMetric",
@@ -1915,9 +1914,9 @@ def get_lextreme_spec(subset: str) -> RunSpec:
 
     metric_specs = get_basic_metric_specs([])
     if task_type == TaskType.MLTC:
-        metric_specs += get_classification_metric_specs(multi_label=True)
+        metric_specs += get_classification_metric_specs(delimiter=", ")
     elif task_type == TaskType.SLTC:
-        metric_specs += get_classification_metric_specs(multi_label=False)
+        metric_specs += get_classification_metric_specs()
 
     return RunSpec(
         name=f"lextreme:subset={subset}",
@@ -1948,9 +1947,9 @@ def get_lex_glue_spec(subset: str) -> RunSpec:
 
     metric_specs = get_basic_metric_specs([])
     if task_type == TaskType.MLTC:
-        metric_specs += get_classification_metric_specs(multi_label=True)
+        metric_specs += get_classification_metric_specs(delimiter=", ")
     elif task_type == TaskType.SLTC:
-        metric_specs += get_classification_metric_specs(multi_label=False)
+        metric_specs += get_classification_metric_specs()
 
     return RunSpec(
         name=f"lex_glue:subset={subset}",

--- a/src/helm/benchmark/run_specs.py
+++ b/src/helm/benchmark/run_specs.py
@@ -271,7 +271,7 @@ def get_generation_adapter_spec(
     max_tokens: int = 5,
     stop_sequences: Optional[List] = None,  # default value of `stop_sequences` is ["\n"]
     temperature: float = 0.0,
-    multi_label: Optional[bool] = None,
+    multi_label: bool = False,
 ) -> AdapterSpec:
     """
     [instructions]
@@ -1909,7 +1909,7 @@ def get_lextreme_spec(subset: str) -> RunSpec:
         output_noun="Answer",
         max_tokens=get_lextreme_max_tokens(subset),
         max_train_instances=get_lextreme_max_train_instances(subset),  # in some subsets the input is very long
-        multi_label=True if task_type == TaskType.MLTC else None,
+        multi_label=(task_type == TaskType.MLTC),
     )
 
     metric_specs = get_basic_metric_specs([])
@@ -1942,7 +1942,7 @@ def get_lex_glue_spec(subset: str) -> RunSpec:
         output_noun="Answer",
         max_tokens=get_lex_glue_max_tokens(subset),
         max_train_instances=get_lex_glue_max_train_instances(subset),  # in some subsets the input is very long
-        multi_label=True if task_type == TaskType.MLTC else None,
+        multi_label=(task_type == TaskType.MLTC),
     )
 
     metric_specs = get_basic_metric_specs([])


### PR DESCRIPTION
If an instance has multiple correct instances, previously the adapter uses all the correct references concatenated together as the output for in context learning examples. 

After this change:

- If `AdapterSpec.multi_label` is true, the adapter uses all the correct references concatenated together as the output for in context learning examples.
- Otherwise, the adapter only uses the first correct reference.