### PR TITLE
Rewrite requests to Together

### DIFF
--- a/src/helm/benchmark/static/schema.yaml
+++ b/src/helm/benchmark/static/schema.yaml
@@ -784,7 +784,7 @@ models:
     num_parameters: 7000000000
     release_date: 2023-03-15
   - name: tiiuae/falcon-40b
-    display_name: Falcon LLM (4B)
+    display_name: Falcon LLM (40B)
     description: Falcon-40B is a 40B parameters causal decoder-only model built by TII and trained on 1,500B tokens of RefinedWeb enhanced with curated corpora.
     creator_organization: TII UAE
     access: open

--- a/src/helm/proxy/clients/test_together_client.py
+++ b/src/helm/proxy/clients/test_together_client.py
@@ -66,24 +66,26 @@ class TestTogetherClient:
                     "top_p": 0.3,
                 },
             ),
-                        (
+            (
                 Request(
                     model="stanford/alpaca-7b",
+                    stop_sequences=["\n"],
                 ),
                 {
                     "best_of": 1,
                     "echo": False,
                     "logprobs": 1,
                     "max_tokens": 100,
-                    "model": "stanford/alpaca-7b",
+                    "model": "togethercomputer/alpaca-7b",
                     "n": 1,
                     "prompt": "",
                     "request_type": "language-model-inference",
-                    "stop": None,
+                    "stop": ["\n", "</s>"],
                     "temperature": 1.0,
                     "top_p": 1,
                 },
             ),
+            # TODO(#1828): Add test for `SET_DETAILS_TO_TRUE` after Together supports it.
         ],
     )
     def test_convert_to_raw_request(self, test_input, expected):

--- a/src/helm/proxy/clients/test_together_client.py
+++ b/src/helm/proxy/clients/test_together_client.py
@@ -66,6 +66,24 @@ class TestTogetherClient:
                     "top_p": 0.3,
                 },
             ),
+                        (
+                Request(
+                    model="stanford/alpaca-7b",
+                ),
+                {
+                    "best_of": 1,
+                    "echo": False,
+                    "logprobs": 1,
+                    "max_tokens": 100,
+                    "model": "stanford/alpaca-7b",
+                    "n": 1,
+                    "prompt": "",
+                    "request_type": "language-model-inference",
+                    "stop": None,
+                    "temperature": 1.0,
+                    "top_p": 1,
+                },
+            ),
         ],
     )
     def test_convert_to_raw_request(self, test_input, expected):

--- a/src/helm/proxy/clients/together_client.py
+++ b/src/helm/proxy/clients/together_client.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import List, Dict, Any, Optional, Union
 
 import requests
@@ -67,6 +68,7 @@ available implementations on Together."""
 
 class _RewriteRequestTags:
     """Tags that indicate that the request for the model must be rewritten before sending to Together."""
+
     # TODO: Convert to StrEnum after upgrading to Python 3.11
 
     ADD_EOS_TOKEN_AS_STOP_SEQUENCE = "ADD_EOS_TOKEN_AS_STOP_SEQUENCE"
@@ -81,7 +83,11 @@ class _RewriteRequestTags:
 
 
 _MODEL_TO_TAGS: Dict[str, List[str]] = {
-    "alpaca-7b": [_RewriteRequestTags.ADD_EOS_TOKEN_AS_STOP_SEQUENCE, _RewriteRequestTags.SET_DETAILS_TO_TRUE]
+    "alpaca-7b": [_RewriteRequestTags.ADD_EOS_TOKEN_AS_STOP_SEQUENCE],
+    "vicuna-7b-v1.3": [_RewriteRequestTags.ADD_EOS_TOKEN_AS_STOP_SEQUENCE],
+    "llama-65b": [_RewriteRequestTags.SET_DETAILS_TO_TRUE],
+    "llama-2-70b": [_RewriteRequestTags.SET_DETAILS_TO_TRUE],
+    "vicuna-13b-v1.3": [_RewriteRequestTags.ADD_EOS_TOKEN_AS_STOP_SEQUENCE],
 }
 """Dict of models to Together model tags.
 
