### PR TITLE
Added special case to support Anthropic Critique

### DIFF
--- a/src/helm/proxy/clients/model_critique_client.py
+++ b/src/helm/proxy/clients/model_critique_client.py
@@ -14,6 +14,8 @@ from helm.common.request import Request, RequestResult, Sequence
 from helm.proxy.clients.client import Client
 from helm.proxy.clients.critique_client import CritiqueClient
 
+import anthropic
+
 
 class CritiqueParseError(Exception):
     pass
@@ -61,6 +63,12 @@ class ModelCritiqueClient(CritiqueClient):
                 max_tokens = len(question.options) * 2
             else:
                 max_tokens = 1
+
+            # Special case for Anthropic to handle prefix and suffix.
+            # TODO(josselin): Fix this once refactor of HELM allows for automatic model prefix and suffix.
+            if self._model_name.startswith("anthropic"):
+                prompt = anthropic.HUMAN_PROMPT + prompt + anthropic.AI_PROMPT
+
             request = Request(
                 model=self._model_name,
                 prompt=prompt,


### PR DESCRIPTION
Quick fix to support Claude in `CritiqueModel`.
I say quick but at the same time I don't think there is a super clean way to handle this for now. We could add the notion of prefix and suffix to the `CritiqueModelClient` but this would still require this logic somewhere. I think this should be handled further down the line by our refactor which would add automatically the correct prefix and suffix for a model.