### PR TITLE
multiprocess http eval

### DIFF
--- a/src/helm/proxy/clients/http_model_client.py
+++ b/src/helm/proxy/clients/http_model_client.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import asdict
 from typing import Optional
 
@@ -32,7 +33,7 @@ class HTTPModelClient(Client):
         do_cache: bool = False,
     ):
         self.cache: Optional[Cache] = Cache(cache_config) if do_cache else None
-        self.base_url = base_url
+        self.base_url = base_url if not os.environ["HELM_BASE_URL"] else os.environ['HELM_BASE_URL']
         self.timeout = timeout
 
     def make_request(self, request: Request) -> RequestResult:

--- a/src/helm/proxy/clients/http_model_client.py
+++ b/src/helm/proxy/clients/http_model_client.py
@@ -33,7 +33,9 @@ class HTTPModelClient(Client):
         do_cache: bool = False,
     ):
         self.cache: Optional[Cache] = Cache(cache_config) if do_cache else None
-        self.base_url = base_url if not os.environ["HELM_HTTP_MODEL_BASE_URL"] else os.environ["HELM_HTTP_MODEL_BASE_URL"]
+        self.base_url = (
+            base_url if not os.environ["HELM_HTTP_MODEL_BASE_URL"] else os.environ["HELM_HTTP_MODEL_BASE_URL"]
+        )
         self.timeout = timeout
 
     def make_request(self, request: Request) -> RequestResult:

--- a/src/helm/proxy/clients/http_model_client.py
+++ b/src/helm/proxy/clients/http_model_client.py
@@ -33,7 +33,7 @@ class HTTPModelClient(Client):
         do_cache: bool = False,
     ):
         self.cache: Optional[Cache] = Cache(cache_config) if do_cache else None
-        self.base_url = base_url if not os.environ["HELM_BASE_URL"] else os.environ['HELM_BASE_URL']
+        self.base_url = base_url if not os.environ["HELM_BASE_URL"] else os.environ["HELM_BASE_URL"]
         self.timeout = timeout
 
     def make_request(self, request: Request) -> RequestResult:

--- a/src/helm/proxy/clients/http_model_client.py
+++ b/src/helm/proxy/clients/http_model_client.py
@@ -33,7 +33,7 @@ class HTTPModelClient(Client):
         do_cache: bool = False,
     ):
         self.cache: Optional[Cache] = Cache(cache_config) if do_cache else None
-        self.base_url = base_url if not os.environ["HELM_BASE_URL"] else os.environ["HELM_BASE_URL"]
+        self.base_url = base_url if not os.environ["HELM_HTTP_MODEL_BASE_URL"] else os.environ["HELM_HTTP_MODEL_BASE_URL"]
         self.timeout = timeout
 
     def make_request(self, request: Request) -> RequestResult:


### PR DESCRIPTION
goal is to support a workflow like `HELM_HTTP_MODEL_BASE_URL=… helm-run …` so we can run multiples processes of helm run concurrently each on different ports

if there's an easier way to do this lmk but iirc for timeout for example we had to update helm source code