### PR TITLE
Remove one-off debug_cap.

### DIFF
--- a/src/helm/benchmark/scenarios/ice_scenario.py
+++ b/src/helm/benchmark/scenarios/ice_scenario.py
@@ -401,7 +401,7 @@ class ICEScenario(Scenario):
         corpus_filenames = list(filter(lambda x: any([regex.match(x) for regex in regexes]), all_corpus_filenames))
         return sorted(corpus_filenames)
 
-    def get_instances(self, debug_cap: Union[int, None] = None) -> List[Instance]:
+    def get_instances(self) -> List[Instance]:
         instances: List[Instance] = []
 
         for subset in self.subset:
@@ -461,8 +461,5 @@ class ICEScenario(Scenario):
 
                 for t in preprocessed_texts:
                     instances.append(Instance(Input(text=t), references=[], split=TEST_SPLIT))
-
-                    if debug_cap and len(instances) >= debug_cap:
-                        return instances
 
         return instances


### PR DESCRIPTION
It is odd that this is the only get_instance that has debug_cap, and I can't find any usage of it.