### PR TITLE
Annotate tqdm type in compute_request_limits

### DIFF
--- a/scripts/compute_request_limits.py
+++ b/scripts/compute_request_limits.py
@@ -90,6 +90,7 @@ def figure_out_max_prompt_length(
 
     # Perform a binary search to find the max tokens between lower_bound and upper_bound
     lower_bound += num_tokens_prefix + num_tokens_suffix
+    pbar: tqdm
     with tqdm(total=int(math.log2(upper_bound - lower_bound))) as pbar:
         while lower_bound < upper_bound:
             middle = math.ceil((lower_bound + upper_bound) / 2)
@@ -142,6 +143,7 @@ def figure_out_max_prompt_length_plus_tokens(
         print("The model has a limit on the number of tokens")
 
     # Perform a binary search to find the max tokens between lower_bound and upper_bound
+    pbar: tqdm
     with tqdm(total=int(math.log2(upper_bound - lower_bound))) as pbar:
         while lower_bound < upper_bound:
             middle = math.ceil((lower_bound + upper_bound) / 2)


### PR DESCRIPTION
For some reason, mypy is failing to correctly infer these types when I run mypy locally, but GitHub Action's mypy does not have this issue. I spent a while investigating and couldn't figure out what the difference was between the two environments, so I instead added type annotations to make my local mypy happy.

For the record, my local mypy was failing with:

```
scripts/compute_request_limits.py:100: error: Self? has no attribute "update"
scripts/compute_request_limits.py:154: error: Self? has no attribute "update"
```