### PR TITLE
Updated pinned transitive dependencies for SpaCy upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -94,7 +94,7 @@ pandas==1.5.0
 pandas-stubs==1.5.0.221003
 parameterized==0.8.1
 pathspec==0.10.1
-pathy==0.6.2
+pathy==0.10.2
 Pillow==9.3.0
 platformdirs==2.5.2
 pluggy==1.0.0
@@ -144,8 +144,8 @@ smart-open==5.2.1
 sniffio==1.3.0
 sortedcontainers==2.4.0
 soupsieve==2.3.2.post1
-spacy==3.2.4
-spacy-legacy==3.0.10
+spacy==3.5.4
+spacy-legacy==3.0.12
 spacy-loggers==1.0.3
 sqlitedict==1.7.0
 srsly==2.4.4
@@ -154,7 +154,7 @@ summ-eval==0.892
 surge-api==1.1.0
 sympy==1.11.1
 tabulate==0.9.0
-thinc==8.0.17
+thinc==8.1.12
 threadpoolctl==3.1.0
 tiktoken==0.3.3
 tls-client==0.1.8


### PR DESCRIPTION
SpaCy was upgraded in #1617, so we need to update the pinned dependencies too.