### PR TITLE
[EXPERIMENTAL, DO NOT MERGE] Output docs associated with ngram

### DIFF
--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -108,7 +108,10 @@ def create_ngram_index(
                             EntryDataOverlapKey(stats_key=stats_key, instance_id=id, part=PART_REF)
                         )
 
-                # compute intersection ngrams [defined as n-grams that occur between instance and reference]
+                # concatenate the last n-1 tokens of input and the first n-1 tokens of reference and compute n-grams on this "interesection token" sequence
+                # for instance: input = ["is 2+2 4 true or false"] reference = ["true"]
+                # the intersection is the 5-gram ["4 true or false true"] 
+                # (which is formed from the input 4-gram [4 true or false] and the reference 1-gram [true])
                 input_end_tokens = input_tokens[-(n - 1) :]
                 for reference in instance.references:
                     reference_unigrams = tokenizer.tokenize(reference)

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -109,10 +109,10 @@ def create_ngram_index(
                         )
 
                 # compute intersection ngrams [defined as n-grams that occur between instance and reference]
-                input_end_tokens = input_tokens[-(n-1):]
+                input_end_tokens = input_tokens[-(n - 1) :]
                 for reference in instance.references:
                     reference_unigrams = tokenizer.tokenize(reference)
-                    reference_start_tokens = reference_unigrams[:n-1]
+                    reference_start_tokens = reference_unigrams[: n - 1]
                     intersection_tokens = input_end_tokens + reference_start_tokens
                     for intersection_ngram in ngrams(intersection_tokens, n):
                         if intersection_ngram not in ngram_index[n]:
