### PR TITLE
Fix missing calibration metrics

### DIFF
--- a/src/helm/benchmark/metrics/basic_metrics.py
+++ b/src/helm/benchmark/metrics/basic_metrics.py
@@ -832,7 +832,7 @@ def _has_non_zero_valued_logprobs(per_instance_stats: Dict[Instance, List[Stat]]
     Some models have partial functionality and produce only zero-valued logprobs."""
     for instance_stats in per_instance_stats.values():
         for stat in instance_stats:
-            if stat.name == "logprob" and stat.sum < 0:
+            if stat.name.name == "logprob" and stat.sum < 0:
                 return True
     return False
 
@@ -844,6 +844,7 @@ def compute_calibration_metrics(per_instance_stats: Dict[Instance, List[Stat]]) 
     # If the model does not produce non-zero-valued logprobs
     # then don't compute calibration metrics.
     if not _has_non_zero_valued_logprobs(per_instance_stats):
+        hlog("Skipping computing calibration metrics because logprobs were not available.")
         return []
 
     for instance_stats in per_instance_stats.values():


### PR DESCRIPTION
This fixes a bug that skipped computing calibration metrics for all runs due to incorrect metric name matching.