### PR TITLE
Increase NeurIPS challenge HTTP client timeout to 5 minutes

### DIFF
--- a/src/helm/proxy/clients/http_model_client.py
+++ b/src/helm/proxy/clients/http_model_client.py
@@ -28,7 +28,7 @@ class HTTPModelClient(Client):
         self,
         cache_config: CacheConfig,
         base_url: str = "http://localhost:8080",
-        timeout: int = 10,
+        timeout: int = 300,
         do_cache: bool = False,
     ):
         self.cache: Optional[Cache] = Cache(cache_config) if do_cache else None


### PR DESCRIPTION
A longer timeout may be needed for requests with thousands of tokens, which take a longer time to process.

Addresses #1790