@@ -92,6 +98,8 @@ The keys are the model engine of the HELM model name (e.g. "alpaca-7b"), not the
 
 _MODEL_TO_EOS_TOKEN: Dict[str, str] = {
     "alpaca-7b": "</s>",
+    "vicuna-7b-v1.3": "</s>",
+    "vicuna-13b-v1.3": "</s>",
 }
 """Dict of models to end of sequence tokens.
 
@@ -103,9 +111,8 @@ The keys are the model engine of the HELM model name (e.g. "alpaca-7b"), not the
 
 def _rewrite_raw_request_for_model_tags(raw_request: Dict[str, Any], model_engine: str) -> Dict[str, Any]:
     """Rewrite the raw request given the model."""
-    from copy import deepcopy
     # Make a deepcopy to avoid mutating the input in unexpected ways
-    # (e.g. raw_request["stop"] is a mutable list)
+    # (e.g. raw_request["stop"] can be a mutable list)
     rewritten_request = deepcopy(raw_request)
     model_tags = _MODEL_TO_TAGS.get(model_engine, [])
     for model_tag in model_tags:
@@ -113,9 +120,9 @@ def _rewrite_raw_request_for_model_tags(raw_request: Dict[str, Any], model_engin
             eos_token = _MODEL_TO_EOS_TOKEN.get(model_engine)
             if not eos_token:
                 raise ValueError(f"Unknown EOS token for: {model_engine}")
-            if rewritten_request["stop"] is None:
-                rewritten_request["stop"] = []
-            rewritten_request["stop"].append(eos_token)
+            rewritten_stop_sequences: List[str] = rewritten_request["stop"] or []
+            rewritten_stop_sequences.append(eos_token)
+            rewritten_request["stop"] = rewritten_stop_sequences
         elif model_tag == _RewriteRequestTags.SET_DETAILS_TO_TRUE:
             rewritten_request["details"] = True
         else:

--- a/src/helm/proxy/clients/together_client.py
+++ b/src/helm/proxy/clients/together_client.py
@@ -65,6 +65,64 @@ This also allows future migration of results in the case of changes of
 available implementations on Together."""
 
 
+class _RewriteRequestTags:
+    """Tags that indicate that the request for the model must be rewritten before sending to Together."""
+    # TODO: Convert to StrEnum after upgrading to Python 3.11
+
+    ADD_EOS_TOKEN_AS_STOP_SEQUENCE = "ADD_EOS_TOKEN_AS_STOP_SEQUENCE"
+    """Indicates that the EOS token should be added as an extra stop sequence.
+    
+    This prevents the model from incorrectly returning the EOS token as part of the generation."""
+
+    SET_DETAILS_TO_TRUE = "SET_DETAILS_TO_TRUE"
+    """Indicates that the `details` field should be set to `true`.
+    
+    This indicates that Together should return logprobs for models that do not return logprobs by default."""
+
+
+_MODEL_TO_TAGS: Dict[str, List[str]] = {
+    "alpaca-7b": [_RewriteRequestTags.ADD_EOS_TOKEN_AS_STOP_SEQUENCE, _RewriteRequestTags.SET_DETAILS_TO_TRUE]
+}
+"""Dict of models to Together model tags.
+
+This indicates which models require their requests to be rewritten before sending to together.
+The keys are the model engine of the HELM model name (e.g. "alpaca-7b"), not the full HELM model name
+(e.g. "stanford/alpaca-7b") or the Together model name (e.g. "togethercomputer/alpaca-7b")."""
+
+
+_MODEL_TO_EOS_TOKEN: Dict[str, str] = {
+    "alpaca-7b": "</s>",
+}
+"""Dict of models to end of sequence tokens.
+
+This provides the end of sequence tokens for models that have `ADD_EOS_TOKEN_AS_STOP_SEQUENCE` as a model tag.
+We hardcode the end of sequence tokens as constants here instead of attepmting to auto-infer them, for simplicity.
+The keys are the model engine of the HELM model name (e.g. "alpaca-7b"), not the full HELM model name
+(e.g. "stanford/alpaca-7b") or the Together model name (e.g. "togethercomputer/alpaca-7b")."""
+
+
+def _rewrite_raw_request_for_model_tags(raw_request: Dict[str, Any], model_engine: str) -> Dict[str, Any]:
+    """Rewrite the raw request given the model."""
+    from copy import deepcopy
+    # Make a deepcopy to avoid mutating the input in unexpected ways
+    # (e.g. raw_request["stop"] is a mutable list)
+    rewritten_request = deepcopy(raw_request)
+    model_tags = _MODEL_TO_TAGS.get(model_engine, [])
+    for model_tag in model_tags:
+        if model_tag == _RewriteRequestTags.ADD_EOS_TOKEN_AS_STOP_SEQUENCE:
+            eos_token = _MODEL_TO_EOS_TOKEN.get(model_engine)
+            if not eos_token:
+                raise ValueError(f"Unknown EOS token for: {model_engine}")
+            if rewritten_request["stop"] is None:
+                rewritten_request["stop"] = []
+            rewritten_request["stop"].append(eos_token)
+        elif model_tag == _RewriteRequestTags.SET_DETAILS_TO_TRUE:
+            rewritten_request["details"] = True
+        else:
+            raise ValueError(f"Unknown `_RewriteRequestTags`: {model_tag}")
+    return rewritten_request
+
+
 class TogetherClientError(Exception):
     pass
 
