### PR TITLE
Configurable models for NeurIPS Efficiency Challenge

### DIFF
--- a/src/helm/benchmark/model_deployment_registry.py
+++ b/src/helm/benchmark/model_deployment_registry.py
@@ -41,7 +41,7 @@ class ModelDeployment:
     tokenizer_name: Optional[str] = None
     """Tokenizer for this model deployment.
 
-    If unset, defaults to the same value as `model_name`."""
+    If unset, auto-inferred by the WindowService."""
 
     window_service_spec: Optional[WindowServiceSpec] = None
     """Specification for instantiating the window service for this model deplooyment"""

--- a/src/helm/benchmark/model_deployment_registry.py
+++ b/src/helm/benchmark/model_deployment_registry.py
@@ -1,3 +1,4 @@
+import os
 from typing import Dict, Optional, List
 from dataclasses import dataclass
 
@@ -6,9 +7,17 @@ import yaml
 
 from helm.common.hierarchical_logger import hlog
 from helm.common.object_spec import ObjectSpec
+from helm.proxy.models import ALL_MODELS, FULL_FUNCTIONALITY_TEXT_MODEL_TAG, MODEL_NAME_TO_MODEL, TEXT_MODEL_TAG, Model
+
+
+MODEL_DEPLOYMENTS_FILE = "model_deployments.yaml"
 
 
 class ClientSpec(ObjectSpec):
+    pass
+
+
+class WindowServiceSpec(ObjectSpec):
     pass
 
 
@@ -16,22 +25,34 @@ class ClientSpec(ObjectSpec):
 class ModelDeployment:
     """A model deployment is an accessible instance of this model (e.g. a hosted endpoint).
 
-    A model can have model deployments."""
+    A model can have multiple model deployments."""
 
     name: str
     """Name of the model deployment."""
 
-    model_name: str
-    """Name of the model that this model deployment is for."""
-
     client_spec: ClientSpec
     """Specification for instantiating the client for this model deployment."""
 
-    max_sequence_length: Optional[int]
-    """Maximum equence length for this model deployment."""
+    model_name: Optional[str] = None
+    """Name of the model that this model deployment is for.
 
-    tokenizer_name: Optional[str]
-    """Tokenizer for this model deployment."""
+    If unset, defaults to the the same value as `name`."""
+
+    tokenizer_name: Optional[str] = None
+    """Tokenizer for this model deployment.
+
+    If unset, defaults to the same value as `model_name`."""
+
+    window_service_spec: Optional[WindowServiceSpec] = None
+    """Specification for instantiating the window service for this model deplooyment"""
+
+    max_sequence_length: Optional[int] = None
+    """Maximum sequence length for this model deployment."""
+
+    max_request_length: Optional[int] = None
+    """Maximum request length for this model deployment.
+
+    If unset, defaults to the same value as max_sequence_length."""
 
 
 @dataclass(frozen=True)
@@ -49,7 +70,26 @@ def register_model_deployments_from_path(path: str) -> None:
         raw = yaml.safe_load(f)
     model_deployments: ModelDeployments = cattrs.structure(raw, ModelDeployments)
     for model_deployment in model_deployments.model_deployments:
+        hlog(f"Registered model deployment {model_deployment.name}")
         _name_to_model_deployment[model_deployment.name] = model_deployment
+
+    # Auto-register a model with this name if none exists
+    model_name = model_deployment.model_name or model_deployment.name
+
+    model = Model(
+        group="unknown",
+        name=model_name,
+        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
+    )
+    MODEL_NAME_TO_MODEL[model_name] = model
+    ALL_MODELS.append(model)
+    hlog(f"Registering model {model_name} with default metadata")
+
+
+def maybe_register_model_deployments_from_base_path(base_path: str) -> None:
+    path = os.path.join(base_path, MODEL_DEPLOYMENTS_FILE)
+    if os.path.exists(path):
+        register_model_deployments_from_path(path)
 
 
 def get_model_deployment(name: str) -> Optional[ModelDeployment]:

