### PR TITLE
Allow multiple train instances samples per train trial

### DIFF
--- a/src/helm/benchmark/adaptation/adapter_spec.py
+++ b/src/helm/benchmark/adaptation/adapter_spec.py
@@ -91,3 +91,19 @@ class AdapterSpec:
     # If true, for instances with multiple correct reference, the gold answer should be considered
     # to be all of the correct references rather than any of the correct references.
     multi_label: bool = False
+
+    # EXPERIMENTAL: This controls how the train instances for in-context learning are sampled.
+    #
+    # When `num_train_instances_samples` is set to a positive integer K, within each trial,
+    # the train instances for in-context learning are sampled K times.
+    # These K train instance samples are rotated round-robin for the eval instances e.g.
+    # train_instances_sample[0] is used for eval_instance[0], eval_instance[K], eval_instance[2 * K], ...
+    # train_instances_sample[1] is used for eval_instance[1], eval_instance[K + 1], eval_instance[2 * K + 1], ...
+    # train_instances_sample[2] is used for eval_instance[2], eval_instance[K + 2], eval_instance[2 * K + 2], ...
+    #
+    # When set to 1, the existing HELM default behavior is observed. Within a single trial, the train instances
+    # for in-context learning are sampled once. The same train instances are re-used for every eval instances.
+    #
+    # When set to >= `max_eval_instances`, the train instances for in-context learning are sampled once per eval
+    # instance.
+    num_train_instances_samples: int = 1

--- a/src/helm/benchmark/adaptation/adapters/adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/adapter.py
@@ -4,7 +4,6 @@ from typing import List
 import numpy as np
 
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
-from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.adaptation.scenario_state import ScenarioState
 from helm.benchmark.scenarios.scenario import Instance, TRAIN_SPLIT, EVAL_SPLITS
 from helm.benchmark.window_services.tokenizer_service import TokenizerService
@@ -30,13 +29,6 @@ class Adapter(ABC):
         """
         Takes a a list of `Instance`s and returns a `ScenarioState` with the
         list of corresponding `RequestState`s.
-        """
-        pass
-
-    @abstractmethod
-    def generate_requests(self, eval_instance: Instance) -> List[RequestState]:
-        """
-        Given a validation or test `Instance`, generates one or more `RequestState`s.
         """
         pass
 

--- a/src/helm/benchmark/adaptation/adapters/binary_ranking_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/binary_ranking_adapter.py
@@ -36,12 +36,12 @@ class BinaryRankingAdapter(InContextLearningAdapter):
     RANKING_CORRECT_LABEL: str = "Yes"
     RANKING_WRONG_LABEL: str = "No"
 
