### PR TITLE
Fix typing errors detected by a newer version of mypy

### DIFF
--- a/scripts/data_overlap/load_documents.py
+++ b/scripts/data_overlap/load_documents.py
@@ -136,4 +136,4 @@ def get_raw_document_iterator(file_path: str) -> Iterator[str]:
 
 def get_custom_document_iterator(file_path: str) -> Iterator[str]:
     """Define your own document reading method"""
-    pass
+    raise NotImplementedError()

--- a/setup.cfg
+++ b/setup.cfg
@@ -137,6 +137,10 @@ ignore = E203,E231,E731,W503,W605
 # Settings for Mypy: static type checker for Python 3
 [mypy]
 ignore_missing_imports = True
+# TODO(#1831): Change this to True
+check_untyped_defs = False
+# TODO(#1831): Change this to True
+disallow_untyped_defs = False
 
 [tool:pytest]
 addopts =

--- a/src/helm/benchmark/augmentations/contrast_sets_perturbation.py
+++ b/src/helm/benchmark/augmentations/contrast_sets_perturbation.py
@@ -83,4 +83,4 @@ class ContrastSetsPerturbation(Perturbation):
         )
 
     def perturb(self, text: str, rng: Random) -> str:  # we need this since parent method is abstract
-        pass
+        raise NotImplementedError("Should never be called since apply() was overridden")

--- a/src/helm/benchmark/augmentations/gender_perturbation.py
+++ b/src/helm/benchmark/augmentations/gender_perturbation.py
@@ -99,7 +99,7 @@ class GenderPerturbation(Perturbation):
         source_class: str,
         target_class: str,
         mapping_file_path: Optional[str] = None,
-        mapping_file_genders: List[str] = None,
+        mapping_file_genders: Optional[List[str]] = None,
         bidirectional: bool = False,
     ):
         """Initialize the gender perturbation.

--- a/src/helm/benchmark/augmentations/person_name_perturbation.py
+++ b/src/helm/benchmark/augmentations/person_name_perturbation.py
@@ -1,4 +1,3 @@
-import abc
 import os
 import re
 from collections import defaultdict
@@ -263,7 +262,6 @@ class PersonNamePerturbation(Perturbation):
         name = rng.choice(list(options))
         return name
 
-    @abc.abstractmethod
     def perturb(self, text: str, rng: Random) -> str:
         """
         Perturbing the text is handled in `perturb_with_persistency` to ensure that perturbed names

--- a/src/helm/benchmark/augmentations/person_name_perturbation.py
+++ b/src/helm/benchmark/augmentations/person_name_perturbation.py
@@ -1,3 +1,4 @@
+import abc
 import os
 import re
 from collections import defaultdict
@@ -262,6 +263,7 @@ class PersonNamePerturbation(Perturbation):
         name = rng.choice(list(options))
         return name
 
+    @abc.abstractmethod
     def perturb(self, text: str, rng: Random) -> str:
         """
         Perturbing the text is handled in `perturb_with_persistency` to ensure that perturbed names

--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -50,10 +50,12 @@ def run_entries_to_run_specs(
             adapter_spec: AdapterSpec = run_spec.adapter_spec
             if max_eval_instances is not None:
                 adapter_spec = replace(adapter_spec, max_eval_instances=max_eval_instances)
-            if num_train_trials is not None or adapter_spec.max_train_instances == 0:
-                adapter_spec = replace(
-                    adapter_spec, num_train_trials=1 if adapter_spec.max_train_instances == 0 else num_train_trials
-                )
+
+            if adapter_spec.max_train_instances == 0:
+                adapter_spec = replace(adapter_spec, num_train_trials=1)
+            elif num_train_trials is not None:
+                adapter_spec = replace(adapter_spec, num_train_trials=num_train_trials)
+
             run_spec = replace(run_spec, adapter_spec=adapter_spec)
 
             # Append groups

--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -90,7 +90,6 @@ class ReplaceRunSpecValueRunExpander(RunExpander):
             replace(
                 run_spec,
                 name=f"{run_spec.name},{self.name}={sanitize(value)}",
-                metrics=value,
             )
             for value in self.values
         ]
@@ -523,7 +522,7 @@ def gender(
     source_class: str,
     target_class: str,
     mapping_file_path: Optional[str] = None,
-    mapping_file_genders: Tuple[str] = None,
+    mapping_file_genders: Optional[Tuple[str]] = None,
     bidirectional: bool = False,
 ) -> PerturbationSpec:
     return PerturbationSpec(

--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -67,34 +67,6 @@ class ReplaceValueRunExpander(RunExpander):
         ]
 
 
-class ReplaceRunSpecValueRunExpander(RunExpander):
-    """
-    Replace a single field (e.g., max_train_instances) with a list of values (e.g., 0, 1, 2).
-    """
-
-    def __init__(self, value):
-        """
-        `value` is either the actual value to use or a lookup into the values dict.
-        """
-        self.name = type(self).name
-        if value in type(self).values_dict:
-            self.values = type(self).values_dict[value]
-        else:
-            self.values = [value]
-
-    def expand(self, run_spec: RunSpec) -> List[RunSpec]:
-        def sanitize(value):
-            return str(value).replace("/", "_")
-
-        return [
-            replace(
-                run_spec,
-                name=f"{run_spec.name},{self.name}={sanitize(value)}",
-            )
-            for value in self.values
-        ]
-
-
 class InstructionsRunExpander(RunExpander):
     """
     Set the instructions of the prompt.

--- a/src/helm/common/cache.py
+++ b/src/helm/common/cache.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 import contextlib
 from dataclasses import dataclass
 import json
@@ -104,7 +104,7 @@ class WithFollowerCacheConfig(CacheConfig):
         return self.main.cache_stats_key
 
 
-class KeyValueStore(ABC, contextlib.AbstractContextManager):
+class KeyValueStore(contextlib.AbstractContextManager):
     """Key value store that persists writes."""
 
     @property

--- a/src/helm/proxy/clients/ai21_client.py
+++ b/src/helm/proxy/clients/ai21_client.py
@@ -129,7 +129,7 @@ class AI21Client(Client):
                 top_logprobs=top_logprobs,
             )
 
-        def parse_sequence(raw: Dict, first: bool, finish_reason: Dict = None) -> Sequence:
+        def parse_sequence(raw: Dict, first: bool, finish_reason: Optional[Dict] = None) -> Sequence:
             text = raw["text"]
             tokens = [parse_token(token, first and i == 0) for i, token in enumerate(raw["tokens"])]
             logprob = sum(token.logprob for token in tokens)

--- a/src/helm/proxy/services/service.py
+++ b/src/helm/proxy/services/service.py
@@ -108,6 +108,7 @@ class Service(ABC):
         """Get toxicity scores for a batch of text."""
         pass
 
+    @abstractmethod
     def make_critique_request(self, auth: Authentication, request: CritiqueRequest) -> CritiqueRequestResult:
         """Get responses to a critique request."""
         pass


### PR DESCRIPTION
Also remove `ReplaceRunSpecValueRunExpander`, which is unused (the correct class is `ReplaceValueRunExpander`)