--- a/src/helm/benchmark/model_deployment_registry.py
+++ b/src/helm/benchmark/model_deployment_registry.py
@@ -87,6 +87,7 @@ def register_model_deployments_from_path(path: str) -> None:
 
 
 def maybe_register_model_deployments_from_base_path(base_path: str) -> None:
+    """Register model deployments from prod_env/model_deployments.yaml"""
     path = os.path.join(base_path, MODEL_DEPLOYMENTS_FILE)
     if os.path.exists(path):
         register_model_deployments_from_path(path)

--- a/src/helm/benchmark/model_deployment_registry.py
+++ b/src/helm/benchmark/model_deployment_registry.py
@@ -73,17 +73,17 @@ def register_model_deployments_from_path(path: str) -> None:
         hlog(f"Registered model deployment {model_deployment.name}")
         _name_to_model_deployment[model_deployment.name] = model_deployment
 
-    # Auto-register a model with this name if none exists
-    model_name = model_deployment.model_name or model_deployment.name
-
-    model = Model(
-        group="unknown",
-        name=model_name,
-        tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
-    )
-    MODEL_NAME_TO_MODEL[model_name] = model
-    ALL_MODELS.append(model)
-    hlog(f"Registering model {model_name} with default metadata")
+        # Auto-register a model with this name if none exists
+        model_name = model_deployment.model_name or model_deployment.name
+        if model_name not in MODEL_NAME_TO_MODEL:
+            model = Model(
+                group="none",
+                name=model_name,
+                tags=[TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG],
+            )
+            MODEL_NAME_TO_MODEL[model_name] = model
+            ALL_MODELS.append(model)
+            hlog(f"Registered default metadata for model {model_name}")
 
 
 def maybe_register_model_deployments_from_base_path(base_path: str) -> None:

--- a/src/helm/benchmark/model_metadata_registry.py
+++ b/src/helm/benchmark/model_metadata_registry.py
@@ -65,6 +65,7 @@ def register_model_metadata_from_path(path: str) -> None:
 
 
 def maybe_register_model_metadata_from_base_path(base_path: str) -> None:
+    """Register model metadata from prod_env/model_metadata.yaml"""
     path = os.path.join(base_path, MODEL_METADATA_FILE)
     if os.path.exists(path):
         register_model_metadata_from_path(path)

--- a/src/helm/benchmark/model_metadata_registry.py
+++ b/src/helm/benchmark/model_metadata_registry.py
@@ -56,7 +56,7 @@ def register_model_metadata_from_path(path: str) -> None:
     model_metadata_list = dacite.from_dict(ModelMetadataList, raw)
     for model_metadata in model_metadata_list.models:
         model = Model(
-            group="unknown",  # TODO: group should be part of model deployment, not model
+            group="none",  # TODO: group should be part of model deployment, not model
             name=model_metadata.name,
             tags=model_metadata.tags,
         )

--- a/src/helm/benchmark/model_metadata_registry.py
+++ b/src/helm/benchmark/model_metadata_registry.py
@@ -56,7 +56,7 @@ def register_model_metadata_from_path(path: str) -> None:
     model_metadata_list = dacite.from_dict(ModelMetadataList, raw)
     for model_metadata in model_metadata_list.models:
         model = Model(
-            group="none",  # TODO: group should be part of model deployment, not model
+            group="none",  # TODO: Group should be part of model deployment, not model
             name=model_metadata.name,
             tags=model_metadata.tags,
         )

--- a/src/helm/benchmark/model_metadata_registry.py
+++ b/src/helm/benchmark/model_metadata_registry.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional, List
 from dataclasses import dataclass, field
 from datetime import date
@@ -6,6 +7,9 @@ import dacite
 import yaml
 
 from helm.proxy.models import ALL_MODELS, MODEL_NAME_TO_MODEL, Model
+
+
+MODEL_METADATA_FILE = "model_metadata.yaml"
 
 
 @dataclass(frozen=True)