-    def generate_requests(self, eval_instance: Instance) -> List[RequestState]:
+    def generate_requests(self, train_instances: List[Instance], eval_instance: Instance) -> List[RequestState]:
         request_states = []
         request_mode = "original"
         for reference_index, reference in enumerate(eval_instance.references):
             prompt = self.construct_prompt(
-                self.train_instances,
+                train_instances,
                 eval_instance,
                 include_output=False,
                 reference_index=reference_index,

--- a/src/helm/benchmark/adaptation/adapters/generation_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/generation_adapter.py
@@ -31,9 +31,9 @@ class GenerationAdapter(InContextLearningAdapter):
         <input_prefix><input><output_prefix><output>
     """
 
-    def generate_requests(self, eval_instance: Instance) -> List[RequestState]:
+    def generate_requests(self, train_instances: List[Instance], eval_instance: Instance) -> List[RequestState]:
         prompt: Prompt = self.construct_prompt(
-            self.train_instances, eval_instance, include_output=False, reference_index=None
+            train_instances, eval_instance, include_output=False, reference_index=None
         )
         request = Request(
             model=self.adapter_spec.model,

--- a/src/helm/benchmark/adaptation/adapters/multiple_choice_calibrated_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/multiple_choice_calibrated_adapter.py
@@ -13,13 +13,13 @@ class MultipleChoiceCalibratedAdapter(MultipleChoiceSeparateAdapter):
     For more details, refer to Section 2.4 of the GPT-3 paper (https://arxiv.org/pdf/2005.14165.pdf).
     """
 
-    def generate_requests(self, eval_instance: Instance) -> List[RequestState]:
+    def generate_requests(self, train_instances: List[Instance], eval_instance: Instance) -> List[RequestState]:
         request_states: List[RequestState] = []
 
         for reference_index, reference in enumerate(eval_instance.references):
             # original
             prompt = self.construct_prompt(
-                self.train_instances,
+                train_instances,
                 eval_instance,
                 include_output=True,
                 reference_index=reference_index,

--- a/src/helm/benchmark/adaptation/adapters/multiple_choice_joint_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/multiple_choice_joint_adapter.py
@@ -45,8 +45,8 @@ class MultipleChoiceJointAdapter(InContextLearningAdapter):
         """
         return prefix.replace("A", chr(ord("A") + i))
 
-    def generate_requests(self, eval_instance: Instance) -> List[RequestState]:
-        prompt = self.construct_prompt(self.train_instances, eval_instance, include_output=False, reference_index=None)
+    def generate_requests(self, train_instances: List[Instance], eval_instance: Instance) -> List[RequestState]:
+        prompt = self.construct_prompt(train_instances, eval_instance, include_output=False, reference_index=None)
         output_mapping: Dict[str, str] = dict(
             (self.get_reference_prefix("A", reference_index), reference.output.text)
             for reference_index, reference in enumerate(eval_instance.references)

--- a/src/helm/benchmark/adaptation/adapters/multiple_choice_separate_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/multiple_choice_separate_adapter.py
@@ -13,12 +13,12 @@ class MultipleChoiceSeparateAdapter(InContextLearningAdapter):
     the sentence probability normalized by the sentence length.
     """
 
-    def generate_requests(self, eval_instance: Instance) -> List[RequestState]:
+    def generate_requests(self, train_instances: List[Instance], eval_instance: Instance) -> List[RequestState]:
         request_states: List[RequestState] = []
 
         for reference_index, reference in enumerate(eval_instance.references):
             prompt = self.construct_prompt(
-                self.train_instances,
+                train_instances,
                 eval_instance,
                 include_output=True,
                 reference_index=reference_index,

--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -311,6 +311,13 @@ class FormatPromptRunExpander(RunExpander):
         ]
 
 
+class NumTrainInstancesSamplesRunExpander(ReplaceValueRunExpander):
+    """For overriding `num_train_instances_samples`."""
+
+    name = "num_train_instances_samples"
+    values_dict: Dict[str, List[str]] = {}
+
+
 class NumTrainTrialsRunExpander(ReplaceValueRunExpander):
     """For estimating variance across runs."""
 
@@ -1045,6 +1052,7 @@ RUN_EXPANDER_SUBCLASSES: List[Type[RunExpander]] = [
     FormatPromptRunExpander,
     AddToStopRunExpander,
     GlobalPrefixRunExpander,
+    NumTrainInstancesSamplesRunExpander,
     NumTrainTrialsRunExpander,
     MaxTrainInstancesRunExpander,
     NumOutputsRunExpander,


### PR DESCRIPTION
When `num_train_instances_samples` is set to a positive integer K, within each trial, the train instances for in-context learning are sampled K times. These K train instance samples are rotated round-robin for the eval instances e.g.

`train_instances_sample[0]` is used for `eval_instance[0]`, `eval_instance[K]`, `eval_instance[2 * K]`, ...
`train_instances_sample[1]` is used for `eval_instance[1]`, `eval_instance[K + 1]`, `eval_instance[2 * K + 1]`, ...
`train_instances_sample[2]` is used for `eval_instance[2]`, `eval_instance[K + 2]`, `eval_instance[2 * K + 2]`, ...

When set to 1, the existing HELM default behavior is observed. Within a single trial, the train instances for in-context learning are sampled once. The same train instances are re-used for every eval instances.

When set to  `max_eval_instances`, the train instances for in-context learning are sampled once per eval instance.

Example 1: Run 100 eval instances; divide the eval instances into 5 subsets of 20 eval instances; use a different sample of train instances for each subset.
```
helm-run --run-specs boolq:model=simple/model1,num_train_instances_samples=5 --max-eval-instances 100 --suite efficient-helm
```

Example 2: Run 100 eval instances, using a different sample of train instances for each eval instance.
```
helm-run --run-specs boolq:model=simple/model1,num_train_instances_samples=100 --max-eval-instances 100 --suite efficient-helm
```
