### PR TITLE
Implement rabin karp

### DIFF
--- a/scripts/data_overlap/common/arguments.py
+++ b/scripts/data_overlap/common/arguments.py
@@ -14,6 +14,7 @@ def get_data_overlap_args() -> Any:
         help="The format of your input file for your training data, e.g. raw, custom, the_pile",
     )
     parser.add_argument("--no-output-ngrams", type=bool, default=False, help="Pass to not output ngrams")
+    parser.add_argument("--skip-check-collision", type=bool, default=False, help="Pass to skip collision check; increases speed and decreases memory")
     parser.add_argument(
         "--tags",
         type=str,

--- a/scripts/data_overlap/common/arguments.py
+++ b/scripts/data_overlap/common/arguments.py
@@ -14,7 +14,12 @@ def get_data_overlap_args() -> Any:
         help="The format of your input file for your training data, e.g. raw, custom, the_pile",
     )
     parser.add_argument("--no-output-ngrams", type=bool, default=False, help="Pass to not output ngrams")
-    parser.add_argument("--skip-check-collision", type=bool, default=False, help="Pass to skip collision check; increases speed and decreases memory")
+    parser.add_argument(
+        "--skip-check-collision",
+        type=bool,
+        default=False,
+        help="Pass to skip collision check; increases speed and decreases memory",
+    )
     parser.add_argument(
         "--tags",
         type=str,

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -36,6 +36,7 @@ NgramIndex = Dict[int, Dict[Ngram, Set[EntryDataOverlapKey]]]
 NgramCounter = Dict[EntryDataOverlapKey, Dict[Ngram, int]]
 HashToNgrams = Dict[int, Dict[int, Set[str]]]
 
+
 def load_light_scenarios_from_jsonl(path: str) -> List[LightScenario]:
     """
     Create a list of light scenarios from a jsonl file, where each json represents a LightScenario object.
@@ -193,10 +194,9 @@ def compute_document_data_overlap(
                 # else:
                 curr_ngram = tuple(document_tokens[start:end])
                 if curr_ngram not in ngrams:
-                    hlog(f'False postive: {curr_ngram} not found for len({len(ngrams)}) and hash {document_hash}')
-                    hlog(', '.join(f'{element}' for element in ngrams))
-                    hlog('\n')
-
+                    hlog(f"False postive: {curr_ngram} not found for len({len(ngrams)}) and hash {document_hash}")
+                    hlog(", ".join(f"{element}" for element in ngrams))
+                    hlog("\n")
 
                 for entry_overlap_key in ngram_index[n][document_hash]:
                     id = entry_overlap_key.instance_id
@@ -233,7 +233,6 @@ if __name__ == "__main__":
         ngram_index, hash_to_ngrams = create_ngram_index(
             light_scenarios=light_scenarios, n_values=args.N, tokenizer=tokenizer, stats_key_counts=stats_key_counts
         )
-
 
     # DataOverlapStatsKey -> Set[str] for ids
     stats_key_to_input_ids: DefaultDict[DataOverlapStatsKey, Set] = defaultdict(set)

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -257,7 +257,7 @@ if __name__ == "__main__":
     light_scenarios = load_light_scenarios_from_jsonl(args.scenario_data)
 
     stats_key_counts: DefaultDict[DataOverlapStatsKey, int] = defaultdict(int)
-    hash_to_ngrams: HashToNgrams = None
+    hash_to_ngrams: HashToNgrams = {}
     with htrack_block("Initializing the stats, ngram_index, and ngram_counter"):
         ngram_index: NgramIndex
         ngram_index = create_ngram_index(

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -96,7 +96,7 @@ def create_ngram_index(
                     input_hash, start, end = input_hash_info
                     if input_hash not in ngram_index[n]:
                         ngram_index[n][input_hash] = set()
-                        hash_to_ngrams[n][input_hash] = set(input_tokens[start:end])
+                        hash_to_ngrams[n][input_hash] = set()
                     ngram_index[n][input_hash].add(
                         EntryDataOverlapKey(stats_key=stats_key, instance_id=id, part=PART_INPUT)
                     )
@@ -233,6 +233,7 @@ if __name__ == "__main__":
         ngram_index, hash_to_ngrams = create_ngram_index(
             light_scenarios=light_scenarios, n_values=args.N, tokenizer=tokenizer, stats_key_counts=stats_key_counts
         )
+
 
     # DataOverlapStatsKey -> Set[str] for ids
     stats_key_to_input_ids: DefaultDict[DataOverlapStatsKey, Set] = defaultdict(set)

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -68,6 +68,7 @@ def load_light_scenarios_from_jsonl(path: str) -> List[LightScenario]:
         light_scenarios.append(LightScenario(scenario_key=light_scenario_key, instances=light_instances))
     return light_scenarios
 
+
 def create_ngram_index(
     light_scenarios: List[LightScenario],
     n_values: List[int],
@@ -109,7 +110,6 @@ def create_ngram_index(
                             EntryDataOverlapKey(stats_key=stats_key, instance_id=id, part=PART_REF)
                         )
     return ngram_index
-
 
 
 def create_hash_to_ngrams(

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -188,14 +188,18 @@ def compute_document_data_overlap(
             document_hash, start, end = document_hash_info
             if document_hash in ngram_index[n]:
                 ngrams = hash_to_ngrams[n][document_hash]
-                # if len(ngrams) == 1:
-                #     continue
-                # else:
                 curr_ngram = tuple(document_tokens[start:end])
                 if curr_ngram not in ngrams:
                     hlog(f"False postive: {curr_ngram} not found for len({len(ngrams)}) and hash {document_hash}")
                     hlog(", ".join(f"{element}" for element in ngrams))
                     hlog("\n")
+
+                    with open(f"{args.output_stats}_collisions_pile", "a") as f:
+                        f.write(
+                            f"False postive: {curr_ngram} not found for len({len(ngrams)}) and hash {document_hash}"
+                        )
+                        f.write(", ".join(f"{element}" for element in ngrams))
+                        f.write("\n")
 
                 for entry_overlap_key in ngram_index[n][document_hash]:
                     id = entry_overlap_key.instance_id
@@ -232,18 +236,18 @@ if __name__ == "__main__":
         ngram_index, hash_to_ngrams = create_ngram_index(
             light_scenarios=light_scenarios, n_values=args.N, tokenizer=tokenizer, stats_key_counts=stats_key_counts
         )
-    
-    with open(f'{args.output_stats}_collisions', "w") as f:
+
+    with open(f"{args.output_stats}_collisions", "w") as f:
         for n in args.N:
             for hash, ngrams in hash_to_ngrams[n].items():
                 if len(ngrams) > 1:
-                    f.write(f'Hash:{hash}\n')
+                    f.write(f"Hash:{hash}\n")
                     for ngram in ngrams:
-                        f.write(f'Ngram:{ngram}')
-                    f.write('\n')
-                    f.write('\n')
+                        f.write(f"Ngram:{ngram}")
+                    f.write("\n")
+                    f.write("\n")
                     break
-        
+
     # DataOverlapStatsKey -> Set[str] for ids
     stats_key_to_input_ids: DefaultDict[DataOverlapStatsKey, Set] = defaultdict(set)
     stats_key_to_reference_ids: DefaultDict[DataOverlapStatsKey, Set] = defaultdict(set)

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -2,7 +2,7 @@ import json
 import os
 import glob
 
-from typing import List, Tuple, Set, DefaultDict
+from typing import List, Tuple, Set, DefaultDict, Optional
 from nltk import ngrams
 from typing import Dict
 from tqdm import tqdm
@@ -33,7 +33,7 @@ PART_REF: str = "references"
 Ngram = Tuple[str, ...]
 NgramIndex = Dict[int, Dict[Ngram, Set[EntryDataOverlapKey]]]
 NgramCounter = Dict[EntryDataOverlapKey, Dict[Ngram, int]]
-HashToNgrams = Dict[int, Dict[int, Set[Tuple[str, ...]]]]
+HashToNgrams = Optional[Dict[int, Dict[int, Set[Tuple[str, ...]]]]]
 
 
 def load_light_scenarios_from_jsonl(path: str) -> List[LightScenario]:

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -219,10 +219,6 @@ def compute_document_data_overlap(
                     ngrams = hash_to_ngrams[n][document_hash]
                     curr_ngram = tuple(document_tokens[start:end])
                     if curr_ngram not in ngrams:
-                        hlog(f"False postive: {curr_ngram} not found for len({len(ngrams)}) and hash {document_hash}")
-                        hlog(", ".join(f"{element}" for element in ngrams))
-                        hlog("\n")
-
                         with open(f"{args.output_stats}_collisions", "a") as f:
                             f.write(
                                 f"False postive: {curr_ngram} not found for len({len(ngrams)}) and hash {document_hash}"

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -3,7 +3,6 @@ import os
 import glob
 
 from typing import List, Tuple, Set, DefaultDict
-from nltk import ngrams
 from typing import Dict
 from tqdm import tqdm
 from collections import defaultdict

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -25,7 +25,6 @@ from common.arguments import get_data_overlap_args
 from common.util import get_tokenizer
 from scenarios.scenario import ScenarioSpec
 
-
 PART_INPUT: str = "input"
 PART_REF: str = "references"
 
@@ -233,7 +232,18 @@ if __name__ == "__main__":
         ngram_index, hash_to_ngrams = create_ngram_index(
             light_scenarios=light_scenarios, n_values=args.N, tokenizer=tokenizer, stats_key_counts=stats_key_counts
         )
-
+    
+    with open(f'{args.output_stats}_collisions', "w") as f:
+        for n in args.N:
+            for hash, ngrams in hash_to_ngrams[n].items():
+                if len(ngrams) > 1:
+                    f.write(f'Hash:{hash}\n')
+                    for ngram in ngrams:
+                        f.write(f'Ngram:{ngram}')
+                    f.write('\n')
+                    f.write('\n')
+                    break
+        
     # DataOverlapStatsKey -> Set[str] for ids
     stats_key_to_input_ids: DefaultDict[DataOverlapStatsKey, Set] = defaultdict(set)
     stats_key_to_reference_ids: DefaultDict[DataOverlapStatsKey, Set] = defaultdict(set)

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -2,7 +2,7 @@ import json
 import os
 import glob
 
-from typing import List, Tuple, Set, DefaultDict, Optional
+from typing import List, Tuple, Set, DefaultDict
 from nltk import ngrams
 from typing import Dict
 from tqdm import tqdm
@@ -33,7 +33,7 @@ PART_REF: str = "references"
 Ngram = Tuple[str, ...]
 NgramIndex = Dict[int, Dict[Ngram, Set[EntryDataOverlapKey]]]
 NgramCounter = Dict[EntryDataOverlapKey, Dict[Ngram, int]]
-HashToNgrams = Optional[Dict[int, Dict[int, Set[Tuple[str, ...]]]]]
+HashToNgrams = Dict[int, Dict[int, Set[Tuple[str, ...]]]]
 
 
 def load_light_scenarios_from_jsonl(path: str) -> List[LightScenario]:

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -33,7 +33,7 @@ PART_REF: str = "references"
 Ngram = Tuple[str, ...]
 NgramIndex = Dict[int, Dict[Ngram, Set[EntryDataOverlapKey]]]
 NgramCounter = Dict[EntryDataOverlapKey, Dict[Ngram, int]]
-HashToNgrams = Dict[int, Dict[int, Set[str]]]
+HashToNgrams = Dict[int, Dict[int, Set[Tuple[str, ...]]]]
 
 
 def load_light_scenarios_from_jsonl(path: str) -> List[LightScenario]:
@@ -194,7 +194,7 @@ def compute_document_data_overlap(
                     hlog(", ".join(f"{element}" for element in ngrams))
                     hlog("\n")
 
-                    with open(f"{args.output_stats}_collisions_pile", "a") as f:
+                    with open(f"{args.output_stats}_collisions", "a") as f:
                         f.write(
                             f"False postive: {curr_ngram} not found for len({len(ngrams)}) and hash {document_hash}"
                         )

--- a/scripts/data_overlap/ngram_hasher.py
+++ b/scripts/data_overlap/ngram_hasher.py
@@ -1,29 +1,23 @@
 from typing import List, Tuple
 
-RABIN_KARP_PRIME = (
-    172001  # chosen as a prime larger than 171,476, estimate vocab size of english (these are the base of exponent)
-)
-CHAR_PRIME = 401  # chosen as a prime larger than 256, UTF-8 space, and distant from 2^n;
+# A prime number chosen as a base for exponentiation, larger than 171,476 (estimated vocab size of English words)
+RABIN_KARP_PRIME = 172001
+
+# A prime number chosen as a base for hashing characters, larger than 256 (UTF-8 character space)
+CHAR_PRIME = 401
 
 
 class RabinKarpHash:
     """
-    (ignoring mods here for simplicity)
+    Rabin-Karp rolling hash for hashing sequences of integers.
+
     Initial hash:
-        for a List[int] i_0...i_n with a window w s.t. w <= n
-        hash is i_0 * 256 ^ {w-1} + i_1 * 256 ^ {w-2} + ... + i_{w-1}
+        For a List[int] i_0...i_n with a window w where w <= n,
+        the hash is calculated as:
+        i_0 * RABIN_KARP_PRIME^(w-1) + i_1 * RABIN_KARP_PRIME^(w-2) + ... + i_{w-1}
 
     high_coefficient:
-        256 * {w-1}
-
-    Is it 256 because 2^8 = 256, and the expected input is UTF-8 chars?
-
-    In our case, it probably makes more sense to use a large prime p
-
-    and convert words/tokens into ints (probably by multiplying chars by a prime or 256)
-
-    I'll use 196613 as it's estimated there are 171,476 words in current use
-    in English language, and it's prime
+        RABIN_KARP_PRIME^(w-1)
     """
 
     def __init__(self, int_sequence: List[int], window_size: int, mod: int = 8554560727166512717):
@@ -34,14 +28,6 @@ class RabinKarpHash:
         self.current_hash = 0
         self.int_sequence = int_sequence
 
-        """
-        Is window_size the number of n-grams (i.e., tokens) or is it the number of characters? The comment says:
-
-        # for i in range(window_size):
-        #     self.hash = (self.hash * 256 + ord(self.text[i])) % mod
-
-        ord only acts at a character level, but the logic only makes sense for n-grams/tokens (otherwise we have no way to configure N, the length of n-grams)
-        """
         for i in range(window_size):
             self.current_hash = (self.current_hash * RABIN_KARP_PRIME + int_sequence[i]) % mod
         if self.current_hash < 0:
@@ -50,19 +36,17 @@ class RabinKarpHash:
     def mult_mod(self, a: int, b: int, k: int) -> int:
         return (a * b) % k
 
-    """
-    Initial hash:
-        for a List[int] i_0...i_n with a window w s.t. w <= n
-        hash is i_0 * 256 ^ {w-1} + i_1 * 256 ^ {w-2} + ... + i_{w-1}
-    
-    start_piece = i_0 * 256 ^ {w-1}
-
-    subtract the start piece and multiply by 256, then add the current value, so we have
-        hash is i_1 * 256 ^ {w-1} + i_2 * 256 ^ {w-2} + ... + i_{w}
-
-    """
-
     def update(self) -> None:
+        """
+        Update the rolling hash value when the window slides by one element.
+
+        - To efficiently update the hash:
+        1. Subtract the contribution of the element moving out of the window (start_piece).
+        2. Multiply the result by RABIN_KARP_PRIME.
+        3. Add the contribution of the new element entering the window.
+
+        Then update the window indices
+        """
         start_piece = self.mult_mod(self.int_sequence[self.window_start], self.high_coefficient, self.mod)
         self.current_hash = self.mult_mod(self.current_hash - start_piece, RABIN_KARP_PRIME, self.mod)
         self.current_hash = (self.current_hash + self.int_sequence[self.window_end]) % self.mod
@@ -74,12 +58,14 @@ class RabinKarpHash:
 
 def compute_hashes(int_sequence: List[int], window_size: int) -> List[Tuple[int, int, int]]:
     """
-    Previously was
-    rk_hash = RabinKarpHash(
-        int_sequence,
-        min(window_size, len(int_sequence))
-    )
-    but we don't want anything to happen when len(int_sequence) < window_size
+    Computes Rabin-Karp rolling hashes for a list of integers.
+
+    Args:
+        int_sequence (List[int]): List of integers.
+        window_size (int): Size of the rolling window.
+
+    Returns:
+        List[Tuple[int, int, int]]: List of tuples containing hash value, window start, and window end.
     """
     if len(int_sequence) < window_size:
         return []
@@ -95,6 +81,16 @@ def compute_hashes(int_sequence: List[int], window_size: int) -> List[Tuple[int,
 
 # mod chosen as large prime of similar size to rabin karp, but distinct
 def hash_token(token: str, mod: int = 8554560727166512181):
+    """
+    Hashes a string token into an integer.
+
+    Args:
+        token (str): Input token.
+        mod (int): Modulus for hashing.
+
+    Returns:
+        int: Hash value.
+    """
     hash_value = 0
     for ch in token:
         hash_value = (hash_value * CHAR_PRIME + ord(ch)) % mod
@@ -102,5 +98,15 @@ def hash_token(token: str, mod: int = 8554560727166512181):
 
 
 def get_ngram_hashes(tokens: List[str], n: int):
+    """
+    Computes Rabin-Karp rolling hashes for a list of string tokens.
+
+    Args:
+        tokens (List[str]): List of string tokens.
+        n (int): Size of the rolling window.
+
+    Returns:
+        List[Tuple[int, int, int]]: List of tuples containing hash value, window start, and window end.
+    """
     hashed_tokens = [hash_token(token) for token in tokens]
     return compute_hashes(hashed_tokens, n)

--- a/scripts/data_overlap/ngram_hasher.py
+++ b/scripts/data_overlap/ngram_hasher.py
@@ -6,6 +6,8 @@ RABIN_KARP_PRIME = 172001
 # A prime number chosen as a base for hashing characters, larger than 256 (UTF-8 character space)
 CHAR_PRIME = 401
 
+hash_token_cache = {}
+
 
 class RabinKarpHash:
     """
@@ -91,9 +93,16 @@ def hash_token(token: str, mod: int = 8554560727166512181):
     Returns:
         int: Hash value.
     """
+
+    # assume mod is constant for space/time efficiency
+    if token in hash_token_cache:
+        return hash_token_cache[token]
+
     hash_value = 0
     for ch in token:
         hash_value = (hash_value * CHAR_PRIME + ord(ch)) % mod
+
+    hash_token_cache[token] = hash_value
     return hash_value
 
 

--- a/scripts/data_overlap/ngram_hasher.py
+++ b/scripts/data_overlap/ngram_hasher.py
@@ -1,0 +1,95 @@
+from typing import List, Tuple
+
+class RabinKarpHash:
+    """
+    (ignoring mods here for simplicity)
+    Initial hash:
+        for a List[int] i_0...i_n with a window w s.t. w <= n
+        hash is i_0 * 256 ^ {w-1} + i_1 * 256 ^ {w-2} + ... + i_{w-1}
+
+    high_coefficient:
+        256 * {w-1}
+    
+    Is it 256 because 2^8 = 256, and the expected input is UTF-8 chars?
+
+    In our case, it probably makes more sense to use a large prime p
+
+    and convert words/tokens into ints (probably by multiplying chars by a prime or 256)
+    """
+    def __init__(self, int_sequence: List[int], window_size: int, mod: int):
+        self.window_start = 0
+        self.window_end = window_size
+        self.mod = mod
+        self.high_coefficient = pow(256, window_size - 1, mod)
+        self.current_hash = 0
+        self.int_sequence = int_sequence
+
+        """
+        Is window_size the number of n-grams (i.e., tokens) or is it the number of characters? The comment says:
+
+        # for i in range(window_size):
+        #     self.hash = (self.hash * 256 + ord(self.text[i])) % mod
+
+        ord only acts at a character level, but the logic only makes sense for n-grams/tokens (otherwise we have no way to configure N, the length of n-grams)
+        """
+        for i in range(window_size):
+            self.current_hash = (self.current_hash * 256 + int_sequence[i]) % mod
+        if self.current_hash < 0:
+            self.current_hash += mod
+
+    def mult_mod(self, a: int, b: int, k: int) -> int:
+        return ((a * b) % k)
+
+    """
+    Initial hash:
+        for a List[int] i_0...i_n with a window w s.t. w <= n
+        hash is i_0 * 256 ^ {w-1} + i_1 * 256 ^ {w-2} + ... + i_{w-1}
+    
+    start_piece = i_0 * 256 ^ {w-1}
+
+    subtract the start piece and multiply by 256, then add the current value, so we have
+        hash is i_1 * 256 ^ {w-1} + i_2 * 256 ^ {w-2} + ... + i_{w}
+
+    """
+    def update(self) -> None:
+        start_piece = self.mult_mod(self.int_sequence[self.window_start], self.high_coefficient, self.mod)
+        self.current_hash = self.mult_mod(self.current_hash - start_piece, 256, self.mod)
+        self.current_hash = (self.current_hash + self.int_sequence[self.window_end]) % self.mod
+        if self.current_hash < 0:
+            self.current_hash += self.mod
+        self.window_start += 1
+        self.window_end += 1
+
+def compute_hashes(int_sequence: List[int], window_size: int, mod: int) -> List[Tuple[int, int, int]]:
+    """
+    Previously was 
+    rk_hash = RabinKarpHash(
+        int_sequence,
+        min(window_size, len(int_sequence))
+    )
+    but we don't want anything to happen when len(int_sequence) < window_size
+    """
+    if len(int_sequence) < window_size:
+        return []
+    rk_hash = RabinKarpHash(
+        int_sequence,
+        window_size,
+        mod
+    )
+    hashes = [(rk_hash.current_hash, rk_hash.window_start, rk_hash.window_end)]
+    for i in range(len(int_sequence) - window_size):
+        rk_hash.update()
+        hash_info = (rk_hash.current_hash, rk_hash.window_start, rk_hash.window_end)
+        hashes.append(hash_info)
+
+    return hashes
+
+def hash_token(token: str, mod: int):
+    hash_value = 0
+    for ch in token:
+        hash_value = (hash_value * 256 + ord(ch)) % mod
+    return hash_value
+
+def get_ngram_hashes(tokens: List[str], n: int, mod: int = 8554560727166512717):
+    hashed_tokens = [hash_token(token, mod) for token in tokens]
+    return compute_hashes(hashed_tokens, n, mod)

--- a/scripts/data_overlap/ngram_hasher.py
+++ b/scripts/data_overlap/ngram_hasher.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List, Tuple, Dict
 
 # A prime number chosen as a base for exponentiation, larger than 171,476 (estimated vocab size of English words)
 RABIN_KARP_PRIME = 172001
@@ -6,7 +6,7 @@ RABIN_KARP_PRIME = 172001
 # A prime number chosen as a base for hashing characters, larger than 256 (UTF-8 character space)
 CHAR_PRIME = 401
 
-hash_token_cache = {}
+hash_token_cache: Dict[str, int] = {}
 
 
 class RabinKarpHash:

--- a/scripts/data_overlap/ngram_hasher.py
+++ b/scripts/data_overlap/ngram_hasher.py
@@ -1,7 +1,11 @@
 from typing import List, Tuple
 
-RABIN_KARP_PRIME = 172001 # chosen as a prime larger than 171,476, estimate vocab size of english (these are the base of exponent)
-CHAR_PRIME = 401 # chosen as a prime larger than 256, UTF-8 space, and distant from 2^n; 
+RABIN_KARP_PRIME = (
+    172001  # chosen as a prime larger than 171,476, estimate vocab size of english (these are the base of exponent)
+)
+CHAR_PRIME = 401  # chosen as a prime larger than 256, UTF-8 space, and distant from 2^n;
+
+
 class RabinKarpHash:
     """
     (ignoring mods here for simplicity)
@@ -11,7 +15,7 @@ class RabinKarpHash:
 
     high_coefficient:
         256 * {w-1}
-    
+
     Is it 256 because 2^8 = 256, and the expected input is UTF-8 chars?
 
     In our case, it probably makes more sense to use a large prime p
@@ -21,6 +25,7 @@ class RabinKarpHash:
     I'll use 196613 as it's estimated there are 171,476 words in current use
     in English language, and it's prime
     """
+
     def __init__(self, int_sequence: List[int], window_size: int, mod: int = 8554560727166512717):
         self.window_start = 0
         self.window_end = window_size
@@ -43,7 +48,7 @@ class RabinKarpHash:
             self.current_hash += mod
 
     def mult_mod(self, a: int, b: int, k: int) -> int:
-        return ((a * b) % k)
+        return (a * b) % k
 
     """
     Initial hash:
@@ -56,6 +61,7 @@ class RabinKarpHash:
         hash is i_1 * 256 ^ {w-1} + i_2 * 256 ^ {w-2} + ... + i_{w}
 
     """
+
     def update(self) -> None:
         start_piece = self.mult_mod(self.int_sequence[self.window_start], self.high_coefficient, self.mod)
         self.current_hash = self.mult_mod(self.current_hash - start_piece, RABIN_KARP_PRIME, self.mod)
@@ -65,9 +71,10 @@ class RabinKarpHash:
         self.window_start += 1
         self.window_end += 1
 
+
 def compute_hashes(int_sequence: List[int], window_size: int) -> List[Tuple[int, int, int]]:
     """
-    Previously was 
+    Previously was
     rk_hash = RabinKarpHash(
         int_sequence,
         min(window_size, len(int_sequence))
@@ -76,10 +83,7 @@ def compute_hashes(int_sequence: List[int], window_size: int) -> List[Tuple[int,
     """
     if len(int_sequence) < window_size:
         return []
-    rk_hash = RabinKarpHash(
-        int_sequence,
-        window_size
-    )
+    rk_hash = RabinKarpHash(int_sequence, window_size)
     hashes = [(rk_hash.current_hash, rk_hash.window_start, rk_hash.window_end)]
     for i in range(len(int_sequence) - window_size):
         rk_hash.update()
@@ -88,12 +92,14 @@ def compute_hashes(int_sequence: List[int], window_size: int) -> List[Tuple[int,
 
     return hashes
 
+
 # mod chosen as large prime of similar size to rabin karp, but distinct
 def hash_token(token: str, mod: int = 8554560727166512181):
     hash_value = 0
     for ch in token:
         hash_value = (hash_value * CHAR_PRIME + ord(ch)) % mod
     return hash_value
+
 
 def get_ngram_hashes(tokens: List[str], n: int):
     hashed_tokens = [hash_token(token) for token in tokens]

--- a/scripts/data_overlap/rabin_compute_metrics_from_ngrams.py
+++ b/scripts/data_overlap/rabin_compute_metrics_from_ngrams.py
@@ -1,0 +1,393 @@
+import argparse
+from typing import Any
+import ast
+import json
+import cattrs
+from nltk import ngrams
+from collections import defaultdict
+from typing import List, Tuple
+from dataclasses import dataclass
+
+from compute_data_overlap_metrics import load_light_scenarios_from_jsonl, create_hash_to_ngrams
+
+from data_overlap_spec import DataOverlapStatsKey, EntryOverlapNgrams
+from light_scenario import ScenarioSpecInstanceIds
+from compute_data_overlap_metrics import load_light_scenarios_from_jsonl
+from common.util import get_tokenizer
+from common.general import asdict_without_nones
+
+from enum import Enum
+
+
+@dataclass(frozen=True)
+class EntryDataOverlapKey:
+    """Unique key representing either the input or references of a single instance in a scenario."""
+
+    stats_key: DataOverlapStatsKey
+    part: str
+    """Either PART_INPUT or PART_REF"""
+    instance_id: str
+
+
+# Input: List[EntryOverlapNgrams]
+@dataclass(frozen=True)
+class EntryOverlapNgrams:
+    """Dataclass that represents output data overlap stats"""
+
+    entry_data_overlap_key: EntryDataOverlapKey
+
+    overlapping_ngram_counts: List[Tuple[str, int]]
+
+
+class PartialOverlapSpec(int, Enum):
+    binary = 0
+    jaccard = 1
+    token = 2
+
+@dataclass(frozen=True)
+class FrequencySpec:
+    # Filter ngrams with frequency >= filter_value; 0 means no filter
+    filter_value: int
+    # Whether to apply weight; we'll do inverse frequency
+    weighting: bool
+
+@dataclass(frozen=True)
+class MetricProtocolSpec:
+    """Specification for how we compute the metric"""
+
+    partial_overlap_spec: PartialOverlapSpec
+    frequency_spec: FrequencySpec
+
+@dataclass(frozen=True)
+class OverlapMetric:
+    metric_score: float # use 0/1 for binary, can revise as neded
+    metric_protocol_spec: MetricProtocolSpec
+
+# Output: List[EntryOverlapMetric]
+@dataclass(frozen=True)
+class EntryOverlapMetric:
+    """Dataclass that represents output data overlap stats"""
+
+    entry_data_overlap_key: EntryDataOverlapKey
+
+    overlap_metric: OverlapMetric
+
+def get_metrics(ngrams_path, scenario_path, out_path, filter_path, N):
+
+    scenario_spec_instance_id_dict = dict()
+    if filter_path:
+        scenario_spec_instance_ids_json = filter_path
+        scenario_spec_instance_ids_jsons = open(scenario_spec_instance_ids_json, "r").readlines()
+        for scenario_spec_instance_ids_json in scenario_spec_instance_ids_jsons:
+            scenario_spec_instance_ids_dict = json.loads(scenario_spec_instance_ids_json)
+            scenario_spec_instance_ids = cattrs.structure(scenario_spec_instance_ids_dict, ScenarioSpecInstanceIds)
+            scenario_spec_instance_id_dict[
+                scenario_spec_instance_ids.scenario_spec
+            ] = scenario_spec_instance_ids.instance_ids
+
+    # Read Ngrams
+    ngram_jsons = open(ngrams_path, "r").readlines()
+    entry_overlap_ngrams_list = []
+    for ngram_json in ngram_jsons:
+        entry_overlap_ngrams = json.loads(ngram_json)
+        entry_overlap_ngrams = cattrs.structure(entry_overlap_ngrams, EntryOverlapNgrams)
+        scenario_spec = entry_overlap_ngrams.entry_data_overlap_key.stats_key.light_scenario_key.scenario_spec
+        if scenario_spec_instance_id_dict:
+            if scenario_spec not in scenario_spec_instance_id_dict:
+                continue
+            instance_ids = scenario_spec_instance_id_dict[scenario_spec]
+            if entry_overlap_ngrams.entry_data_overlap_key.instance_id not in instance_ids:
+                continue
+            else:
+                entry_overlap_ngrams_list.append(entry_overlap_ngrams)
+        else:
+                entry_overlap_ngrams_list.append(entry_overlap_ngrams)
+
+
+
+
+    def merge_entries(entry_overlap_ngrams_list):
+        overlapping_counts = defaultdict(int)
+        for entry_overlap_ngrams in entry_overlap_ngrams_list:
+            entry_data_overlap_key = entry_overlap_ngrams.entry_data_overlap_key
+            overlapping_ngram_counts = entry_overlap_ngrams.overlapping_ngram_counts
+            for ngram, count in overlapping_ngram_counts:
+                overlapping_counts[ngram] += count
+        overlapping_ngram_counts_list = []
+        for ngram, count in overlapping_counts.items():
+            overlapping_ngram_counts_list.append((ngram, count))
+        return [EntryOverlapNgrams(
+                        entry_data_overlap_key=entry_data_overlap_key, overlapping_ngram_counts=overlapping_ngram_counts_list
+                    )]
+
+    # create entry_overlap_ngrams_dict, a dict of entry_data_overlap_key -> EntryOverlapNgrams
+    entry_overlap_ngrams_dict = defaultdict(list)
+    for entry_overlap_ngrams in entry_overlap_ngrams_list:
+        entry_data_overlap_key = entry_overlap_ngrams.entry_data_overlap_key
+        overlapping_ngram_counts = entry_overlap_ngrams.overlapping_ngram_counts
+        ngram_count = entry_data_overlap_key.stats_key.overlap_protocol_spec.n
+        if ngram_count not in [N]:
+            continue
+        entry_overlap_ngrams_dict[entry_data_overlap_key].append(entry_overlap_ngrams)
+
+        # We need to merge entries if sharded by training data, since there'll be redundancy
+        # Can refactor to no list later
+        if len(entry_overlap_ngrams_dict[entry_data_overlap_key]) > 1:
+            entry_overlap_ngrams_dict[entry_data_overlap_key] = merge_entries(entry_overlap_ngrams_dict[entry_data_overlap_key])
+
+
+    # Read Scenarios
+    light_scenarios = load_light_scenarios_from_jsonl(scenario_path)
+    light_scenario_instance_dict = dict()
+    for light_scenario in light_scenarios:
+        instances = light_scenario.instances
+        instance_dict = dict()
+        for instance in instances:
+            instance_dict[instance.id] = instance
+        light_scenario_instance_dict[light_scenario.scenario_key] = instance_dict
+
+
+    def compute_binary_overlap(instance_str, overlapping_ngram_counts, tokenizer, frequency = 0):
+        """ 
+        Compute  binary overlap
+        If pass in frequency, include only the ngrams with count <= frequency
+        """
+        tokens = tokenizer.tokenize(instance_str)
+        ngram_counts_dict = defaultdict(int)
+
+        # construct a dict of ngram -> count
+        for ngram, count in overlapping_ngram_counts:
+            ngram_counts_dict[ngram] = count
+
+        metric_score = 0
+
+        for ngram in ngrams(tokens, 13):
+            count = ngram_counts_dict[ngram]
+            if frequency == 0 or count <= frequency:
+                if count != 0:
+                    metric_score = 1
+                    break
+
+        overlap_metric = OverlapMetric(
+            metric_score = metric_score,
+            metric_protocol_spec = MetricProtocolSpec(
+                partial_overlap_spec = PartialOverlapSpec.binary,
+                frequency_spec = FrequencySpec(
+                    filter_value = frequency,
+                    weighting = False
+                )
+            )
+        )
+
+        return overlap_metric
+
+    def compute_jaccard_overlap(instance_str, overlapping_ngram_counts, tokenizer, frequency = 0):
+        """ 
+        Compute weighted and unweighted jaccard overlap
+        If pass in frequency, include only the ngrams with count <= frequency
+        """
+        tokens = tokenizer.tokenize(instance_str)
+        ngram_counts_dict = defaultdict(int)
+
+        # construct a dict of ngram -> count
+        for ngram, count in overlapping_ngram_counts:
+            ngram_counts_dict[ngram] = count
+
+        total_ngram_count = 0
+        counts = 0
+        weighted_score = 0
+
+        for ngram in ngrams(tokens, 13):
+            count = ngram_counts_dict[ngram]
+            if frequency == 0 or count <= frequency:
+                if count != 0:
+                    counts += 1
+                    weighted_score += 1 / count
+            total_ngram_count += 1
+
+        unweighted_score = counts / total_ngram_count
+        weighted_score = weighted_score / total_ngram_count
+
+        unweighted_overlap_metric = OverlapMetric(
+            metric_score = unweighted_score ,
+            metric_protocol_spec = MetricProtocolSpec(
+                partial_overlap_spec = PartialOverlapSpec.jaccard,
+                frequency_spec = FrequencySpec(
+                    filter_value = frequency,
+                    weighting = False
+                )
+            )
+        )
+
+        weighted_overlap_metric = OverlapMetric(
+            metric_score = weighted_score ,
+            metric_protocol_spec = MetricProtocolSpec(
+                partial_overlap_spec = PartialOverlapSpec.jaccard,
+                frequency_spec = FrequencySpec(
+                    filter_value = frequency,
+                    weighting = True
+                )
+            )
+        )
+
+        return unweighted_overlap_metric, weighted_overlap_metric
+
+    # Token overlap
+    def compute_token_overlap(instance_str, overlapping_ngram_counts, tokenizer, frequency = 0):
+        """ 
+        Compute weighted and unweighted token overlap
+        If pass in frequency, include only the ngrams with count <= frequency
+        """
+        tokens = tokenizer.tokenize(instance_str)
+        ngram_counts_dict = defaultdict(int)
+
+        # construct a dict of ngram -> count
+        for ngram, count in overlapping_ngram_counts:
+            ngram_counts_dict[ngram] = count
+
+        total_token_count = 0
+        counts = 0
+        weighted_score = 0
+        weight = 0
+        token_budget = 0
+
+        for ngram in ngrams(tokens, 13):
+            curr_count = ngram_counts_dict[ngram]
+            # either no frequency, or check current count is less than frequency
+            # or a previous contiguous count (weight != 0) less than frequency
+            if frequency == 0 or curr_count <= frequency or (weight != 0 and weight <= frequency):
+                if curr_count != 0:
+                    token_budget = 13
+                    if weight > 0:
+                        weight = min(curr_count, weight)
+                    else:
+                        weight = curr_count 
+
+            if token_budget > 0:
+                token_budget -= 1
+                counts += 1
+                weighted_score += 1 / weight
+            else:
+                weight = 0
+            total_token_count += 1
+
+        for token in ngram[1:]:
+            if token_budget > 0:
+                token_budget -= 1
+                counts += 1
+                weighted_score += 1 / weight
+            total_token_count += 1
+
+        unweighted_score = counts / total_token_count
+        weighted_score = weighted_score / total_token_count
+
+        unweighted_overlap_metric = OverlapMetric(
+            metric_score = unweighted_score ,
+            metric_protocol_spec = MetricProtocolSpec(
+                partial_overlap_spec = PartialOverlapSpec.token,
+                frequency_spec = FrequencySpec(
+                    filter_value = frequency,
+                    weighting = False
+                )
+            )
+        )
+
+        weighted_overlap_metric = OverlapMetric(
+            metric_score = weighted_score ,
+            metric_protocol_spec = MetricProtocolSpec(
+                partial_overlap_spec = PartialOverlapSpec.token,
+                frequency_spec = FrequencySpec(
+                    filter_value = frequency,
+                    weighting = True
+                )
+            )
+        )
+
+        return unweighted_overlap_metric, weighted_overlap_metric
+
+    def compute_and_add_metrics(instance_str, overlapping_ngram_counts, tokenizer, entry_data_overlap_key, entry_overlap_metric_list, frequency = 0):
+
+        overlap_metric = compute_binary_overlap(instance_str, overlapping_ngram_counts, tokenizer, frequency)
+        binary_metric = EntryOverlapMetric(entry_data_overlap_key=entry_data_overlap_key, overlap_metric=overlap_metric)
+        entry_overlap_metric_list.append(binary_metric)
+
+        unweighted_overlap_metric, weighted_overlap_metric = compute_jaccard_overlap(instance_str, overlapping_ngram_counts, tokenizer, frequency)
+        unweighted_jaccard = EntryOverlapMetric(entry_data_overlap_key=entry_data_overlap_key, overlap_metric=unweighted_overlap_metric)
+        weighted_jaccard = EntryOverlapMetric(entry_data_overlap_key=entry_data_overlap_key, overlap_metric=weighted_overlap_metric)
+        entry_overlap_metric_list.append(unweighted_jaccard)
+        entry_overlap_metric_list.append(weighted_jaccard)
+
+        unweighted_overlap_metric, weighted_overlap_metric = compute_token_overlap(instance_str, overlapping_ngram_counts, tokenizer, frequency)
+        unweighted_token = EntryOverlapMetric(entry_data_overlap_key=entry_data_overlap_key, overlap_metric=unweighted_overlap_metric)
+        weighted_token = EntryOverlapMetric(entry_data_overlap_key=entry_data_overlap_key, overlap_metric=weighted_overlap_metric)
+        entry_overlap_metric_list.append(unweighted_token)
+        entry_overlap_metric_list.append(weighted_token)
+
+    def save_metrics_to_jsonl(overlap_metrics: List[EntryOverlapMetric], filename: str):
+        with open(filename, "w") as f:
+            for overlap_metric in overlap_metrics:
+                f.write(json.dumps(asdict_without_nones(overlap_metric), ensure_ascii=False) + "\n")
+
+
+    entry_overlap_metric_list = []
+    tokenizer = get_tokenizer('default')
+    light_scenarios = load_light_scenarios_from_jsonl(scenario_path)
+    
+    hash_to_ngrams = create_hash_to_ngrams(
+        light_scenarios=light_scenarios, n_values=[13], tokenizer=tokenizer
+    )
+    hash_to_ngrams = hash_to_ngrams[13] 
+
+
+    for entry_data_overlap_key, entry_overlap_ngrams_list in entry_overlap_ngrams_dict.items():
+        data_overlap_stats_key = entry_data_overlap_key.stats_key
+        light_scenario_key = data_overlap_stats_key.light_scenario_key
+        instance_dict = light_scenario_instance_dict[light_scenario_key]
+        for entry_overlap_ngrams in entry_overlap_ngrams_list:
+            entry_data_overlap_key = entry_overlap_ngrams.entry_data_overlap_key
+            instance_id = entry_data_overlap_key.instance_id
+            instance = instance_dict[instance_id]
+            part = entry_data_overlap_key.part
+            overlapping_ngram_counts = entry_overlap_ngrams.overlapping_ngram_counts
+            unhashed_ngram_counts = []
+            for hash_val, count in overlapping_ngram_counts:
+                hash_val = int(hash_val)
+                if hash_val in hash_to_ngrams:
+                    ngrams_list = list(hash_to_ngrams[hash_val])
+                    if len(ngrams_list) > 1:
+                        raise Exception('there should be no collisions in the test data')
+                    ngram_val = ngrams_list[0]
+                    unhashed_ngram_counts.append((ngram_val, count))
+                else:
+                    print(hash_val)
+                    print(type(hash_val))
+            overlapping_ngram_counts = unhashed_ngram_counts
+
+            if part == 'input':
+                compute_and_add_metrics(instance.input, overlapping_ngram_counts, tokenizer, entry_data_overlap_key, entry_overlap_metric_list)
+                compute_and_add_metrics(instance.input, overlapping_ngram_counts, tokenizer, entry_data_overlap_key, entry_overlap_metric_list, frequency=10)
+            if part == 'references':
+                reference = ' '.join(instance.references)
+                compute_and_add_metrics(reference, overlapping_ngram_counts, tokenizer, entry_data_overlap_key, entry_overlap_metric_list)
+                compute_and_add_metrics(reference, overlapping_ngram_counts, tokenizer, entry_data_overlap_key, entry_overlap_metric_list, frequency=10)
+
+    save_metrics_to_jsonl(entry_overlap_metric_list, out_path)
+
+
+
+def get_args() -> Any:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ngrams-path", type=str, required=True, help="Path to your ngrams")
+    parser.add_argument("--scenario-path", type=str, required=True, help="Path to scenario data (benchmarking data)")
+    parser.add_argument("--out-path", type=str, required=True, help="Path to the output metrics file")
+    parser.add_argument("--filter-path", type=str, default='', help="Path to file for filtering a subset of tests")
+    return parser.parse_args()
+
+if __name__ == "__main__":
+    args = get_args()
+
+    # hard code computing for n = 13 for now
+    N = 13
+
+    # Call the get_metrics function with the constructed arguments
+    get_metrics(args.ngrams_path, args.scenario_path, args.out_path, args.filter_path, N)

--- a/scripts/data_overlap/test/test_compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/test/test_compute_data_overlap_metrics.py
@@ -160,10 +160,7 @@ def test_create_hash_to_ngrams():
     tokenizer = LightTokenizer()
     scenarios = [TEST_SCENARIO_1, TEST_SCENARIO_2]
     hash_to_ngrams: HashToNgrams
-    hash_to_ngrams = create_hash_to_ngrams(
-        light_scenarios=scenarios, n_values=N_VALUES, tokenizer=tokenizer
-    )
-
+    hash_to_ngrams = create_hash_to_ngrams(light_scenarios=scenarios, n_values=N_VALUES, tokenizer=tokenizer)
 
     test_5_gram: Ngram = ("Center", "for", "Research", "on", "Foundation")
     test_13_gram: Ngram = (
@@ -184,18 +181,8 @@ def test_create_hash_to_ngrams():
     test_5_gram_hash, _, _ = get_ngram_hashes(list(test_5_gram), 5)[0]
     test_13_gram_hash, _, _ = get_ngram_hashes(list(test_13_gram), 13)[0]
 
-    assert hash_to_ngrams[5][test_5_gram_hash] == set(
-        [
-            test_5_gram
-        ]
-    )
-    assert hash_to_ngrams[13][test_13_gram_hash] == set(
-        [
-            test_13_gram
-        ]
-    )
-
-
+    assert hash_to_ngrams[5][test_5_gram_hash] == set([test_5_gram])
+    assert hash_to_ngrams[13][test_13_gram_hash] == set([test_13_gram])
 
 
 def test_create_ngram_index():

--- a/scripts/data_overlap/test/test_compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/test/test_compute_data_overlap_metrics.py
@@ -14,6 +14,7 @@ from data_overlap_spec import DataOverlapStatsKey, OverlapProtocolSpec
 from light_scenario import LightScenario, LightInstance, LightScenarioKey
 from light_tokenizer import LightTokenizer, DefaultTokenizer
 from scenarios.scenario import ScenarioSpec
+from ngram_hasher import get_ngram_hashes
 
 N_VALUES = [5, 13]
 
@@ -190,15 +191,17 @@ def test_create_ngram_index():
         "initiative",
         "born",
     )
+    test_5_gram_hash, _, _ = get_ngram_hashes(list(test_5_gram), 5)[0]
+    test_13_gram_hash, _, _ = get_ngram_hashes(list(test_13_gram), 13)[0]
 
-    assert ngram_index[5][test_5_gram] == set(
+    assert ngram_index[5][test_5_gram_hash] == set(
         [
             EntryDataOverlapKey(stats_key=stats_1_key, instance_id="id1", part=PART_INPUT),
             EntryDataOverlapKey(stats_key=stats_2_key, instance_id="id1", part=PART_INPUT),
             EntryDataOverlapKey(stats_key=stats_2_key, instance_id="id1", part=PART_REF),
         ]
     )
-    assert ngram_index[13][test_13_gram] == set(
+    assert ngram_index[13][test_13_gram_hash] == set(
         [
             EntryDataOverlapKey(stats_key=stats_3_key, instance_id="id1", part=PART_INPUT),
             EntryDataOverlapKey(stats_key=stats_3_key, instance_id="id1", part=PART_REF),
@@ -226,6 +229,7 @@ def test_compute_document_data_overlap():
         stats_key_to_reference_ids=stats_key_to_reference_ids,
         entry_overlap_key_to_ngram_counts=None,
         output_ngrams=False,
+        hash_to_ngrams={},
     )
     assert stats_key_to_input_ids == defaultdict(
         set,

--- a/scripts/data_overlap/test/test_compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/test/test_compute_data_overlap_metrics.py
@@ -4,9 +4,11 @@ from collections import defaultdict
 from compute_data_overlap_metrics import (
     compute_document_data_overlap,
     create_ngram_index,
+    create_hash_to_ngrams,
     EntryDataOverlapKey,
     Ngram,
     NgramIndex,
+    HashToNgrams,
     PART_INPUT,
     PART_REF,
 )
@@ -152,6 +154,48 @@ def test_light_tokenizer():
         "est",
         "case",
     ]
+
+
+def test_create_hash_to_ngrams():
+    tokenizer = LightTokenizer()
+    scenarios = [TEST_SCENARIO_1, TEST_SCENARIO_2]
+    hash_to_ngrams: HashToNgrams
+    hash_to_ngrams = create_hash_to_ngrams(
+        light_scenarios=scenarios, n_values=N_VALUES, tokenizer=tokenizer
+    )
+
+
+    test_5_gram: Ngram = ("Center", "for", "Research", "on", "Foundation")
+    test_13_gram: Ngram = (
+        "The",
+        "Center",
+        "for",
+        "Research",
+        "on",
+        "Foundation",
+        "Models",
+        "(CRFM)",
+        "is",
+        "an",
+        "interdisciplinary",
+        "initiative",
+        "born",
+    )
+    test_5_gram_hash, _, _ = get_ngram_hashes(list(test_5_gram), 5)[0]
+    test_13_gram_hash, _, _ = get_ngram_hashes(list(test_13_gram), 13)[0]
+
+    assert hash_to_ngrams[5][test_5_gram_hash] == set(
+        [
+            test_5_gram
+        ]
+    )
+    assert hash_to_ngrams[13][test_13_gram_hash] == set(
+        [
+            test_13_gram
+        ]
+    )
+
+
 
 
 def test_create_ngram_index():

--- a/scripts/data_overlap/test/test_ngram_hasher.py
+++ b/scripts/data_overlap/test/test_ngram_hasher.py
@@ -1,13 +1,16 @@
 import pytest
 from ngram_hasher import RabinKarpHash, compute_hashes, hash_token, get_ngram_hashes
 
+
 @pytest.fixture
 def example_int_sequence():
     return [1, 2, 3, 4, 5]
 
+
 @pytest.fixture
 def example_tokens():
     return ["apple", "banana", "cherry", "date", "elderberry"]
+
 
 def test_RabinKarpHash_initialization(example_int_sequence):
     window_size = 3
@@ -15,33 +18,37 @@ def test_RabinKarpHash_initialization(example_int_sequence):
     assert isinstance(rk_hash, RabinKarpHash)
     assert rk_hash.current_hash != 0
 
+
 def test_RabinKarpHash_update(example_int_sequence):
     window_size = 3
     rk_hash = RabinKarpHash(example_int_sequence, window_size)
-    
+
     initial_hash = rk_hash.current_hash
     rk_hash.update()
     updated_hash = rk_hash.current_hash
-    
+
     assert updated_hash != initial_hash
+
 
 def test_compute_hashes(example_int_sequence):
     window_size = 3
     hashes = compute_hashes(example_int_sequence, window_size)
-    
+
     assert isinstance(hashes, list)
     assert len(hashes) == len(example_int_sequence) - window_size + 1
+
 
 def test_hash_token():
     token = "apple"
     hash_value = hash_token(token)
-    
+
     assert isinstance(hash_value, int)
     assert hash_value != 0
+
 
 def test_get_ngram_hashes(example_tokens):
     n = 2
     hashes = get_ngram_hashes(example_tokens, n)
-    
+
     assert isinstance(hashes, list)
     assert len(hashes) == len(example_tokens) - n + 1

--- a/scripts/data_overlap/test/test_ngram_hasher.py
+++ b/scripts/data_overlap/test/test_ngram_hasher.py
@@ -15,6 +15,7 @@ def example_tokens():
 def test_RabinKarpHash_initialization(example_int_sequence):
     window_size = 3
     rk_hash = RabinKarpHash(example_int_sequence, window_size)
+
     assert isinstance(rk_hash, RabinKarpHash)
     assert rk_hash.current_hash != 0
 
@@ -37,6 +38,13 @@ def test_compute_hashes(example_int_sequence):
     assert isinstance(hashes, list)
     assert len(hashes) == len(example_int_sequence) - window_size + 1
 
+    for h in hashes:
+        assert isinstance(h, tuple)
+        assert len(h) == 3
+
+    distinct_hashes = set(hash[0] for hash in hashes)
+    assert len(distinct_hashes) == len(hashes)
+
 
 def test_hash_token():
     token = "apple"
@@ -52,3 +60,10 @@ def test_get_ngram_hashes(example_tokens):
 
     assert isinstance(hashes, list)
     assert len(hashes) == len(example_tokens) - n + 1
+
+    for h in hashes:
+        assert isinstance(h, tuple)
+        assert len(h) == 3
+
+    distinct_hashes = set(hash[0] for hash in hashes)
+    assert len(distinct_hashes) == len(hashes)

--- a/scripts/data_overlap/test/test_ngram_hasher.py
+++ b/scripts/data_overlap/test/test_ngram_hasher.py
@@ -1,0 +1,47 @@
+import pytest
+from ngram_hasher import RabinKarpHash, compute_hashes, hash_token, get_ngram_hashes
+
+@pytest.fixture
+def example_int_sequence():
+    return [1, 2, 3, 4, 5]
+
+@pytest.fixture
+def example_tokens():
+    return ["apple", "banana", "cherry", "date", "elderberry"]
+
+def test_RabinKarpHash_initialization(example_int_sequence):
+    window_size = 3
+    rk_hash = RabinKarpHash(example_int_sequence, window_size)
+    assert isinstance(rk_hash, RabinKarpHash)
+    assert rk_hash.current_hash != 0
+
+def test_RabinKarpHash_update(example_int_sequence):
+    window_size = 3
+    rk_hash = RabinKarpHash(example_int_sequence, window_size)
+    
+    initial_hash = rk_hash.current_hash
+    rk_hash.update()
+    updated_hash = rk_hash.current_hash
+    
+    assert updated_hash != initial_hash
+
+def test_compute_hashes(example_int_sequence):
+    window_size = 3
+    hashes = compute_hashes(example_int_sequence, window_size)
+    
+    assert isinstance(hashes, list)
+    assert len(hashes) == len(example_int_sequence) - window_size + 1
+
+def test_hash_token():
+    token = "apple"
+    hash_value = hash_token(token)
+    
+    assert isinstance(hash_value, int)
+    assert hash_value != 0
+
+def test_get_ngram_hashes(example_tokens):
+    n = 2
+    hashes = get_ngram_hashes(example_tokens, n)
+    
+    assert isinstance(hashes, list)
+    assert len(hashes) == len(example_tokens) - n + 1


### PR DESCRIPTION
The hashing function and constants are chosen to be empirically effective; simpler solutions such as assigning an incremental id to words, and choosing small non-prime exponential bases resulting in high collision rates as early as the n-gram index construction. For 13-grams, there are 0 collisions in n-gram index construction and we are running/measuring collisions in the pile (which takes longer).


Memory usage profiling on 34 & 4 MB Scenario FIle to construct 13-gram_index:

4 MB Input:
550 MB -> 160 MB

34 MB Input:
12 GB -> 3.5 GB

So around 71% memory savings. Speed should also improve significantly. 627 MB Input (largest shard, should be upper bound memory usage) now takes 36 GB to build ngram indices (3 GB just to load scenario data file) so total memory usage should be around ~45-50GB. Previous memory estimates were based on slurm run success memory allocation, which was less precise (and based on these numbers, likely underestimates, as 36 / 0.3 = 120 G, whereas slurm succeeded with 60)


Note that when running with collision checks, memory usage goes up, not down; it's done to demonstrate effectiveness of hashing and to estimate collision frequency. Then, when sharing with companies, they can run with `--skip-check-collision = True` for very fast and memory efficient results.
