### PR TITLE
Fix test_huggingface_tokenizer

### DIFF
--- a/src/helm/proxy/clients/test_huggingface_tokenizer.py
+++ b/src/helm/proxy/clients/test_huggingface_tokenizer.py
@@ -40,7 +40,7 @@ class TestHuggingFaceTokenizers:
         TestHuggingFaceTokenizers.verify_get_tokenizer("bigscience/T0pp", 58)
 
     def test_get_tokenizer_t511b(self):
-        TestHuggingFaceTokenizers.verify_get_tokenizer("google/t5-11b", 58)
+        TestHuggingFaceTokenizers.verify_get_tokenizer("google/t5-11b", 58, pretrained_model_name_or_path="t5-11b")
 
     def test_get_tokenizer_ul2(self):
         TestHuggingFaceTokenizers.verify_get_tokenizer("google/ul2", 58)


### PR DESCRIPTION
Fixes the test breakage with the following output:

```
E           OSError: google/t5-11b is not a local folder and is not a valid model identifier listed on 'https://huggingface.co/models'
E           If this is a private repository, make sure to pass a token having permission to this repo with `use_auth_token` or log in with `huggingface-cli login` and pass `use_auth_token=True`.
```