@@ -87,7 +145,7 @@ class TogetherClient(Client):
     @staticmethod
     def convert_to_raw_request(request: Request) -> Dict:
         # Following the examples from https://github.com/togethercomputer/open-models-api
-        return {
+        raw_request = {
             "request_type": "language-model-inference",
             "model": MODEL_ALIASES.get(request.model_engine, request.model_engine),
             "prompt": request.prompt,
@@ -100,6 +158,7 @@ class TogetherClient(Client):
             "echo": request.echo_prompt,
             "top_p": request.top_p,
         }
+        return _rewrite_raw_request_for_model_tags(raw_request, request.model_engine)
 
     def __init__(self, cache_config: CacheConfig, api_key: Optional[str] = None):
         # TODO: the endpoint currently doesn't require an API key. When an API key is not specified

--- a/src/helm/proxy/clients/together_client.py
+++ b/src/helm/proxy/clients/together_client.py
@@ -73,12 +73,12 @@ class _RewriteRequestTags:
 
     ADD_EOS_TOKEN_AS_STOP_SEQUENCE = "ADD_EOS_TOKEN_AS_STOP_SEQUENCE"
     """Indicates that the EOS token should be added as an extra stop sequence.
-    
+
     This prevents the model from incorrectly returning the EOS token as part of the generation."""
 
     SET_DETAILS_TO_TRUE = "SET_DETAILS_TO_TRUE"
     """Indicates that the `details` field should be set to `true`.
-    
+
     This indicates that Together should return logprobs for models that do not return logprobs by default."""
 
 

--- a/src/helm/proxy/clients/together_client.py
+++ b/src/helm/proxy/clients/together_client.py
@@ -120,9 +120,10 @@ def _rewrite_raw_request_for_model_tags(raw_request: Dict[str, Any], model_engin
             eos_token = _MODEL_TO_EOS_TOKEN.get(model_engine)
             if not eos_token:
                 raise ValueError(f"Unknown EOS token for: {model_engine}")
-            rewritten_stop_sequences: List[str] = rewritten_request["stop"] or []
-            rewritten_stop_sequences.append(eos_token)
-            rewritten_request["stop"] = rewritten_stop_sequences
+            if isinstance(rewritten_request["stop"], list):
+                rewritten_request["stop"].append(eos_token)
+            else:
+                rewritten_request["stop"] = [eos_token]
         elif model_tag == _RewriteRequestTags.SET_DETAILS_TO_TRUE:
             rewritten_request["details"] = True
         else:

--- a/src/helm/proxy/models.py
+++ b/src/helm/proxy/models.py
@@ -302,57 +302,59 @@ ALL_MODELS = [
     Model(
         group="together",
         name="eleutherai/pythia-1b-v0",
-        tags=[TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG],
+        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
     ),
     Model(
         group="together",
         name="eleutherai/pythia-2.8b-v0",
-        tags=[TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG],
+        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
     ),
     Model(
         group="together",
         name="eleutherai/pythia-6.9b",
-        tags=[TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG],
+        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
     ),
     Model(
         group="together",
         name="eleutherai/pythia-12b-v0",
-        tags=[TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG],
+        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
     ),
     # Meta
     Model(
         group="together",
         name="meta/llama-7b",
-        tags=[TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG],
+        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
     ),
     Model(
         group="together",
         name="meta/llama-13b",
-        tags=[TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG],
+        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
     ),
     Model(
         group="together",
         name="meta/llama-30b",
-        tags=[TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG],
+        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
     ),
     Model(
         group="together",
         name="meta/llama-65b",
+        # TODO(#1828): Upgrade to FULL_FUNCTIONALITY_TEXT_MODEL_TAG
         tags=[TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG],
     ),
     Model(
         group="together",
         name="meta/llama-2-7b",
-        tags=[TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG],
+        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
     ),
     Model(
         group="together",
         name="meta/llama-2-13b",
-        tags=[TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG],
+        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
     ),
     Model(
         group="together",
         name="meta/llama-2-70b",
+        # TODO(#1828): Upgrade to FULL_FUNCTIONALITY_TEXT_MODEL_TAG
         tags=[TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG],
     ),
     # Stanford


### PR DESCRIPTION
This implements two workarounds suggested by Together for specific Together models:

- Add the EOS token as an extra stop sequence. This prevents the model from incorrectly returning the EOS token as part of the generation.
- Set the `details` field to `true`. This indicates that Together should return logprobs for models that do not return logprobs by default.