### PR TITLE
Fix tsx type name in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,4 +9,4 @@ repos:
   rev: 'fc260393cc4ec09f8fc0a5ba4437f481c8b55dc1'
   hooks:
     - id: prettier
-      types_or: [typescript, javascript]
+      types_or: [tsx, javascript]


### PR DESCRIPTION
Fixes this error when running `pre-commit`:
```
==> At Hook(id='prettier')
==> At key: types_or
==> At index 0
=====> Type tag 'typescript' is not recognized.  Try upgrading identify and pre-commit?
```