### PR TITLE
Fixed typo in optional dependencies message

### DIFF
--- a/src/helm/common/optional_dependencies.py
+++ b/src/helm/common/optional_dependencies.py
@@ -6,5 +6,5 @@ def handle_module_not_found_error(e: ModuleNotFoundError):
     # TODO: Ask user to install more specific optional dependencies
     # e.g. crfm-helm[plots] or crfm-helm[server]
     raise OptionalDependencyNotInstalled(
-        f"Optional dependency {e.name} is not installed. " "Please run `pip install helm-crfm[all]` to install it."
+        f"Optional dependency {e.name} is not installed. " "Please run `pip install crfm-helm[all]` to install it."
     ) from e


### PR DESCRIPTION
When installing helm[all] it displays the message with wrong name. This PR does a small fix of that.

Fixes issue #1894 