### PR TITLE
Support Python 3.9 and 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
       # Installs dependencies and performs static code checks
       - run: python3 -m pip install virtualenv && python3 -m virtualenv -p python3 venv
       - run: source venv/bin/activate && ./install-dev.sh
-      - run: source venv/bin/activate && pre-commit
+      - run: source venv/bin/activate && ./pre-commit.sh
       - name: Run tests
         run: source venv/bin/activate && pytest
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -37,6 +37,9 @@ jobs:
   test:
     name: Tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - name: Clear free space
         run: |
@@ -45,7 +48,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.python-version }}
       - uses: actions/cache@v2
         with:
           path: ~/.cache/pip
@@ -55,7 +58,7 @@ jobs:
       # Installs dependencies and performs static code checks
       - run: python3 -m pip install virtualenv && python3 -m virtualenv -p python3 venv
       - run: source venv/bin/activate && ./install-dev.sh
-      - run: source venv/bin/activate && ./pre-commit.sh
+      - run: source venv/bin/activate && pre-commit
       - name: Run tests
         run: source venv/bin/activate && pytest
         env:
@@ -64,11 +67,3 @@ jobs:
       - name: Run entire pipeline quickly without any data
         # Checking RunSpecs with openai/davinci should be comprehensive enough
         run: source venv/bin/activate && helm-run --suite test -m 100 --skip-instances --models-to-run openai/davinci --exit-on-error
-
-  ci:
-    name: All CI tasks complete
-    runs-on: ubuntu-latest
-    needs: [install, test]
-    steps:
-      - uses: actions/checkout@v2
-      - run: echo Done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - name: Clear free space
         run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ classifiers =
 url = https://github.com/stanford-crfm/helm
 
 [options]
-python_requires = ~=3.8
+python_requires = '>=3.8,<3.11'
 package_dir =
     =src
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ classifiers =
 url = https://github.com/stanford-crfm/helm
 
 [options]
-python_requires = '>=3.8,<3.11'
+python_requires = >=3.8,<3.11
 package_dir =
     =src
 packages = find:


### PR DESCRIPTION
This updates `python_requires` of the package. It also runs CI on Python 3.8 through 3.10. This triples the number of GitHub Action minutes used, which should hopefully not be a problem.

Fixes #1511