@@ -204,7 +204,6 @@ def compute_document_data_overlap(
                         stats_key_to_intersection_ids[entry_overlap_key.stats_key].add(id)
                     if output_ngrams:
                         entry_overlap_key_to_ngram_counts[entry_overlap_key][document_ngram] += 1
-
 
 
 if __name__ == "__main__":

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -138,6 +138,7 @@ def compute_all_data_overlap(
     stats_key_to_intersection_ids: DefaultDict[DataOverlapStatsKey, Set[str]],
     entry_overlap_key_to_ngram_counts: DefaultDict[EntryDataOverlapKey, DefaultDict[str, int]],
     output_ngrams: bool,
+    output_path: str,
 ) -> None:
     """
     Given an input file, compute a overlap stats for each n and each scenario by calling
@@ -163,6 +164,7 @@ def compute_all_data_overlap(
             stats_key_to_intersection_ids=stats_key_to_intersection_ids,
             entry_overlap_key_to_ngram_counts=entry_overlap_key_to_ngram_counts,
             output_ngrams=output_ngrams,
+            output_path=output_path,
         )
 
 
@@ -175,6 +177,7 @@ def compute_document_data_overlap(
     stats_key_to_intersection_ids: DefaultDict[DataOverlapStatsKey, Set[str]],
     entry_overlap_key_to_ngram_counts: DefaultDict[EntryDataOverlapKey, DefaultDict[str, int]],
     output_ngrams: bool,
+    output_path: str,
 ) -> None:
     """
     Given a document, compute a overlap stats for each n and each scenario. The function
@@ -208,7 +211,7 @@ def compute_document_data_overlap(
                         stats_key_to_intersection_ids[entry_overlap_key.stats_key].add(id)
                     if output_ngrams:
                         entry_overlap_key_to_ngram_counts[entry_overlap_key][document_ngram] += 1
-                        with open(f'ngram_docs_{document_ngram}', 'a') as f:
+                        with open(f'{output_path}_{document_ngram}', 'a') as f:
                             f.write(document)
 
 if __name__ == "__main__":
@@ -261,6 +264,7 @@ if __name__ == "__main__":
                 stats_key_to_intersection_ids=stats_key_to_intersection_ids,
                 entry_overlap_key_to_ngram_counts=entry_overlap_key_to_ngram_counts,
                 output_ngrams=not args.no_output_ngrams,
+                output_path=args.output_stats,
             )
 
     if not args.no_output_ngrams:

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -211,11 +211,13 @@ def compute_document_data_overlap(
                         stats_key_to_intersection_ids[entry_overlap_key.stats_key].add(id)
                     if output_ngrams:
                         entry_overlap_key_to_ngram_counts[entry_overlap_key][document_ngram] += 1
-                        ngram_str = '/'.join(document_ngram)
-                        directory_path = f"{output_path}_docs/{ngram_str}"
-                        if not os.path.exists(directory_path):
-                            os.makedirs(directory_path)
-                        with open(f'{ngram_str}', 'a') as f:
+                        ngram_prefix= '/'.join(document_ngram[0:2])
+                        ngram_suffix = ' '.join(document_ngram[2:])
+                        directory_path = f"{output_path}_docs/{ngram_prefix}"
+                        file_path = f'{directory_path}/{ngram_suffix}'
+                        if not os.path.exists(file_path):
+                            os.makedirs(file_path)
+                        with open(file_path, 'a') as f:
                             f.write(document)
                             f.write('\n------------- DOCUMENT DELIMITER --------------\n')
 

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -110,7 +110,7 @@ def create_ngram_index(
 
                 # concatenate the last n-1 tokens of input and the first n-1 tokens of reference and compute n-grams on this "interesection token" sequence
                 # for instance: input = ["is 2+2 4 true or false"] reference = ["true"]
-                # the intersection is the 5-gram ["4 true or false true"] 
+                # the intersection is the 5-gram ["4 true or false true"]
                 # (which is formed from the input 4-gram [4 true or false] and the reference 1-gram [true])
                 input_end_tokens = input_tokens[-(n - 1) :]
                 for reference in instance.references:

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -211,8 +211,10 @@ def compute_document_data_overlap(
                         stats_key_to_intersection_ids[entry_overlap_key.stats_key].add(id)
                     if output_ngrams:
                         entry_overlap_key_to_ngram_counts[entry_overlap_key][document_ngram] += 1
-                        with open(f'{output_path}_{document_ngram}', 'a') as f:
+                        ngram_str = ' '.join(document_ngram)
+                        with open(f'{output_path}_{ngram_str}', 'a') as f:
                             f.write(document)
+                            f.write('------------- DOCUMENT DELIMITER --------------\n\n')
 
 if __name__ == "__main__":
     args = get_data_overlap_args()

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -212,7 +212,7 @@ def compute_document_data_overlap(
                     if output_ngrams:
                         entry_overlap_key_to_ngram_counts[entry_overlap_key][document_ngram] += 1
                         ngram_str = '/'.join(document_ngram)
-                        directory_path = "{output_path}/{ngram_str}"
+                        directory_path = "{output_path}_docs/{ngram_str}"
                         if not os.path.exists(directory_path):
                             os.makedirs(directory_path)
                         with open(f'{ngram_str}', 'a') as f:

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -214,9 +214,9 @@ def compute_document_data_overlap(
                         ngram_prefix= '/'.join(document_ngram[0:2])
                         ngram_suffix = ' '.join(document_ngram[2:])
                         directory_path = f"{output_path}_docs/{ngram_prefix}"
+                        if not os.path.exists(directory_path):
+                            os.makedirs(directory_path)
                         file_path = f'{directory_path}/{ngram_suffix}'
-                        if not os.path.exists(file_path):
-                            os.makedirs(file_path)
                         with open(file_path, 'a') as f:
                             f.write(document)
                             f.write('\n------------- DOCUMENT DELIMITER --------------\n')

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -208,7 +208,8 @@ def compute_document_data_overlap(
                         stats_key_to_intersection_ids[entry_overlap_key.stats_key].add(id)
                     if output_ngrams:
                         entry_overlap_key_to_ngram_counts[entry_overlap_key][document_ngram] += 1
-
+                        with open(f'ngram_docs_{document_ngram}', 'a') as f:
+                            f.write(document)
 
 if __name__ == "__main__":
     args = get_data_overlap_args()

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -109,7 +109,7 @@ def create_ngram_index(
                         )
 
                 # concatenate the last n-1 tokens of input and the first n-1 tokens 
-                # of reference and compute n-grams on this "interesection token" sequence
+                # of reference and compute n-grams on this "interesection token sequence"
                 # for instance: input = ["is 2+2 4 true or false"] reference = ["true"]
                 # the intersection is the 5-gram ["4 true or false true"]
                 # (which is formed from the input 4-gram [4 true or false] and the reference 1-gram [true])

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -278,6 +278,7 @@ if __name__ == "__main__":
             data_overlap_stats_key=stats_key,
             instance_ids_with_overlapping_input=sorted(stats_key_to_input_ids[stats_key]),
             instance_ids_with_overlapping_reference=sorted(stats_key_to_reference_ids[stats_key]),
+            instance_ids_with_overlapping_intersection=sorted(stats_key_to_intersection_ids[stats_key]),
             num_instances=count,
         )
         all_data_overlap_stats.append(data_overlap_stats)

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -28,8 +28,6 @@ from scenarios.scenario import ScenarioSpec
 PART_INPUT: str = "input"
 PART_REF: str = "references"
 PART_INTERSECT: str = "intersect"
-
-
 # type alias for overlap-related data structures
 Ngram = Tuple[str, ...]
 NgramIndex = Dict[int, Dict[Ngram, Set[EntryDataOverlapKey]]]
@@ -154,7 +152,9 @@ def compute_all_data_overlap(
     output_ngrams: whether we should output ngrams
     """
     document_iterator = get_document_iterator(file_path=training_file_path, file_format=file_format)
+    doc_id = 0
     for document in document_iterator:
+        doc_id += 1
         compute_document_data_overlap(
             document=document,
             ngram_index=ngram_index,
@@ -211,10 +211,13 @@ def compute_document_data_overlap(
                         stats_key_to_intersection_ids[entry_overlap_key.stats_key].add(id)
                     if output_ngrams:
                         entry_overlap_key_to_ngram_counts[entry_overlap_key][document_ngram] += 1
-                        ngram_str = ' '.join(document_ngram)
-                        with open(f'{output_path}_{ngram_str}', 'a') as f:
+                        ngram_str = '/'.join(document_ngram)
+                        directory_path = "{output_path}/{ngram_str}"
+                        if not os.path.exists(directory_path):
+                            os.makedirs(directory_path)
+                        with open(f'{ngram_str}', 'a') as f:
                             f.write(document)
-                            f.write('------------- DOCUMENT DELIMITER --------------\n\n')
+                            f.write('\n------------- DOCUMENT DELIMITER --------------\n')
 
 if __name__ == "__main__":
     args = get_data_overlap_args()

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -108,7 +108,8 @@ def create_ngram_index(
                             EntryDataOverlapKey(stats_key=stats_key, instance_id=id, part=PART_REF)
                         )
 
-                # concatenate the last n-1 tokens of input and the first n-1 tokens of reference and compute n-grams on this "interesection token" sequence
+                # concatenate the last n-1 tokens of input and the first n-1 tokens 
+                # of reference and compute n-grams on this "interesection token" sequence
                 # for instance: input = ["is 2+2 4 true or false"] reference = ["true"]
                 # the intersection is the 5-gram ["4 true or false true"]
                 # (which is formed from the input 4-gram [4 true or false] and the reference 1-gram [true])

--- a/scripts/data_overlap/compute_data_overlap_metrics.py
+++ b/scripts/data_overlap/compute_data_overlap_metrics.py
@@ -212,7 +212,7 @@ def compute_document_data_overlap(
                     if output_ngrams:
                         entry_overlap_key_to_ngram_counts[entry_overlap_key][document_ngram] += 1
                         ngram_str = '/'.join(document_ngram)
-                        directory_path = "{output_path}_docs/{ngram_str}"
+                        directory_path = f"{output_path}_docs/{ngram_str}"
                         if not os.path.exists(directory_path):
                             os.makedirs(directory_path)
                         with open(f'{ngram_str}', 'a') as f:

--- a/scripts/data_overlap/data_overlap_spec.py
+++ b/scripts/data_overlap/data_overlap_spec.py
@@ -65,6 +65,8 @@ class DataOverlapStats:
     instance_ids_with_overlapping_input: List[str]
 
     instance_ids_with_overlapping_reference: List[str]
+    
+    instance_ids_with_overlapping_intersection: List[str]
 
 
 @dataclass(frozen=True)

--- a/scripts/data_overlap/data_overlap_spec.py
+++ b/scripts/data_overlap/data_overlap_spec.py
@@ -65,7 +65,7 @@ class DataOverlapStats:
     instance_ids_with_overlapping_input: List[str]
 
     instance_ids_with_overlapping_reference: List[str]
-    
+
     instance_ids_with_overlapping_intersection: List[str]
 
 

--- a/scripts/data_overlap/load_documents.py
+++ b/scripts/data_overlap/load_documents.py
@@ -115,7 +115,7 @@ def get_the_pile_document_iterator(file_path: str) -> Iterator[str]:
     """
     with open(file_path, "r") as f:
         import random
-        if random.random < 1 / 1000:
+        if random.random() < 1 / 1000:
             for line in f:
                 yield json.loads(line)["text"]
 

--- a/scripts/data_overlap/load_documents.py
+++ b/scripts/data_overlap/load_documents.py
@@ -114,8 +114,8 @@ def get_the_pile_document_iterator(file_path: str) -> Iterator[str]:
     {"text": "Foo bar", "meta": {"pile_set_name": "Pile-CC"}}
     """
     with open(file_path, "r") as f:
-        for line in f:
-            yield json.loads(line)["text"]
+            for line in f:
+                yield json.loads(line)["text"]
 
 
 def get_raw_document_iterator(file_path: str) -> Iterator[str]:

--- a/scripts/data_overlap/load_documents.py
+++ b/scripts/data_overlap/load_documents.py
@@ -118,7 +118,7 @@ def get_the_pile_document_iterator(file_path: str) -> Iterator[str]:
     """
     with open(file_path, "r") as f:
         for line in f:
-            if random.random() < 1 / 10000:
+            if random.random() < 1 / 1000:
                 yield json.loads(line)["text"]
 
 

--- a/scripts/data_overlap/load_documents.py
+++ b/scripts/data_overlap/load_documents.py
@@ -115,7 +115,7 @@ def get_the_pile_document_iterator(file_path: str) -> Iterator[str]:
     """
     with open(file_path, "r") as f:
         import random
-        if random.random() < 1 / 1000:
+        if random.random() < 1 / 10:
             for line in f:
                 yield json.loads(line)["text"]
 

--- a/scripts/data_overlap/load_documents.py
+++ b/scripts/data_overlap/load_documents.py
@@ -114,8 +114,10 @@ def get_the_pile_document_iterator(file_path: str) -> Iterator[str]:
     {"text": "Foo bar", "meta": {"pile_set_name": "Pile-CC"}}
     """
     with open(file_path, "r") as f:
-        for line in f:
-            yield json.loads(line)["text"]
+        import random
+        if random.random < 1 / 1000:
+            for line in f:
+                yield json.loads(line)["text"]
 
 
 def get_raw_document_iterator(file_path: str) -> Iterator[str]:

--- a/scripts/data_overlap/load_documents.py
+++ b/scripts/data_overlap/load_documents.py
@@ -114,8 +114,8 @@ def get_the_pile_document_iterator(file_path: str) -> Iterator[str]:
     {"text": "Foo bar", "meta": {"pile_set_name": "Pile-CC"}}
     """
     with open(file_path, "r") as f:
-            for line in f:
-                yield json.loads(line)["text"]
+        for line in f:
+            yield json.loads(line)["text"]
 
 
 def get_raw_document_iterator(file_path: str) -> Iterator[str]:

--- a/scripts/data_overlap/load_documents.py
+++ b/scripts/data_overlap/load_documents.py
@@ -103,6 +103,9 @@ def get_flan_document_iterator(file_path: str) -> Iterator[str]:
                 yield sample["output"]
 
 
+import random
+random.seed(0)
+
 def get_the_pile_document_iterator(file_path: str) -> Iterator[str]:
     """
     This method reads input files with similar file formats with The Pile's jsonl format.
@@ -114,9 +117,8 @@ def get_the_pile_document_iterator(file_path: str) -> Iterator[str]:
     {"text": "Foo bar", "meta": {"pile_set_name": "Pile-CC"}}
     """
     with open(file_path, "r") as f:
-        import random
-        if random.random() < 1 / 10:
-            for line in f:
+        for line in f:
+            if random.random() < 1 / 10000:
                 yield json.loads(line)["text"]
 
 


### PR DESCRIPTION
We want to get the training docs associated with n_gram overlap so we can look at the specific docs and compare with test scenarios. We sample 1/1000 lines to be somewhat random/representative and bc very large and expensive