### PR TITLE
Make max_eval_instances optional

### DIFF
--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -140,7 +140,7 @@ def add_run_args(parser: argparse.ArgumentParser):
         "-m",
         "--max-eval-instances",
         type=int,
-        required=True,
+        required=False,
         help="Maximum number of instances to evaluate on, overrides the value in Adapter spec.",
     )
     parser.add_argument(


### PR DESCRIPTION
### Summary
Not sure if this needs to be required since there is logic to check the optional case, and when I want to run a full dataset I think I just don't specify this