### PR TITLE
prevent error with default localhost setting

### DIFF
--- a/src/helm/proxy/clients/http_model_client.py
+++ b/src/helm/proxy/clients/http_model_client.py
@@ -34,7 +34,7 @@ class HTTPModelClient(Client):
     ):
         self.cache: Optional[Cache] = Cache(cache_config) if do_cache else None
         self.base_url = (
-            base_url if not os.environ["HELM_HTTP_MODEL_BASE_URL"] else os.environ["HELM_HTTP_MODEL_BASE_URL"]
+            base_url if not os.environ.get("HELM_HTTP_MODEL_BASE_URL") else os.environ["HELM_HTTP_MODEL_BASE_URL"]
         )
         self.timeout = timeout
 


### PR DESCRIPTION
Current default runs will encounter error if user do not indicate the key. 