### PR TITLE
Add intersection of input, reference to overlap

### DIFF
--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -108,7 +108,10 @@ def create_ngram_index(
                             EntryDataOverlapKey(stats_key=stats_key, instance_id=id, part=PART_REF)
                         )
 
-                # compute intersection ngrams [defined as n-grams that occur between instance and reference]
+                # concatenate the last n-1 tokens of input and the first n-1 tokens of reference and compute n-grams on this "interesection token" sequence
+                # for instance: input = ["is 2+2 4 true or false"] reference = ["true"]
+                # the intersection is the 5-gram ["4 true or false true"] 
+                # (which is formed from the input 4-gram [4 true or false] and the reference 1-gram [true])
                 input_end_tokens = input_tokens[-(n - 1) :]
                 for reference in instance.references:
                     reference_unigrams = tokenizer.tokenize(reference)

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -109,10 +109,10 @@ def create_ngram_index(
                         )
 
                 # compute intersection ngrams [defined as n-grams that occur between instance and reference]
-                input_end_tokens = input_tokens[-(n-1):]
+                input_end_tokens = input_tokens[-(n - 1) :]
                 for reference in instance.references:
                     reference_unigrams = tokenizer.tokenize(reference)
-                    reference_start_tokens = reference_unigrams[:n-1]
+                    reference_start_tokens = reference_unigrams[: n - 1]
                     intersection_tokens = input_end_tokens + reference_start_tokens
                     for intersection_ngram in ngrams(intersection_tokens, n):
                         if intersection_ngram not in ngram_index[n]:
@@ -204,7 +204,6 @@ def compute_document_data_overlap(
                         stats_key_to_intersection_ids[entry_overlap_key.stats_key].add(id)
                     if output_ngrams:
                         entry_overlap_key_to_ngram_counts[entry_overlap_key][document_ngram] += 1
-
 
 
 if __name__ == "__main__":

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -110,7 +110,7 @@ def create_ngram_index(
 
                 # concatenate the last n-1 tokens of input and the first n-1 tokens of reference and compute n-grams on this "interesection token" sequence
                 # for instance: input = ["is 2+2 4 true or false"] reference = ["true"]
-                # the intersection is the 5-gram ["4 true or false true"] 
+                # the intersection is the 5-gram ["4 true or false true"]
                 # (which is formed from the input 4-gram [4 true or false] and the reference 1-gram [true])
                 input_end_tokens = input_tokens[-(n - 1) :]
                 for reference in instance.references:

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -108,7 +108,7 @@ def create_ngram_index(
                             EntryDataOverlapKey(stats_key=stats_key, instance_id=id, part=PART_REF)
                         )
 
-                # concatenate the last n-1 tokens of input and the first n-1 tokens 
+                # concatenate the last n-1 tokens of input and the first n-1 tokens
                 # of reference and compute n-grams on this "interesection token sequence"
                 # for instance: input = ["is 2+2 4 true or false"] reference = ["true"]
                 # the intersection is the 5-gram ["4 true or false true"]

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -109,7 +109,7 @@ def create_ngram_index(
                         )
 
                 # concatenate the last n-1 tokens of input and the first n-1 tokens 
-                # of reference and compute n-grams on this "interesection token" sequence
+                # of reference and compute n-grams on this "interesection token sequence"
                 # for instance: input = ["is 2+2 4 true or false"] reference = ["true"]
                 # the intersection is the 5-gram ["4 true or false true"]
                 # (which is formed from the input 4-gram [4 true or false] and the reference 1-gram [true])

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -278,6 +278,7 @@ if __name__ == "__main__":
             data_overlap_stats_key=stats_key,
             instance_ids_with_overlapping_input=sorted(stats_key_to_input_ids[stats_key]),
             instance_ids_with_overlapping_reference=sorted(stats_key_to_reference_ids[stats_key]),
+            instance_ids_with_overlapping_intersection=sorted(stats_key_to_intersection_ids[stats_key]),
             num_instances=count,
         )
         all_data_overlap_stats.append(data_overlap_stats)

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -108,7 +108,8 @@ def create_ngram_index(
                             EntryDataOverlapKey(stats_key=stats_key, instance_id=id, part=PART_REF)
                         )
 
-                # concatenate the last n-1 tokens of input and the first n-1 tokens of reference and compute n-grams on this "interesection token" sequence
+                # concatenate the last n-1 tokens of input and the first n-1 tokens 
+                # of reference and compute n-grams on this "interesection token" sequence
                 # for instance: input = ["is 2+2 4 true or false"] reference = ["true"]
                 # the intersection is the 5-gram ["4 true or false true"]
                 # (which is formed from the input 4-gram [4 true or false] and the reference 1-gram [true])

--- a/scripts/data_overlap/data_overlap_spec.py
+++ b/scripts/data_overlap/data_overlap_spec.py
@@ -65,6 +65,8 @@ class DataOverlapStats:
     instance_ids_with_overlapping_input: List[str]
 
     instance_ids_with_overlapping_reference: List[str]
+    
+    instance_ids_with_overlapping_intersection: List[str]
 
 
 @dataclass(frozen=True)

--- a/scripts/data_overlap/data_overlap_spec.py
+++ b/scripts/data_overlap/data_overlap_spec.py
@@ -65,7 +65,7 @@ class DataOverlapStats:
     instance_ids_with_overlapping_input: List[str]
 
     instance_ids_with_overlapping_reference: List[str]
-    
+
     instance_ids_with_overlapping_intersection: List[str]
 
 

--- a/scripts/data_overlap/load_documents.py
+++ b/scripts/data_overlap/load_documents.py
@@ -114,8 +114,8 @@ def get_the_pile_document_iterator(file_path: str) -> Iterator[str]:
     {"text": "Foo bar", "meta": {"pile_set_name": "Pile-CC"}}
     """
     with open(file_path, "r") as f:
-        for line in f:
-            yield json.loads(line)["text"]
+            for line in f:
+                yield json.loads(line)["text"]
 
 
 def get_raw_document_iterator(file_path: str) -> Iterator[str]:

--- a/scripts/data_overlap/load_documents.py
+++ b/scripts/data_overlap/load_documents.py
@@ -114,8 +114,8 @@ def get_the_pile_document_iterator(file_path: str) -> Iterator[str]:
     {"text": "Foo bar", "meta": {"pile_set_name": "Pile-CC"}}
     """
     with open(file_path, "r") as f:
-            for line in f:
-                yield json.loads(line)["text"]
+        for line in f:
+            yield json.loads(line)["text"]
 
 
 def get_raw_document_iterator(file_path: str) -> Iterator[str]:


### PR DESCRIPTION
Previously, we computed ngrams for input and references, but did not calculate ngrams for those on the boundary of input and reference. e.g. input = ["is 2+2 4 true or false"] reference = ["true"], the 5-gram ["4 true or false true"] is not captured; this PR adds this in