@@ -52,9 +56,15 @@ def register_model_metadata_from_path(path: str) -> None:
     model_metadata_list = dacite.from_dict(ModelMetadataList, raw)
     for model_metadata in model_metadata_list.models:
         model = Model(
-            group="none",  # TODO: Group should be part of model deployment, not model
+            group="unknown",  # TODO: group should be part of model deployment, not model
             name=model_metadata.name,
             tags=model_metadata.tags,
         )
         MODEL_NAME_TO_MODEL[model_metadata.name] = model
         ALL_MODELS.append(model)
+
+
+def maybe_register_model_metadata_from_base_path(base_path: str) -> None:
+    path = os.path.join(base_path, MODEL_METADATA_FILE)
+    if os.path.exists(path):
+        register_model_metadata_from_path(path)

--- a/src/helm/benchmark/run_specs.py
+++ b/src/helm/benchmark/run_specs.py
@@ -2516,7 +2516,13 @@ def construct_run_specs(spec: ObjectSpec) -> List[RunSpec]:
         ]
 
     def alter_run_spec(run_spec: RunSpec) -> RunSpec:
-        model = get_model(run_spec.adapter_spec.model)
+        try:
+            model = get_model(run_spec.adapter_spec.model)
+        except ValueError:
+            # Models registered from configs cannot have expanders applied to them,
+            # because the models will not have been registered yet at this point.
+            # TODO: Figure out a cleaner way to deal with this.
+            return run_spec
         # For models that strip newlines, when we're generating, we need to set
         # the delimiter to be '###' so we stop properly.
         if NO_NEWLINES_TAG in model.tags and run_spec.adapter_spec.method in (

--- a/src/helm/benchmark/tokenizer_config_registry.py
+++ b/src/helm/benchmark/tokenizer_config_registry.py
@@ -1,0 +1,57 @@
+import os
+from typing import Dict, Optional, List
+from dataclasses import dataclass
+
+import cattrs
+import yaml
+
+from helm.common.hierarchical_logger import hlog
+from helm.common.object_spec import ObjectSpec
+
+
+TOKENIEZR_CONFIGS_FILE = "tokenizer_configs.yaml"
+
+
+class TokenizerSpec(ObjectSpec):
+    pass
+
+
+@dataclass(frozen=True)
+class TokenizerConfig:
+    """Configuration for a tokenizer."""
+
+    name: str
+    """Name of the tokenizer."""
+
+    tokenizer_spec: TokenizerSpec
+    """Specification for instantiating the client for this tokenizer."""
+
+    # TODO: Add `end_of_text_token`` and `prefix_token``
+
+
+@dataclass(frozen=True)
+class TokenizerConfigs:
+    tokenizers: List[TokenizerConfig]
+
+
+_name_to_tokenizer_config: Dict[str, TokenizerConfig] = {}
+
+
+def register_tokenizer_configs_from_path(path: str) -> None:
+    global _name_to_tokenizer_config
+    hlog(f"Reading tokenizer configs from {path}...")
+    with open(path, "r") as f:
+        raw = yaml.safe_load(f)
+    tokenizer_configs: TokenizerConfigs = cattrs.structure(raw, TokenizerConfigs)
+    for tokenizer_config in tokenizer_configs.tokenizers:
+        _name_to_tokenizer_config[tokenizer_config.name] = tokenizer_config
+
+
+def maybe_register_tokenizer_configs_from_base_path(base_path: str) -> None:
+    path = os.path.join(base_path, TOKENIEZR_CONFIGS_FILE)
+    if os.path.exists(path):
+        register_tokenizer_configs_from_path(path)
+
+
+def get_tokenizer_config(name: str) -> Optional[TokenizerConfig]:
+    return _name_to_tokenizer_config.get(name)

--- a/src/helm/benchmark/tokenizer_config_registry.py
+++ b/src/helm/benchmark/tokenizer_config_registry.py
@@ -31,7 +31,7 @@ class TokenizerConfig:
 
 @dataclass(frozen=True)
 class TokenizerConfigs:
-    tokenizers: List[TokenizerConfig]
+    tokenizer_configs: List[TokenizerConfig]
 
 
 _name_to_tokenizer_config: Dict[str, TokenizerConfig] = {}

--- a/src/helm/benchmark/tokenizer_config_registry.py
+++ b/src/helm/benchmark/tokenizer_config_registry.py
@@ -43,7 +43,7 @@ def register_tokenizer_configs_from_path(path: str) -> None:
     with open(path, "r") as f:
         raw = yaml.safe_load(f)
     tokenizer_configs: TokenizerConfigs = cattrs.structure(raw, TokenizerConfigs)
-    for tokenizer_config in tokenizer_configs.tokenizers:
+    for tokenizer_config in tokenizer_configs.tokenizer_configs:
         _name_to_tokenizer_config[tokenizer_config.name] = tokenizer_config
 
 

--- a/src/helm/benchmark/window_services/default_window_service.py
+++ b/src/helm/benchmark/window_services/default_window_service.py
@@ -1,0 +1,39 @@
+from typing import Optional
+from .local_window_service import LocalWindowService
+from .tokenizer_service import TokenizerService
+
+
+class DefaultWindowService(LocalWindowService):
+    def __init__(
+        self,
+        service: TokenizerService,
+        tokenizer_name: str,
+        max_sequence_length: int,
+        max_request_length: Optional[int] = None,
+    ):
+        super().__init__(service)
+        self._tokenizer_name = tokenizer_name
+        self._max_sequence_length = max_sequence_length
+        self._max_request_length = max_request_length
+
+    @property
+    def max_sequence_length(self) -> int:
+        return self._max_sequence_length
+
+    @property
+    def max_request_length(self) -> int:
+        return self._max_request_length or self._max_sequence_length
+
+    @property
+    def end_of_text_token(self) -> str:
+        # TODO: Support this
+        return ""
+
+    @property
+    def tokenizer_name(self) -> str:
+        return self._tokenizer_name
+
+    @property
+    def prefix_token(self) -> str:
+        # TODO: Support this
+        return ""

--- a/src/helm/benchmark/window_services/huggingface_window_service.py
+++ b/src/helm/benchmark/window_services/huggingface_window_service.py
@@ -2,15 +2,18 @@ from typing import Optional
 from helm.proxy.clients.huggingface_tokenizer import HuggingFaceTokenizers
 from .local_window_service import LocalWindowService
 from .tokenizer_service import TokenizerService
-from helm.proxy.clients.huggingface_client import HuggingFaceModelConfig
 
 
 class HuggingFaceWindowService(LocalWindowService):
     def __init__(
-        self, service: TokenizerService, model_config: HuggingFaceModelConfig, max_sequence_length: Optional[int] = None
+        self,
+        service: TokenizerService,
+        tokenizer_name: str,
+        max_sequence_length: Optional[int] = None,
+        max_reqeust_length: Optional[int] = None,
     ):
         super().__init__(service)
-        self._tokenizer_name = model_config.model_id
+        self._tokenizer_name = tokenizer_name
         tokenizer = HuggingFaceTokenizers.get_tokenizer(self._tokenizer_name)
         self._prefix_token = tokenizer.bos_token
         self._end_of_text_token = tokenizer.eos_token
@@ -22,6 +25,7 @@ class HuggingFaceWindowService(LocalWindowService):
             self._max_sequence_length = max_sequence_length
         else:
             self._max_sequence_length = tokenizer.model_max_length
+        self._max_request_length = max_reqeust_length
 
     @property
     def max_sequence_length(self) -> int:
@@ -31,7 +35,7 @@ class HuggingFaceWindowService(LocalWindowService):
     @property
     def max_request_length(self) -> int:
         """Return the max request length of this tokenizer."""
-        return self.max_sequence_length
+        return self._max_request_length or self._max_sequence_length
 
     @property
     def end_of_text_token(self) -> str:

--- a/src/helm/benchmark/window_services/llama_window_service.py
+++ b/src/helm/benchmark/window_services/llama_window_service.py
@@ -1,4 +1,3 @@
-from helm.proxy.clients.huggingface_client import HuggingFaceHubModelConfig
 from helm.benchmark.window_services.huggingface_window_service import HuggingFaceWindowService
 from helm.benchmark.window_services.tokenizer_service import TokenizerService
 
@@ -7,10 +6,7 @@ class LlamaWindowService(HuggingFaceWindowService):
     def __init__(self, service: TokenizerService):
         # Tokenizer name hf-internal-testing/llama-tokenizer is taken from:
         # https://huggingface.co/docs/transformers/main/en/model_doc/llama#transformers.LlamaTokenizerFast.example
-        model_config = HuggingFaceHubModelConfig(
-            namespace="hf-internal-testing", model_name="llama-tokenizer", revision=None
-        )
-        super().__init__(service, model_config)
+        super().__init__(service, "hf-internal-testing/llama-tokenizer")
 
 
 class Llama2WindowService(HuggingFaceWindowService):
@@ -25,8 +21,7 @@ class Llama2WindowService(HuggingFaceWindowService):
     #     meta-llama/Llama-2-70b-hf is not a local folder and is not a valid model identifier listed on
     #     'https://huggingface.co/models'
     def __init__(self, service: TokenizerService):
-        model_config = HuggingFaceHubModelConfig(namespace="meta-llama", model_name="Llama-2-7b-hf", revision=None)
-        super().__init__(service, model_config)
+        super().__init__(service, "meta-llama/Llama-2-7b-hf")
 
     @property
     def max_sequence_length(self) -> int:

--- a/src/helm/benchmark/window_services/window_service_factory.py
+++ b/src/helm/benchmark/window_services/window_service_factory.py
@@ -48,6 +48,13 @@ class WindowServiceFactory:
                 window_service_spec = WindowServiceSpec(
                     class_name="helm.benchmark.window_services.default_window_service.DefaultWindowService", args={}
                 )
+            # Perform dependency injection to fill in remaining arguments.
+            # Dependency injection is needed here for these reasons:
+            #
+            # 1. Different window services have different parameters. Dependency injection provides arguments
+            #    that match the parameters of the window services.
+            # 2. Some arguments, such as the tokenizer service, are not static data objects that can be
+            #    in the users configuration file. Instead, they have to be constructed dynamically at runtime.
             window_service_spec = inject_object_spec_args(
                 window_service_spec,
                 {

--- a/src/helm/benchmark/window_services/window_service_factory.py
+++ b/src/helm/benchmark/window_services/window_service_factory.py
@@ -1,5 +1,4 @@
 from helm.benchmark.model_deployment_registry import WindowServiceSpec, get_model_deployment
-from helm.proxy.clients.huggingface_model_registry import HuggingFaceHubModelConfig
 from helm.proxy.models import (
     get_model,
     get_model_names_with_tag,
@@ -66,7 +65,7 @@ class WindowServiceFactory:
 
             window_service = HTTPModelWindowServce(service)
         elif huggingface_model_config:
-            window_service = HuggingFaceWindowService(service=service, model_config=huggingface_model_config)
+            window_service = HuggingFaceWindowService(service=service, tokenizer_name=huggingface_model_config.model_id)
         elif organization == "openai":
             from helm.benchmark.window_services.openai_window_service import OpenAIWindowService
             from helm.benchmark.window_services.wider_openai_window_service import (
@@ -197,10 +196,7 @@ class WindowServiceFactory:
             "tiiuae/falcon-40b",
             "tiiuae/falcon-40b-instruct",
         ]:
-            window_service = HuggingFaceWindowService(
-                service=service,
-                model_config=HuggingFaceHubModelConfig(namespace="tiiuae", model_name="falcon-7b", revision=None),
-            )
+            window_service = HuggingFaceWindowService(service=service, tokenizer_name="tiiuae/falcon-7b")
         elif model_name in [
             "stabilityai/stablelm-base-alpha-3b",
             "stabilityai/stablelm-base-alpha-7b",

--- a/src/helm/common/object_spec.py
+++ b/src/helm/common/object_spec.py
@@ -52,7 +52,18 @@ def inject_object_spec_args(
     If found in constant_bindings, add the corresponding value to args.
     If found in provider_bindings, call the corresponding value and add the return values to args.
 
-    This is loosely based on instance (constant) bindings and provider bindings in Guice dependency injection."""
+    This is loosely based on instance (constant) bindings and provider bindings in Guice dependency injection.
+
+    Example:
+
+    class MyClass:
+        def __init__(a: int, b: int, c: int, d: int = 0):
+            pass
+
+    old_object_spec = ObjectSpec(class_name="MyClass", args={"a": 11})
+    new_object_spec = inject_object_spec_args(old_object_spec, {"b": 12}, {"c": lambda: 13})
+    # new_object_spec is now ObjectSpec(class_name="MyClass", args={"a": 11, "b": 12, "c": 13})
+    """
     cls = get_class_by_name(spec.class_name)
     init_signature = inspect.signature(cls.__init__)
     args = {}

--- a/src/helm/common/object_spec.py
+++ b/src/helm/common/object_spec.py
@@ -52,7 +52,7 @@ def inject_object_spec_args(
     If found in constant_bindings, add the corresponding value to args.
     If found in provider_bindings, call the corresponding value and add the return values to args.
 
-    This is loosely based on instances (constant) bindings and provider bindings in Guice dependency injection."""
+    This is loosely based on instance (constant) bindings and provider bindings in Guice dependency injection."""
     cls = get_class_by_name(spec.class_name)
     init_signature = inspect.signature(cls.__init__)
     args = {}
@@ -72,7 +72,6 @@ def create_object(spec: ObjectSpec):
     cls = get_class_by_name(spec.class_name)
     args = {}
     args.update(spec.args)
-    print(cls)
     return cls(**args)
 
 

--- a/src/helm/common/object_spec.py
+++ b/src/helm/common/object_spec.py
@@ -1,6 +1,8 @@
 import importlib
+import dataclasses
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Tuple, Hashable, Type
+import inspect
+from typing import Any, Callable, Dict, Optional, Tuple, Hashable, Type, TypeVar
 
 
 @dataclass(frozen=True)
@@ -32,13 +34,45 @@ def get_class_by_name(full_class_name: str) -> Type[Any]:
     return getattr(importlib.import_module(module_name), class_name)
 
 
-def create_object(spec: ObjectSpec, additional_args: Optional[Dict[str, Any]] = None):
+ObjectSpecT = TypeVar("ObjectSpecT", bound=ObjectSpec)
+
+
+def inject_object_spec_args(
+    spec: ObjectSpecT,
+    constant_bindings: Optional[Dict[str, Any]] = None,
+    provider_bindings: Optional[Dict[str, Callable[[], Any]]] = None,
+) -> ObjectSpecT:
+    """Return a new ObjectSpec that is a copy of the original ObjectSpec with additional arguments.
+
+    The original ObjectSpec may be missing arguments for parameters that are required by the
+    ObjectSpec's class's constructor.
+    This function returns a new ObjectSpec with these missing parameter filled in.
+    To do this, for every missing parameter, check look up each of the `*_bindings` arguments in order until we
+    find one with a key matching the missing parameter's name.
+    If found in constant_bindings, add the corresponding value to args.
+    If found in provider_bindings, call the corresponding value and add the return values to args.
+
+    This is loosely based on instances (constant) bindings and provider bindings in Guice dependency injection."""
+    cls = get_class_by_name(spec.class_name)
+    init_signature = inspect.signature(cls.__init__)
+    args = {}
+    args.update(spec.args)
+    for parameter_name in init_signature.parameters.keys():
+        if parameter_name == "self" or parameter_name in args:
+            continue
+        elif constant_bindings and parameter_name in constant_bindings:
+            args[parameter_name] = constant_bindings[parameter_name]
+        elif provider_bindings and parameter_name in provider_bindings:
+            args[parameter_name] = provider_bindings[parameter_name]()
+    return dataclasses.replace(spec, args=args)
+
+
+def create_object(spec: ObjectSpec):
     """Create the actual object given the `spec`."""
     cls = get_class_by_name(spec.class_name)
     args = {}
     args.update(spec.args)
-    if additional_args:
-        args.update(additional_args)
+    print(cls)
     return cls(**args)
 
 

--- a/src/helm/proxy/clients/auto_client.py
+++ b/src/helm/proxy/clients/auto_client.py
@@ -71,7 +71,6 @@ class AutoClient(Client):
             # TODO: Migrate all clients to use model deployments
             model_deployment = get_model_deployment(model)
             if model_deployment:
-                api_key = None
 
                 def provide_api_key():
                     if "deployments" not in self.credentials:
@@ -94,6 +93,8 @@ class AutoClient(Client):
                 from helm.proxy.clients.huggingface_client import HuggingFaceClient
 
                 client = HuggingFaceClient(cache_config=cache_config)
+            elif organization == "neurips":
+                client = HTTPModelClient(cache_config=cache_config)
             elif organization == "openai":
                 from helm.proxy.clients.openai_client import OpenAIClient
 

--- a/src/helm/proxy/clients/auto_client.py
+++ b/src/helm/proxy/clients/auto_client.py
@@ -82,6 +82,18 @@ class AutoClient(Client):
                         )
                     return deployment_api_keys[model]
 
+                # Perform dependency injection to fill in remaining arguments.
+                # Dependency injection is needed here for these reasons:
+                #
+                # 1. Different clients have different parameters. Dependency injection provides arguments
+                #    that match the parameters of the client.
+                # 2. Some arguments, such as the tokenizer, are not static data objects that can be
+                #    in the users configuration file. Instead, they have to be constructed dynamically at
+                #    runtime.
+                # 3. The providers must be lazily-evaluated, because eager evaluation can result in an
+                #    exception. For instance, some clients do not require an API key, so trying to fetch
+                #    the API key from configuration eagerly will result in an exception because the user
+                #    will not have configured an API key.
                 client_spec = inject_object_spec_args(
                     model_deployment.client_spec,
                     constant_bindings={"cache_config": cache_config},

--- a/src/helm/proxy/clients/http_model_client.py
+++ b/src/helm/proxy/clients/http_model_client.py
@@ -123,7 +123,6 @@ class HTTPModelClient(Client):
     def decode(self, request: DecodeRequest) -> DecodeRequestResult:
         # raise NotImplementedError("Not implemented yet.")
         cache_key = asdict(request)
-
         try:
 
             def do_it():

--- a/src/helm/proxy/clients/http_model_client.py
+++ b/src/helm/proxy/clients/http_model_client.py
@@ -123,6 +123,7 @@ class HTTPModelClient(Client):
     def decode(self, request: DecodeRequest) -> DecodeRequestResult:
         # raise NotImplementedError("Not implemented yet.")
         cache_key = asdict(request)
+
         try:
 
             def do_it():

--- a/src/helm/proxy/services/server_service.py
+++ b/src/helm/proxy/services/server_service.py
@@ -2,7 +2,6 @@ import os
 import signal
 from typing import List, Optional
 
-
 from helm.benchmark.model_metadata_registry import maybe_register_model_metadata_from_base_path
 from helm.benchmark.model_deployment_registry import maybe_register_model_deployments_from_base_path
 from helm.benchmark.tokenizer_config_registry import maybe_register_tokenizer_configs_from_base_path

--- a/src/helm/proxy/services/server_service.py
+++ b/src/helm/proxy/services/server_service.py
@@ -2,6 +2,10 @@ import os
 import signal
 from typing import List, Optional
 
+
+from helm.benchmark.model_metadata_registry import maybe_register_model_metadata_from_base_path
+from helm.benchmark.model_deployment_registry import maybe_register_model_deployments_from_base_path
+from helm.benchmark.tokenizer_config_registry import maybe_register_tokenizer_configs_from_base_path
 from helm.common.critique_request import CritiqueRequest, CritiqueRequestResult
 from helm.common.authentication import Authentication
 from helm.common.general import ensure_directory_exists, parse_hocon, get_credentials
@@ -44,6 +48,10 @@ class ServerService(Service):
         cache_path = os.path.join(base_path, CACHE_DIR)
         ensure_directory_exists(cache_path)
         accounts_path = os.path.join(base_path, ACCOUNTS_FILE)
+
+        maybe_register_model_metadata_from_base_path(base_path)
+        maybe_register_model_deployments_from_base_path(base_path)
+        maybe_register_tokenizer_configs_from_base_path(base_path)
 
         self.client = AutoClient(credentials, cache_path, mongo_uri)
         self.token_counter = AutoTokenCounter(self.client.get_huggingface_client())


### PR DESCRIPTION
This supports running a model for NeurIPS Efficiency Challenge with a user-configurable model name, HTTP service URL, window service and tokenizer.

-----

For models that use a built-in `WindowService`:

`prod_env/model_deployments.yaml`:

```
model_deployments:
  - name: neurips/my-pythia-model
    window_service_spec:
      class_name: "helm.benchmark.window_services.gptneox_window_service.GPTNeoXWindowService"
      args: {}
    client_spec:
      class_name: "helm.proxy.clients.http_model_client.HTTPModelClient"
      args: {
        base_url: "http://localhost:2345"
      }
```

The following models are supported, with corresponding `class_name` inside `window_service_spec`:

- LLaMA: `helm.benchmark.window_services.llama_window_service.LlamaWindowService`
- Llama 2: `helm.benchmark.window_services.llama_window_service.Llama2WindowService`
- Red Pajama Base (not instruction tuned models): `helm.benchmark.window_services.gptneox_window_service.GPTNeoXWindowService`
- MPT: `helm.benchmark.window_services.gptneox_window_service.GPTNeoXWindowService`
- OPT: `helm.benchmark.window_services.opt_window_service.OPTWindowService`
- Bloom: `helm.benchmark.window_services.bloom_window_service.BloomWindowService`
- GPT Neo, J, NeoX, Pythia: `helm.benchmark.window_services.gptneox_window_service.GPTNeoXWindowService`
- GPT2: `helm.benchmark.window_services.gpt2_window_service.GPT2WindowService`
- T5 (not Flan-T5): `helm.benchmark.window_services.t511b_window_service.T511bWindowService`
- UL2: `helm.benchmark.window_services.ul2_window_serviceUL2WindowService`

-----

For models that use Hugging Face `AutoTokenizer`:

`prod_env/model_deployments.yaml`:

```
model_deployments:
  - name: neurips/my-falcon-7b-model
    tokenizer_name: "tiiuae/falcon-7b"
    sequence_length: 2048
    window_service_spec:
      class_name: "helm.benchmark.window_services.huggingface_window_service.HuggingFaceWindowService"
      args: {}
    client_spec:
      class_name: "helm.proxy.clients.http_model_client.HTTPModelClient"
      args: {
        base_url: "http://localhost:2345"
      }
```

Change `tokenizer_name` and `sequence_length` accordingly. Refer to the Hugging Face model card for the correct values.

If `sequence_length` is not set, it will be auto-inferred from Hugging Face Hub's `AutoTokenizer`, which can result in incorrect values because many Hugging Face Hub `AutoTokenizer`s have incorrect metadata.

The following models are supported, with corresponding `tokenizer_name`:

- Falcon: `tiiuae/falcon-7b`

-----

For any models not listed, you can fall back to the HTTP service tokenizer:

`prod_env/model_deployments.yaml`:

```
model_deployments:
  - name: neurips/my-model
    tokenizer_name: neurips/my-tokenizer
    max_sequence_length: 2048
    client_spec:
      class_name: "helm.proxy.clients.http_model_client.HTTPModelClient"
      args: {
        base_url: "http://localhost:2345"
      }
```

`prod_env/tokenizer_configs.yaml`:

```
tokenizer_configs:
  - name: neurips/my-tokenizer
    tokenizer_spec:
      class_name: "helm.proxy.clients.http_model_client.HTTPModelClient"
      args: {
        base_url: "http://localhost:1234"
      }
```