### PR TITLE
Metadata yaml associating a data_overlap output file to the models

### DIFF
--- a/scripts/data_overlap/metadata.yaml
+++ b/scripts/data_overlap/metadata.yaml
@@ -1,0 +1,19 @@
+file_models_mapping:
+  - file_name: output_stats_pile_all 
+    model_names:
+      - together/bloom
+      - together/gpt-j-6b
+      - together/gpt-neox-20b
+      - together/opt-66b
+      - together/opt-175b
+      - microsoft/TNLGv2_7B
+      - microsoft/TNLGv2_530B
+      - anthropic/stanford-online-all-v4-s3
+      - anthropic/claude-v1.3
+      - anthropic/claude-instant-v1
+      - together/yalm
+      - together/cerebras-gpt-6.7b
+      - together/cerebras-gpt-13b
+      - together/pythia-3b
+      - together/pythia-7b
+      - together/pythia-12b


### PR DESCRIPTION
This file will include the metadata information associating a data_overlap output file to the models; for instance, this is for the pile. I think it makes sense to include in the codebase, and regardless I wanted to open this so that we can at least have a chance to review and go through this file before we upload (going forward)