### PR TITLE
Dependency injection for model deployments

### DIFF
--- a/src/helm/benchmark/run_specs.py
+++ b/src/helm/benchmark/run_specs.py
@@ -1,4 +1,3 @@
-import importlib
 import itertools
 from typing import Any, Callable, List, Dict, Optional, Set, TypeVar
 

--- a/src/helm/benchmark/run_specs.py
+++ b/src/helm/benchmark/run_specs.py
@@ -3,7 +3,7 @@ import itertools
 from typing import Any, Callable, List, Dict, Optional, Set, TypeVar
 
 from helm.common.hierarchical_logger import hlog, htrack
-from helm.common.object_spec import ObjectSpec
+from helm.common.object_spec import ObjectSpec, get_class_by_name
 from helm.benchmark.adaptation.adapters.adapter_factory import (
     ADAPT_LANGUAGE_MODELING,
     ADAPT_MULTIPLE_CHOICE_JOINT,
@@ -2290,10 +2290,7 @@ def construct_run_specs(spec: ObjectSpec) -> List[RunSpec]:
             add_to_stop_expander = AddToStopRunExpander(anthropic.HUMAN_PROMPT)
             increase_max_tokens_expander = IncreaseMaxTokensRunExpander(value=AnthropicClient.ADDITIONAL_TOKENS)
             # Get scenario tags
-            components = run_spec.scenario_spec.class_name.split(".")
-            class_name = components[-1]
-            module_name = ".".join(components[:-1])
-            cls = getattr(importlib.import_module(module_name), class_name)
+            cls = get_class_by_name(run_spec.scenario_spec.class_name)
             scenario_tags: List[str] = cls.tags
             # If the scenario is instruction, do not use PROMPT_ANSWER_START
             if "instructions" in scenario_tags:

--- a/src/helm/common/object_spec.py
+++ b/src/helm/common/object_spec.py
@@ -32,7 +32,9 @@ def create_object(spec: ObjectSpec, additional_args: Optional[Dict[str, Any]] = 
     if additional_args:
         key_collisions = set(args.keys()) & set(additional_args.keys())
         if key_collisions:
-            raise ValueError(f"Argument name collisions {key_collisions} when trying to create object of class {spec.class_name}")
+            raise ValueError(
+                f"Argument name collisions {key_collisions} when trying to create object of class {spec.class_name}"
+            )
         args.update(additional_args)
     return cls(**args)
 

--- a/src/helm/proxy/clients/simple_client.py
+++ b/src/helm/proxy/clients/simple_client.py
@@ -30,23 +30,19 @@ class SimpleClient(Client):
             "n": request.num_completions,
         }
 
-        if request.model_engine == "model1":
+        def do_it():
+            return self.invoke_model1(raw_request)
 
-            def do_it():
-                return self.invoke_model1(raw_request)
-
-            cache_key = Client.make_cache_key(raw_request, request)
-            response, cached = self.cache.get(cache_key, wrap_request_time(do_it))
-            completions = [
-                Sequence(
-                    text=text,
-                    logprob=logprob,
-                    tokens=[Token(text=text, logprob=logprob, top_logprobs=response["completions"])],
-                )
-                for text, logprob in response["completions"].items()
-            ]
-        else:
-            raise ValueError(f"Invalid model: {request.model}")
+        cache_key = Client.make_cache_key(raw_request, request)
+        response, cached = self.cache.get(cache_key, wrap_request_time(do_it))
+        completions = [
+            Sequence(
+                text=text,
+                logprob=logprob,
+                tokens=[Token(text=text, logprob=logprob, top_logprobs=response["completions"])],
+            )
+            for text, logprob in response["completions"].items()
+        ]
 
         return RequestResult(
             success=True,


### PR DESCRIPTION
This allows using `ModelDeploymentRegistry` with clients that do not have a `api_key` parameter.

Example:

`helm-run --run-specs boolq:model=simple/my-simple-model --suite debug -m 5 --model-deployment-paths model_deployments_simple.yaml --model-metadata models.yaml`

`models.yaml`:

```
models:
  - name: simple/my-simple-model
```

`model_deployments_simple.yaml`:

```
model_deployments:
  - name: simple/my-simple-model
    model_name: simple/my-simple-model
    tokenizer_name: "huggingface/gpt2"
    max_sequence_length: 2048
    client_spec:
      class_name: "helm.proxy.clients.simple_client.SimpleClient"
      args: {}
```