### PR TITLE
Add MaxEvalInstancesRunExpander

### DIFF
--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -48,7 +48,7 @@ def run_entries_to_run_specs(
 
             # Modify AdapterSpec
             adapter_spec: AdapterSpec = run_spec.adapter_spec
-            if max_eval_instances is not None:
+            if max_eval_instances is not None and adapter_spec.max_eval_instances is None:
                 adapter_spec = replace(adapter_spec, max_eval_instances=max_eval_instances)
             if num_train_trials is not None or adapter_spec.max_train_instances == 0:
                 adapter_spec = replace(

--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import replace
-from typing import List, Dict, Optional, Tuple, Type
+from typing import Any, List, Dict, Optional, Tuple, Type
 
 from helm.proxy.models import (
     get_all_instruction_following_models,
@@ -334,6 +334,13 @@ class MaxTrainInstancesRunExpander(ReplaceValueRunExpander):
         "all": [0, 1, 2, 4, 8, 16],  # Cap at 16 due to limited context length
         "big_bench_few_shot_setting": [0, 1, 2, 3],  # Commonly used few-shot setting in BIG-bench
     }
+
+
+class MaxEvalInstancesRunExpander(ReplaceValueRunExpander):
+    """For overriding the number of eval instances at the run level."""
+
+    name = "max_eval_instances"
+    values_dict: Dict[str, List[Any]] = {}
 
 
 class NumOutputsRunExpander(ReplaceValueRunExpander):
@@ -1047,6 +1054,7 @@ RUN_EXPANDER_SUBCLASSES: List[Type[RunExpander]] = [
     GlobalPrefixRunExpander,
     NumTrainTrialsRunExpander,
     MaxTrainInstancesRunExpander,
+    MaxEvalInstancesRunExpander,
     NumOutputsRunExpander,
     ModelRunExpander,
     DataAugmentationRunExpander,


### PR DESCRIPTION
This can be used to overriding the number of eval instances at the run level e.g. `mmlu:subject=anatomy,model=simple/model1,max_eval_instances=20`