### PR TITLE
Pass output_path into get_instances instead of setting it in runner

### DIFF
--- a/src/helm/benchmark/adaptation/adapters/test_generation_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/test_generation_adapter.py
@@ -14,7 +14,7 @@ class TestGenerationAdapter(TestAdapter):
         scenario = create_scenario(get_scenario_spec1())
         adapter_spec = get_adapter_spec1()
         adapter = AdapterFactory.get_adapter(adapter_spec, self.tokenizer_service)
-        scenario_state = adapter.adapt(scenario.get_instances(), parallelism=1)
+        scenario_state = adapter.adapt(scenario.get_instances(output_path=""), parallelism=1)
 
         # Make sure we generated the right number of request_states:
         # For each trial, instance and reference (+ 1 for free-form generation).

--- a/src/helm/benchmark/data_overlap/export_scenario_text.py
+++ b/src/helm/benchmark/data_overlap/export_scenario_text.py
@@ -40,13 +40,13 @@ def get_light_scenarios_from_scenario_spec(
     scenario: Scenario = create_scenario(scenario_spec)
 
     ensure_directory_exists(scenario_download_path)
-    scenario.output_path = os.path.join(scenario_download_path, scenario.name)
-    ensure_directory_exists(scenario.output_path)
+    scenario_output_path = os.path.join(scenario_download_path, scenario.name)
+    ensure_directory_exists(scenario_output_path)
 
     # Load instances
     instances: List[Instance]
     with htrack_block("scenario.get_instances"):
-        instances = scenario.get_instances()
+        instances = scenario.get_instances(scenario_output_path)
 
     # Get instance ids
     instances = with_instance_ids(instances)

--- a/src/helm/benchmark/runner.py
+++ b/src/helm/benchmark/runner.py
@@ -186,8 +186,8 @@ class Runner:
         scenario: Scenario = create_scenario(run_spec.scenario_spec)
 
         # This `output_path` will be used when `Adapter` calls `Scenario.get_instances`.
-        scenario.output_path = os.path.join(self.scenarios_path, scenario.name)
-        ensure_directory_exists(scenario.output_path)
+        scenario_output_path = os.path.join(self.scenarios_path, scenario.name)
+        ensure_directory_exists(scenario_output_path)
 
         # This 'output_path' will be used when the model's input instances are saved.
         args_str = ",".join([f"{k}={v}" for k, v in sorted(run_spec.scenario_spec.args.items())])
@@ -218,7 +218,7 @@ class Runner:
             else:
                 # Create the instances of the scenario
                 with htrack_block("scenario.get_instances"):
-                    instances = scenario.get_instances()
+                    instances = scenario.get_instances(scenario_output_path)
         if self.cache_instances and not os.path.exists(input_instances_file_path):
             # Save instances to file
             ensure_directory_exists(input_instances_output_path)

--- a/src/helm/benchmark/scenarios/anthropic_hh_rlhf_scenario.py
+++ b/src/helm/benchmark/scenarios/anthropic_hh_rlhf_scenario.py
@@ -28,7 +28,7 @@ class AnthropicHHRLHFScenario(Scenario):
             raise ValueError(f"Invalid subset: {subset}")
         self.subset = subset
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         split_to_tag: Dict[str, str] = {"train": TRAIN_SPLIT, "test": TEST_SPLIT}
 
         def get_first_utterance(dialogue: str):

--- a/src/helm/benchmark/scenarios/babi_qa_scenario.py
+++ b/src/helm/benchmark/scenarios/babi_qa_scenario.py
@@ -98,8 +98,8 @@ class BabiQAScenario(Scenario):
             assert task in all_tasks
             self.tasks = [task]
 
-    def get_instances(self) -> List[Instance]:
-        data_path = os.path.join(self.output_path, "data")
+    def get_instances(self, output_path: str) -> List[Instance]:
+        data_path = os.path.join(output_path, "data")
         ensure_directory_exists(data_path)
 
         instances: List[Instance] = []

--- a/src/helm/benchmark/scenarios/bbq_scenario.py
+++ b/src/helm/benchmark/scenarios/bbq_scenario.py
@@ -71,8 +71,8 @@ class BBQScenario(Scenario):
         super().__init__()
         self.subject = subject
 
-    def get_instances(self) -> List[Instance]:
-        data_path = os.path.join(self.output_path, "data")
+    def get_instances(self, output_path: str) -> List[Instance]:
+        data_path = os.path.join(output_path, "data")
         os.makedirs(data_path, exist_ok=True)
 
         if self.subject == "all":

--- a/src/helm/benchmark/scenarios/big_bench_scenario.py
+++ b/src/helm/benchmark/scenarios/big_bench_scenario.py
@@ -76,11 +76,11 @@ class BIGBenchScenario(Scenario):
         self.task: str = task
         self.subtask: str = subtask
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         """
         Construct `Instance`s using the examples from the BIG-bench task.
         """
-        big_bench_task: Dict = BIGBenchScenario.download_and_get_task(self.output_path, self.task, self.subtask)
+        big_bench_task: Dict = BIGBenchScenario.download_and_get_task(output_path, self.task, self.subtask)
 
         # From https://github.com/google/BIG-bench/blob/main/docs/doc.md#json-schema,
         # "keywords", "description" and "examples" are all required fields for a BIG-bench task.

--- a/src/helm/benchmark/scenarios/blimp_scenario.py
+++ b/src/helm/benchmark/scenarios/blimp_scenario.py
@@ -114,9 +114,9 @@ class BLiMPScenario(Scenario):
         assert phenomenon in self.phenomenon_to_paradigms, f"Unsupported phenomenon: {phenomenon}"
         self.phenomenon: str = phenomenon
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         # Download the raw data
-        data_path: str = os.path.join(self.output_path, "data")
+        data_path: str = os.path.join(output_path, "data")
         ensure_file_downloaded(
             source_url="https://github.com/alexwarstadt/blimp/blob/master/BLiMP.zip?raw=true",
             target_path=data_path,

--- a/src/helm/benchmark/scenarios/bold_scenario.py
+++ b/src/helm/benchmark/scenarios/bold_scenario.py
@@ -61,8 +61,8 @@ class BOLDScenario(Scenario):
         super().__init__()
         self.subject = subject
 
-    def get_instances(self) -> List[Instance]:
-        data_path = os.path.join(self.output_path, "data")
+    def get_instances(self, output_path: str) -> List[Instance]:
+        data_path = os.path.join(output_path, "data")
         os.makedirs(data_path, exist_ok=True)
 
         if self.subject == "all":

--- a/src/helm/benchmark/scenarios/boolq_scenario.py
+++ b/src/helm/benchmark/scenarios/boolq_scenario.py
@@ -137,8 +137,8 @@ class BoolQScenario(Scenario):
                 split_instances.append(instance)
         return split_instances
 
-    def get_instances(self) -> List[Instance]:
-        data_path: str = os.path.join(self.output_path, "data")
+    def get_instances(self, output_path: str) -> List[Instance]:
+        data_path: str = os.path.join(output_path, "data")
         ensure_directory_exists(data_path)
 
         instances: List[Instance] = []

--- a/src/helm/benchmark/scenarios/civil_comments_scenario.py
+++ b/src/helm/benchmark/scenarios/civil_comments_scenario.py
@@ -93,8 +93,8 @@ class CivilCommentsScenario(Scenario):
         ), f"Invalid demographic: {demographic}"
         self.demographic: str = demographic
 
-    def get_instances(self) -> List[Instance]:
-        data_path: str = os.path.join(self.output_path, "wilds_civil_comments.csv")
+    def get_instances(self, output_path: str) -> List[Instance]:
+        data_path: str = os.path.join(output_path, "wilds_civil_comments.csv")
         ensure_file_downloaded(
             source_url=CivilCommentsScenario.DATASET_DOWNLOAD_URL,
             target_path=data_path,

--- a/src/helm/benchmark/scenarios/cleva_scenario.py
+++ b/src/helm/benchmark/scenarios/cleva_scenario.py
@@ -446,7 +446,7 @@ class CLEVAScenario(Scenario):
             raise ValueError(f"Missing prompt template file at '{file_path}'")
         return prompt_templates
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         # Download the raw data
         dataset = self.load_dataset()
 
@@ -930,7 +930,7 @@ class CLEVADialogueGenerationScenario(CLEVAScenario):
     def task(self) -> str:
         return "dialogue_generation"
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         # Download the raw data
         dataset = self.load_dataset()
 

--- a/src/helm/benchmark/scenarios/code_scenario.py
+++ b/src/helm/benchmark/scenarios/code_scenario.py
@@ -290,10 +290,10 @@ class CodeScenario(Scenario):
 
         self.human_eval_hparams = dict(num_train_instances=0, num_val_instances=0, num_test_instances=164)
 
-    def get_instances(self) -> List[Instance]:
-        # By construction, self.output_path == 'benchmark_output/scenarios/code'.
+    def get_instances(self, output_path: str) -> List[Instance]:
+        # By construction, output_path == 'benchmark_output/scenarios/code'.
         if self.dataset == "humaneval":
-            target_path = os.path.join(self.output_path, "HumanEval.jsonl")
+            target_path = os.path.join(output_path, "HumanEval.jsonl")
             ensure_file_downloaded(
                 source_url="https://github.com/openai/human-eval/raw/master/data/HumanEval.jsonl.gz",
                 target_path=target_path,
@@ -305,7 +305,7 @@ class CodeScenario(Scenario):
             # This dataset doesn't have a validation set.
             # Unclear how they do validation. Also not clarified in their paper.
             # `target_path` is the output folder, not the compressed file, since we unpack!
-            target_path = os.path.join(self.output_path, "APPS")
+            target_path = os.path.join(output_path, "APPS")
             ensure_file_downloaded(
                 source_url="https://people.eecs.berkeley.edu/~hendrycks/APPS.tar.gz",
                 target_path=target_path,

--- a/src/helm/benchmark/scenarios/commonsense_scenario.py
+++ b/src/helm/benchmark/scenarios/commonsense_scenario.py
@@ -107,7 +107,7 @@ class CommonSenseScenario(Scenario):
 
     def download_dataset(self):
         # Download the raw data
-        data_path = os.path.join(self.output_path, "data", self.dataset)
+        data_path = os.path.join(output_path, "data", self.dataset)
         ensure_directory_exists(data_path)
 
         if self.dataset == "hellaswag":
@@ -190,7 +190,7 @@ class CommonSenseScenario(Scenario):
             raise ValueError(f"Unknown dataset: {self.dataset}")
 
     def load_dataset(self) -> List[List[str]]:
-        data_path = os.path.join(self.output_path, "data", self.dataset)
+        data_path = os.path.join(output_path, "data", self.dataset)
 
         if self.dataset == "hellaswag":
             split_to_file = {
@@ -235,7 +235,7 @@ class CommonSenseScenario(Scenario):
                     data.append([question, answers, correct_answer, split])
         return data
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         self.download_dataset()
         data = self.load_dataset()
 

--- a/src/helm/benchmark/scenarios/commonsense_scenario.py
+++ b/src/helm/benchmark/scenarios/commonsense_scenario.py
@@ -105,7 +105,7 @@ class CommonSenseScenario(Scenario):
         assert correct_choice in [0, 1, 2]
         return question, answers, correct_answer
 
-    def download_dataset(self):
+    def download_dataset(self, output_path: str):
         # Download the raw data
         data_path = os.path.join(output_path, "data", self.dataset)
         ensure_directory_exists(data_path)
@@ -189,7 +189,7 @@ class CommonSenseScenario(Scenario):
         else:
             raise ValueError(f"Unknown dataset: {self.dataset}")
 
-    def load_dataset(self) -> List[List[str]]:
+    def load_dataset(self, output_path: str) -> List[List[str]]:
         data_path = os.path.join(output_path, "data", self.dataset)
 
         if self.dataset == "hellaswag":
@@ -236,8 +236,8 @@ class CommonSenseScenario(Scenario):
         return data
 
     def get_instances(self, output_path: str) -> List[Instance]:
-        self.download_dataset()
-        data = self.load_dataset()
+        self.download_dataset(output_path)
+        data = self.load_dataset(output_path)
 
         splits = {
             "train": TRAIN_SPLIT,

--- a/src/helm/benchmark/scenarios/copyright_scenario.py
+++ b/src/helm/benchmark/scenarios/copyright_scenario.py
@@ -62,8 +62,8 @@ class CopyrightScenario(Scenario):
         self.datatag = datatag
         self.source_url = f"https://drive.google.com/uc?id={datatag2hash[datatag]}"
 
-    def get_instances(self) -> List[Instance]:
-        target_path: str = os.path.join(self.output_path, f"{self.datatag}.json")
+    def get_instances(self, output_path: str) -> List[Instance]:
+        target_path: str = os.path.join(output_path, f"{self.datatag}.json")
         ensure_file_downloaded(self.source_url, target_path)
 
         with open(target_path, "r") as f:

--- a/src/helm/benchmark/scenarios/covid_dialog_scenario.py
+++ b/src/helm/benchmark/scenarios/covid_dialog_scenario.py
@@ -40,7 +40,7 @@ class COVIDDialogScenario(Scenario):
     description = "Medical dialogue dataset of conversations between doctors and patients on their COVID-19 concerns"
     tags = ["dialogue", "biomedical"]
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         """
         Build `Instance`s using the questions asked by concerned patients and the responses by doctors.
         """
@@ -56,7 +56,7 @@ class COVIDDialogScenario(Scenario):
             with open(file_path) as f:
                 return f.read().splitlines()
 
-        data_path: str = os.path.join(self.output_path, "data")
+        data_path: str = os.path.join(output_path, "data")
         ensure_directory_exists(data_path)
 
         instances: List[Instance] = []

--- a/src/helm/benchmark/scenarios/dialogue_scenarios.py
+++ b/src/helm/benchmark/scenarios/dialogue_scenarios.py
@@ -43,7 +43,7 @@ class EmpatheticDialoguesScenario(Scenario):
         super().__init__()
         pass
 
-    def download_data(self):
+    def download_data(self, output_path: str):
         # Download the raw data
         self.data_path: str = os.path.join(output_path, "data")
         ensure_file_downloaded(
@@ -133,12 +133,11 @@ class EmpatheticDialoguesScenario(Scenario):
         return instances
 
     def get_instances(self, output_path: str) -> List[Instance]:
-        self.download_data()
+        self.download_data(output_path)
         return self.filter_instances(self.read_instances())
 
 
 if __name__ == "__main__":
     scenario = EmpatheticDialoguesScenario()
-    scenario.output_path = "./benchmark_output/scenarios/empatheticdialogues"
-    instances = scenario.get_instances()
+    instances = scenario.get_instances("./benchmark_output/scenarios/empatheticdialogues")
     print(instances[100])

--- a/src/helm/benchmark/scenarios/dialogue_scenarios.py
+++ b/src/helm/benchmark/scenarios/dialogue_scenarios.py
@@ -45,7 +45,7 @@ class EmpatheticDialoguesScenario(Scenario):
 
     def download_data(self):
         # Download the raw data
-        self.data_path: str = os.path.join(self.output_path, "data")
+        self.data_path: str = os.path.join(output_path, "data")
         ensure_file_downloaded(
             source_url="https://dl.fbaipublicfiles.com/parlai/empatheticdialogues/empatheticdialogues.tar.gz",
             target_path=self.data_path,
@@ -132,7 +132,7 @@ class EmpatheticDialoguesScenario(Scenario):
 
         return instances
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         self.download_data()
         return self.filter_instances(self.read_instances())
 

--- a/src/helm/benchmark/scenarios/disinformation_scenario.py
+++ b/src/helm/benchmark/scenarios/disinformation_scenario.py
@@ -144,7 +144,7 @@ class DisinformationScenario(Scenario):
 
         return instances
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         if self.capability == "reiteration":
             data_url = REITERATION_DATA_URL
         elif self.capability == "wedging":
@@ -152,7 +152,7 @@ class DisinformationScenario(Scenario):
         else:
             raise ValueError(f"Unknown disinformation evaluation: {self.capability}")
 
-        data_path = os.path.join(self.output_path, self.capability)
+        data_path = os.path.join(output_path, self.capability)
         ensure_file_downloaded(source_url=data_url, target_path=data_path)
 
         data = []

--- a/src/helm/benchmark/scenarios/dyck_language_scenario.py
+++ b/src/helm/benchmark/scenarios/dyck_language_scenario.py
@@ -207,7 +207,7 @@ class DyckLanguageScenario(Scenario):
                 instances.append(instance)
         return inputs, instances
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         np.random.seed(self.random_seed)
         random.seed(self.random_seed)
 

--- a/src/helm/benchmark/scenarios/entity_data_imputation_scenario.py
+++ b/src/helm/benchmark/scenarios/entity_data_imputation_scenario.py
@@ -110,8 +110,8 @@ class EntityDataImputationScenario(Scenario):
             res.append(f"{c}: {row[c]}".strip())
         return ". ".join(res)
 
-    def get_instances(self) -> List[Instance]:
-        data_path = Path(self.output_path) / "data" / self.dataset
+    def get_instances(self, output_path: str) -> List[Instance]:
+        data_path = Path(output_path) / "data" / self.dataset
         data_path.parent.mkdir(parents=True, exist_ok=True)
         ensure_file_downloaded(
             source_url=self.datasets_paths[self.dataset],

--- a/src/helm/benchmark/scenarios/entity_matching_scenario.py
+++ b/src/helm/benchmark/scenarios/entity_matching_scenario.py
@@ -102,9 +102,9 @@ class EntityMatchingScenario(Scenario):
             res.append(f"{c_map}: {row[c_og]}".strip())
         return ". ".join(res)
 
-    def get_instances(self) -> List[Instance]:
-        set_fixed_random_state_for_dataset(self.output_path, self.dataset)
-        data_path = Path(self.output_path) / "data" / self.dataset
+    def get_instances(self, output_path: str) -> List[Instance]:
+        set_fixed_random_state_for_dataset(output_path, self.dataset)
+        data_path = Path(output_path) / "data" / self.dataset
         data_path.parent.mkdir(parents=True, exist_ok=True)
         ensure_file_downloaded(
             source_url=f"http://pages.cs.wisc.edu/~anhai/data1/deepmatcher_data/"

--- a/src/helm/benchmark/scenarios/grammar_scenario.py
+++ b/src/helm/benchmark/scenarios/grammar_scenario.py
@@ -18,7 +18,7 @@ class GrammarScenario(Scenario):
         self.path = path
         self.tags = tags.split(",") if tags else []
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         # Generate derivations
         grammar = read_grammar(self.path)
         derivations = generate_derivations(grammar)

--- a/src/helm/benchmark/scenarios/gsm_scenario.py
+++ b/src/helm/benchmark/scenarios/gsm_scenario.py
@@ -34,14 +34,14 @@ class GSM8KScenario(Scenario):
     description = "Grade school math dataset with 8.5K examples (GSM8K)."
     tags = ["reasoning", "math"]
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         splits = {"train": TRAIN_SPLIT, "test": TEST_SPLIT}
         base_url = "https://raw.githubusercontent.com/openai/grade-school-math/master/grade_school_math/data/"
         instances: List[Instance] = []
 
         for split, split_tag in splits.items():  # Iterate over the splits
             source_url: str = f"{base_url}/{split}.jsonl"
-            data_path: str = os.path.join(self.output_path, f"gsm_data_{split}")
+            data_path: str = os.path.join(output_path, f"gsm_data_{split}")
             ensure_file_downloaded(source_url=source_url, target_path=data_path)
 
             with open(data_path, "r") as f:

--- a/src/helm/benchmark/scenarios/ice_scenario.py
+++ b/src/helm/benchmark/scenarios/ice_scenario.py
@@ -435,10 +435,10 @@ class ICEScenario(Scenario):
                 self.filter_by_metadata(
                     subset,
                     os.path.join(data_path, "Headers"),
-                    listdir_with_pinned_file_order(self.output_path, corpus_path),
+                    listdir_with_pinned_file_order(output_path, corpus_path),
                 )
                 if can_filter
-                else listdir_with_pinned_file_order(self.output_path, corpus_path)
+                else listdir_with_pinned_file_order(output_path, corpus_path)
             )
 
             for filename in selected_texts:

--- a/src/helm/benchmark/scenarios/ice_scenario.py
+++ b/src/helm/benchmark/scenarios/ice_scenario.py
@@ -401,7 +401,7 @@ class ICEScenario(Scenario):
         corpus_filenames = list(filter(lambda x: any([regex.match(x) for regex in regexes]), all_corpus_filenames))
         return sorted(corpus_filenames)
 
-    def get_instances(self, output_path: str, debug_cap: Union[int, None] = None) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         instances: List[Instance] = []
 
         for subset in self.subset:
@@ -461,8 +461,5 @@ class ICEScenario(Scenario):
 
                 for t in preprocessed_texts:
                     instances.append(Instance(Input(text=t), references=[], split=TEST_SPLIT))
-
-                    if debug_cap and len(instances) >= debug_cap:
-                        return instances
 
         return instances

--- a/src/helm/benchmark/scenarios/ice_scenario.py
+++ b/src/helm/benchmark/scenarios/ice_scenario.py
@@ -401,7 +401,7 @@ class ICEScenario(Scenario):
         corpus_filenames = list(filter(lambda x: any([regex.match(x) for regex in regexes]), all_corpus_filenames))
         return sorted(corpus_filenames)
 
-    def get_instances(self, debug_cap: Union[int, None] = None) -> List[Instance]:
+    def get_instances(self, output_path: str, debug_cap: Union[int, None] = None) -> List[Instance]:
         instances: List[Instance] = []
 
         for subset in self.subset:

--- a/src/helm/benchmark/scenarios/imdb_scenario.py
+++ b/src/helm/benchmark/scenarios/imdb_scenario.py
@@ -122,8 +122,8 @@ class IMDBScenario(Scenario):
             }
         return contrast_map
 
-    def get_instances(self) -> List[Instance]:
-        target_path: str = os.path.join(self.output_path, "data")
+    def get_instances(self, output_path: str) -> List[Instance]:
+        target_path: str = os.path.join(output_path, "data")
 
         instances: List[Instance] = []
 

--- a/src/helm/benchmark/scenarios/interactive_qa_mmlu_scenario.py
+++ b/src/helm/benchmark/scenarios/interactive_qa_mmlu_scenario.py
@@ -32,9 +32,9 @@ class InteractiveQAMMLUScenario(MMLUScenario):
         assert subject in InteractiveQAMMLUScenario.VALID_SUBJECTS, f"Invalid subject for Interactive QA: {subject}"
         super().__init__(subject)
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         # Download the MMLU data and the subsets for InteractiveQA
-        data_path: str = os.path.join(self.output_path, "data")
+        data_path: str = os.path.join(output_path, "data")
         self.download_mmlu(data_path)
 
         test_path: str = os.path.join(data_path, "test", InteractiveQAMMLUScenario.INTERACTIVE_QA_DIR)

--- a/src/helm/benchmark/scenarios/koala_scenario.py
+++ b/src/helm/benchmark/scenarios/koala_scenario.py
@@ -17,10 +17,10 @@ class KoalaScenario(Scenario):
     description = "Koala eval dataset"
     tags = ["instructions"]
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         # Download the raw data
         source_url = "https://raw.githubusercontent.com/arnav-gudibande/koala-test-set/main/koala_test_set.jsonl"
-        data_path: str = os.path.join(self.output_path, "Koala_prompts.jsonl")
+        data_path: str = os.path.join(output_path, "Koala_prompts.jsonl")
 
         ensure_file_downloaded(
             source_url=source_url,

--- a/src/helm/benchmark/scenarios/legal_summarization_scenario.py
+++ b/src/helm/benchmark/scenarios/legal_summarization_scenario.py
@@ -134,7 +134,7 @@ class LegalSummarizationScenario(Scenario):
         self.doc_max_length = doc_max_length
 
     def _download_dataset(self, hf_name):
-        cache_dir = str(Path(self.output_path) / "data")
+        cache_dir = str(Path(output_path) / "data")
         if self.dataset_name == "EurLexSum":
             # IMPORTANT: change this once more languages should be supported
             dataset: Any = load_dataset(hf_name, "english", cache_dir=cache_dir)
@@ -166,7 +166,7 @@ class LegalSummarizationScenario(Scenario):
 
         return dataset, article_key, summary_key
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         dataset, article_key, summary_key = self._load_dataset(self.dataset_name)
 
         instances: List[Instance] = []

--- a/src/helm/benchmark/scenarios/legal_summarization_scenario.py
+++ b/src/helm/benchmark/scenarios/legal_summarization_scenario.py
@@ -133,7 +133,7 @@ class LegalSummarizationScenario(Scenario):
         self.sampling_max_length = sampling_max_length
         self.doc_max_length = doc_max_length
 
-    def _download_dataset(self, hf_name, output_path: str):
+    def _download_dataset(self, hf_name, output_path):
         cache_dir = str(Path(output_path) / "data")
         if self.dataset_name == "EurLexSum":
             # IMPORTANT: change this once more languages should be supported
@@ -145,7 +145,7 @@ class LegalSummarizationScenario(Scenario):
 
         return dataset
 
-    def _load_dataset(self, dataset_name: str, output_path: str):
+    def _load_dataset(self, dataset_name: str, output_path):
         if dataset_name == "BillSum":
             hf_name = "billsum"
             dataset = self._download_dataset(hf_name, output_path)
@@ -166,7 +166,7 @@ class LegalSummarizationScenario(Scenario):
 
         return dataset, article_key, summary_key
 
-    def get_instances(self, output_path: str) -> List[Instance]:
+    def get_instances(self, output_path) -> List[Instance]:
         dataset, article_key, summary_key = self._load_dataset(self.dataset_name, output_path)
 
         instances: List[Instance] = []

--- a/src/helm/benchmark/scenarios/legal_summarization_scenario.py
+++ b/src/helm/benchmark/scenarios/legal_summarization_scenario.py
@@ -133,7 +133,7 @@ class LegalSummarizationScenario(Scenario):
         self.sampling_max_length = sampling_max_length
         self.doc_max_length = doc_max_length
 
-    def _download_dataset(self, hf_name):
+    def _download_dataset(self, hf_name, output_path: str):
         cache_dir = str(Path(output_path) / "data")
         if self.dataset_name == "EurLexSum":
             # IMPORTANT: change this once more languages should be supported
@@ -145,20 +145,20 @@ class LegalSummarizationScenario(Scenario):
 
         return dataset
 
-    def _load_dataset(self, dataset_name: str):
+    def _load_dataset(self, dataset_name: str, output_path: str):
         if dataset_name == "BillSum":
             hf_name = "billsum"
-            dataset = self._download_dataset(hf_name)
+            dataset = self._download_dataset(hf_name, output_path)
             article_key = "text"
             summary_key = "summary"
         elif dataset_name == "MultiLexSum":
             hf_name = "allenai/multi_lexsum"
-            dataset = self._download_dataset(hf_name)
+            dataset = self._download_dataset(hf_name, output_path)
             article_key = "summary/long"
             summary_key = "summary/short"  # we could do summary/tiny additionally here
         elif dataset_name == "EurLexSum":
             hf_name = "dennlinger/eur-lex-sum"
-            dataset = self._download_dataset(hf_name)
+            dataset = self._download_dataset(hf_name, output_path)
             article_key = "reference"
             summary_key = "summary"
         else:
@@ -167,7 +167,7 @@ class LegalSummarizationScenario(Scenario):
         return dataset, article_key, summary_key
 
     def get_instances(self, output_path: str) -> List[Instance]:
-        dataset, article_key, summary_key = self._load_dataset(self.dataset_name)
+        dataset, article_key, summary_key = self._load_dataset(self.dataset_name, output_path)
 
         instances: List[Instance] = []
         for split, split_name in self.splits_mapping.items():

--- a/src/helm/benchmark/scenarios/legal_support_scenario.py
+++ b/src/helm/benchmark/scenarios/legal_support_scenario.py
@@ -51,8 +51,8 @@ class LegalSupportScenario(Scenario):
     description = "Binary multiple choice question dataset for legal argumentative reasoning."
     tags = ["question_answering", "law"]
 
-    def get_instances(self) -> List[Instance]:
-        data_path: str = os.path.join(self.output_path, "data")
+    def get_instances(self, output_path: str) -> List[Instance]:
+        data_path: str = os.path.join(output_path, "data")
         ensure_file_downloaded(
             source_url="https://docs.google.com/uc?export=download&id=1PVoyddrCHChMxYrLhsI-zu7Xzs5S8N77",
             target_path=data_path,

--- a/src/helm/benchmark/scenarios/lex_glue_scenario.py
+++ b/src/helm/benchmark/scenarios/lex_glue_scenario.py
@@ -187,7 +187,7 @@ class LexGLUEScenario(Scenario):
     def get_instances_for_subset(self, config: str) -> List[Instance]:
         task_code = TASK_CODE_MAPPING[config]
         # Load dataset
-        cache_dir = str(Path(self.output_path) / "data")
+        cache_dir = str(Path(output_path) / "data")
         dataset: Any = load_dataset(self.dataset_name, config, cache_dir=cache_dir)
 
         if task_code in [TaskType.SLTC, TaskType.QA]:
@@ -246,7 +246,7 @@ class LexGLUEScenario(Scenario):
 
         return generate_instances(TRAIN_SPLIT) + generate_instances(VALID_SPLIT) + generate_instances(TEST_SPLIT)
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         instances = []
         for subset in self.subsets:
             instances.extend(self.get_instances_for_subset(subset))

--- a/src/helm/benchmark/scenarios/lex_glue_scenario.py
+++ b/src/helm/benchmark/scenarios/lex_glue_scenario.py
@@ -184,7 +184,7 @@ class LexGLUEScenario(Scenario):
         self.subsets = [subset] if subset != "all" else list(TASK_CODE_MAPPING.keys())
         self.random: random.Random = random.Random(42)
 
-    def get_instances_for_subset(self, config: str) -> List[Instance]:
+    def get_instances_for_subset(self, config: str, output_path: str) -> List[Instance]:
         task_code = TASK_CODE_MAPPING[config]
         # Load dataset
         cache_dir = str(Path(output_path) / "data")
@@ -249,5 +249,5 @@ class LexGLUEScenario(Scenario):
     def get_instances(self, output_path: str) -> List[Instance]:
         instances = []
         for subset in self.subsets:
-            instances.extend(self.get_instances_for_subset(subset))
+            instances.extend(self.get_instances_for_subset(subset, output_path))
         return instances

--- a/src/helm/benchmark/scenarios/lextreme_scenario.py
+++ b/src/helm/benchmark/scenarios/lextreme_scenario.py
@@ -371,7 +371,7 @@ class LEXTREMEScenario(Scenario):
     def get_instances_for_subset(self, config: str) -> List[Instance]:
         task_code = TASK_CODE_MAPPING[config]
         # Load dataset
-        cache_dir = str(Path(self.output_path) / "data")
+        cache_dir = str(Path(output_path) / "data")
         dataset: Any = load_dataset(self.dataset_name, config, cache_dir=cache_dir)
 
         if task_code == TaskType.SLTC:
@@ -451,7 +451,7 @@ class LEXTREMEScenario(Scenario):
 
         return generate_instances(TRAIN_SPLIT) + generate_instances(VALID_SPLIT) + generate_instances(TEST_SPLIT)
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         instances = []
         for subset in self.subsets:
             instances.extend(self.get_instances_for_subset(subset))

--- a/src/helm/benchmark/scenarios/lextreme_scenario.py
+++ b/src/helm/benchmark/scenarios/lextreme_scenario.py
@@ -368,7 +368,7 @@ class LEXTREMEScenario(Scenario):
         self.subsets = [subset] if subset != "all" else list(TASK_CODE_MAPPING.keys())
         self.random: random.Random = random.Random(42)
 
-    def get_instances_for_subset(self, config: str) -> List[Instance]:
+    def get_instances_for_subset(self, config: str, output_path: str) -> List[Instance]:
         task_code = TASK_CODE_MAPPING[config]
         # Load dataset
         cache_dir = str(Path(output_path) / "data")
@@ -454,5 +454,5 @@ class LEXTREMEScenario(Scenario):
     def get_instances(self, output_path: str) -> List[Instance]:
         instances = []
         for subset in self.subsets:
-            instances.extend(self.get_instances_for_subset(subset))
+            instances.extend(self.get_instances_for_subset(subset, output_path))
         return instances

--- a/src/helm/benchmark/scenarios/lsat_qa_scenario.py
+++ b/src/helm/benchmark/scenarios/lsat_qa_scenario.py
@@ -104,8 +104,8 @@ class LSATScenario(Scenario):
         question_type: str = tags[2].replace("grouping (distribution)", "distribution grouping") or "miscellaneous"
         return [question_type.replace(" ", "_").replace("/", "_"), self.subtype2type.get(question_type)]
 
-    def get_instances(self) -> List[Instance]:
-        data_path = os.path.join(self.output_path, "data")
+    def get_instances(self, output_path: str) -> List[Instance]:
+        data_path = os.path.join(output_path, "data")
         ensure_directory_exists(data_path)
 
         instances: List[Instance] = []

--- a/src/helm/benchmark/scenarios/math_scenario.py
+++ b/src/helm/benchmark/scenarios/math_scenario.py
@@ -352,7 +352,7 @@ class MATHScenario(Scenario):
         if use_chain_of_thought:
             assert not use_official_examples, "Cannot use official examples when use_chain_of_thought is True."
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         dataset = {}
         data = typing.cast(DatasetDict, load_dataset("competition_math", ignore_verifications=True))
 

--- a/src/helm/benchmark/scenarios/me_q_sum_scenario.py
+++ b/src/helm/benchmark/scenarios/me_q_sum_scenario.py
@@ -45,7 +45,7 @@ class MeQSumScenario(Scenario):
     description = "MeQSum is a corpus of 1,000 summarized consumer health questions."
     tags = ["summarization", "biomedical"]
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         """
         Build `Instance`s using the consumer health questions and their summarized versions.
         """
@@ -61,7 +61,7 @@ class MeQSumScenario(Scenario):
             with open(file_path) as f:
                 return f.read().splitlines()
 
-        data_path: str = os.path.join(self.output_path, "data")
+        data_path: str = os.path.join(output_path, "data")
         ensure_directory_exists(data_path)
 
         instances: List[Instance] = []

--- a/src/helm/benchmark/scenarios/med_dialog_scenario.py
+++ b/src/helm/benchmark/scenarios/med_dialog_scenario.py
@@ -102,8 +102,8 @@ class MedDialogScenario(Scenario):
         assert subset in ["healthcaremagic", "icliniq"], f"Invalid subset specified for {self.name}: {subset}."
         self.subset: str = subset
 
-    def get_instances(self) -> List[Instance]:
-        data_path: str = os.path.join(self.output_path, self.subset)
+    def get_instances(self, output_path: str) -> List[Instance]:
+        data_path: str = os.path.join(output_path, self.subset)
         ensure_directory_exists(data_path)
 
         instances: List[Instance] = []

--- a/src/helm/benchmark/scenarios/med_mcqa_scenario.py
+++ b/src/helm/benchmark/scenarios/med_mcqa_scenario.py
@@ -63,8 +63,8 @@ class MedMCQAScenario(Scenario):
     )
     tags = ["question_answering", "biomedical"]
 
-    def get_instances(self) -> List[Instance]:
-        data_path: str = os.path.join(self.output_path, "data")
+    def get_instances(self, output_path: str) -> List[Instance]:
+        data_path: str = os.path.join(output_path, "data")
         ensure_file_downloaded(
             source_url=self.DATASET_DOWNLOAD_URL,
             target_path=data_path,

--- a/src/helm/benchmark/scenarios/med_paragraph_simplification_scenario.py
+++ b/src/helm/benchmark/scenarios/med_paragraph_simplification_scenario.py
@@ -80,8 +80,8 @@ class MedParagraphSimplificationScenario(Scenario):
     description = "Corpus with technical abstracts and their lay summaries on various clinical topics"
     tags = ["summarization", "biomedical"]
 
-    def get_instances(self) -> List[Instance]:
-        data_path: str = os.path.join(self.output_path, "data")
+    def get_instances(self, output_path: str) -> List[Instance]:
+        data_path: str = os.path.join(output_path, "data")
         ensure_directory_exists(data_path)
 
         instances: List[Instance] = []

--- a/src/helm/benchmark/scenarios/med_qa_scenario.py
+++ b/src/helm/benchmark/scenarios/med_qa_scenario.py
@@ -58,8 +58,8 @@ class MedQAScenario(Scenario):
     description = "An open domain question answering (QA) dataset collected from professional medical board exams."
     tags = ["question_answering", "biomedical"]
 
-    def get_instances(self) -> List[Instance]:
-        data_path: str = os.path.join(self.output_path, "data")
+    def get_instances(self, output_path: str) -> List[Instance]:
+        data_path: str = os.path.join(output_path, "data")
         ensure_file_downloaded(
             source_url=self.DATASET_DOWNLOAD_URL,
             target_path=data_path,

--- a/src/helm/benchmark/scenarios/mmlu_scenario.py
+++ b/src/helm/benchmark/scenarios/mmlu_scenario.py
@@ -93,9 +93,9 @@ class MMLUScenario(Scenario):
                 instances.append(instance)
         return instances
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         # Download the raw data
-        data_path: str = os.path.join(self.output_path, "data")
+        data_path: str = os.path.join(output_path, "data")
         self.download_mmlu(data_path)
 
         # Read all the instances

--- a/src/helm/benchmark/scenarios/msmarco_scenario.py
+++ b/src/helm/benchmark/scenarios/msmarco_scenario.py
@@ -423,7 +423,7 @@ class MSMARCOScenario(Scenario):
         topk_dict = {k: v for k, v in topk_dict.items()}  # Convert the defaultdict to a regular dict
         return topk_dict
 
-    def prepare_data(self, output_path: str):
+    def prepare_data(self, output_path):
         """Download and load all the data."""
         # Passages
         self.document_dict = self.create_id_item_dict(self.download_helper(("documents",), output_path))

--- a/src/helm/benchmark/scenarios/msmarco_scenario.py
+++ b/src/helm/benchmark/scenarios/msmarco_scenario.py
@@ -332,9 +332,9 @@ class MSMARCOScenario(Scenario):
         """Download the resource at urlstring and return the absolute path.
 
         Downloaded file is saved to a directory named 'data' in
-        self.output_path.
+        output_path.
         """
-        data_path = os.path.join(self.output_path, "data")
+        data_path = os.path.join(output_path, "data")
         ensure_directory_exists(data_path)
         target_file_path = os.path.join(data_path, target_file_name)
         ensure_file_downloaded(source_url=urlstring, target_path=target_file_path)
@@ -631,7 +631,7 @@ class MSMARCOScenario(Scenario):
         instances = [self.get_valid_instance(qid) for qid in qids]
         return instances
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         """Get instances for this scenario.
 
         Refer to the documentation of the following methods for details on how

--- a/src/helm/benchmark/scenarios/narrativeqa_scenario.py
+++ b/src/helm/benchmark/scenarios/narrativeqa_scenario.py
@@ -136,8 +136,8 @@ class NarrativeQAScenario(Scenario):
 
         return split_instances
 
-    def get_instances(self) -> List[Instance]:
-        data_path = os.path.join(self.output_path, "data")
+    def get_instances(self, output_path: str) -> List[Instance]:
+        data_path = os.path.join(output_path, "data")
         ensure_directory_exists(data_path)
 
         repo_url: str = "https://github.com/deepmind/narrativeqa/archive/master.zip"

--- a/src/helm/benchmark/scenarios/natural_qa_scenario.py
+++ b/src/helm/benchmark/scenarios/natural_qa_scenario.py
@@ -307,8 +307,8 @@ class NaturalQAScenario(Scenario):
             instances.append(instance)
         return instances
 
-    def get_instances(self) -> List[Instance]:
-        data_path = os.path.join(self.output_path, "data")
+    def get_instances(self, output_path: str) -> List[Instance]:
+        data_path = os.path.join(output_path, "data")
         ensure_directory_exists(data_path)
         random.seed(0)
 

--- a/src/helm/benchmark/scenarios/newsqa_scenario.py
+++ b/src/helm/benchmark/scenarios/newsqa_scenario.py
@@ -164,7 +164,7 @@ class NewsQAScenario(Scenario):
             file_instances.append(instance)
         return file_instances
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         file_path: str = os.path.join("restricted", self.name, "combined-newsqa-data-v1.json")
         assert os.path.exists(file_path)
         splits = {"train": TRAIN_SPLIT, "valid": VALID_SPLIT}

--- a/src/helm/benchmark/scenarios/numeracy_scenario.py
+++ b/src/helm/benchmark/scenarios/numeracy_scenario.py
@@ -653,7 +653,7 @@ class NumeracyScenario(Scenario):
         self.num_train = MODE_INFO[mode]["num_train"]
         self.num_test = MODE_INFO[mode]["num_test"]
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         assert self.random_seed is not None
         random.seed(self.random_seed)
         np.random.seed(self.random_seed)

--- a/src/helm/benchmark/scenarios/open_assistant_scenario.py
+++ b/src/helm/benchmark/scenarios/open_assistant_scenario.py
@@ -26,7 +26,7 @@ class OpenAssistantScenario(Scenario):
         super().__init__()
         self.language: str = language
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         """An example of a message in the dataset:
         {
             'message_id': '6ab24d72-0181-4594-a9cd-deaf170242fb',

--- a/src/helm/benchmark/scenarios/opinions_qa_scenario.py
+++ b/src/helm/benchmark/scenarios/opinions_qa_scenario.py
@@ -109,16 +109,16 @@ class OpinionsQAScenario(Scenario):
 
     def download_data(self):
 
-        self.output_path: str = os.path.join(self.output_path, "data")
-        if not os.path.exists(self.output_path):
-            os.makedirs(self.output_path)
+        output_path: str = os.path.join(output_path, "data")
+        if not os.path.exists(output_path):
+            os.makedirs(output_path)
 
         DOWNLOAD_FILENAMES = [self.FILE_NAME.format(wave=wave) for wave in self.PEW_SURVEY_WAVES]
         DOWNLOAD_FILENAMES += [f"{steer}.csv" for steer in ["steer-qa", "steer-bio", "steer-portray"]]
         DOWNLOAD_FILENAMES += ["Pew_American_Trends_Panel_disagreement_500.csv"]
 
         for filename in DOWNLOAD_FILENAMES:
-            data_path: str = os.path.join(self.output_path, filename)
+            data_path: str = os.path.join(output_path, filename)
 
             source_url: str = self.CODALAB_URI_TEMPLATE.format(bundle=self.CODALAB_BUNDLE, filename=filename)
             ensure_file_downloaded(source_url=source_url, target_path=data_path, downloader_executable="gdown")
@@ -128,7 +128,7 @@ class OpinionsQAScenario(Scenario):
         df["options"] = df.apply(lambda x: eval(x["options"]), axis=1)
         return df
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         self.download_data()
 
         # Read all the instances
@@ -140,13 +140,13 @@ class OpinionsQAScenario(Scenario):
 
         all_splits = ["dev", "test"] if self.context == "steer-qa" else ["test"]
         csv_dict = {
-            "dev": os.path.join(self.output_path, f"{self.context}.csv"),
-            "test": os.path.join(self.output_path, f"{self.survey_type}.csv"),
+            "dev": os.path.join(output_path, f"{self.context}.csv"),
+            "test": os.path.join(output_path, f"{self.survey_type}.csv"),
         }
 
         bios_df = None
         if self.context in ["steer-bio", "steer-portray"]:
-            bios_path = os.path.join(self.output_path, f"{self.context}.csv")
+            bios_path = os.path.join(output_path, f"{self.context}.csv")
             bios_df = pd.read_csv(bios_path, sep="\t")
 
         for split in all_splits:

--- a/src/helm/benchmark/scenarios/pubmed_qa_scenario.py
+++ b/src/helm/benchmark/scenarios/pubmed_qa_scenario.py
@@ -122,8 +122,8 @@ class PubMedQAScenario(Scenario):
 
     POSSIBLE_ANSWER_CHOICES: List[str] = ["yes", "no", "maybe"]
 
-    def get_instances(self) -> List[Instance]:
-        data_path: str = os.path.join(self.output_path, "data")
+    def get_instances(self, output_path: str) -> List[Instance]:
+        data_path: str = os.path.join(output_path, "data")
         ensure_directory_exists(data_path)
 
         instances: List[Instance] = []

--- a/src/helm/benchmark/scenarios/quac_scenario.py
+++ b/src/helm/benchmark/scenarios/quac_scenario.py
@@ -166,8 +166,8 @@ class QuACScenario(Scenario):
 
         return split_instances
 
-    def get_instances(self) -> List[Instance]:
-        data_path = os.path.join(self.output_path, "data")
+    def get_instances(self, output_path: str) -> List[Instance]:
+        data_path = os.path.join(output_path, "data")
         ensure_directory_exists(data_path)
 
         base_url: str = "https://s3.amazonaws.com/my89public/quac"

--- a/src/helm/benchmark/scenarios/raft_scenario.py
+++ b/src/helm/benchmark/scenarios/raft_scenario.py
@@ -99,12 +99,12 @@ class RAFTScenario(Scenario):
 
     def load_prompt_construction_settings(self):
         # Load from prompt construction settings
-        cache_dir = str(Path(self.output_path) / "data")
+        cache_dir = str(Path(output_path) / "data")
         return get_raft_prompt_settings(self.subset, cache_dir)
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         fields, _ = self.load_prompt_construction_settings()
-        cache_dir = str(Path(self.output_path) / "data")
+        cache_dir = str(Path(output_path) / "data")
         # Download raw data
         # Note: Only using public labeled instances now. Check if we can get the hidden test set labels.
         all_usable_dataset = datasets.load_dataset("ought/raft", self.subset, cache_dir=cache_dir, split="train")

--- a/src/helm/benchmark/scenarios/raft_scenario.py
+++ b/src/helm/benchmark/scenarios/raft_scenario.py
@@ -97,13 +97,13 @@ class RAFTScenario(Scenario):
         self.subset = subset
         self.random_seed = random_seed
 
-    def load_prompt_construction_settings(self):
+    def load_prompt_construction_settings(self, output_path: str):
         # Load from prompt construction settings
         cache_dir = str(Path(output_path) / "data")
         return get_raft_prompt_settings(self.subset, cache_dir)
 
     def get_instances(self, output_path: str) -> List[Instance]:
-        fields, _ = self.load_prompt_construction_settings()
+        fields, _ = self.load_prompt_construction_settings(output_path)
         cache_dir = str(Path(output_path) / "data")
         # Download raw data
         # Note: Only using public labeled instances now. Check if we can get the hidden test set labels.

--- a/src/helm/benchmark/scenarios/real_toxicity_prompts_scenario.py
+++ b/src/helm/benchmark/scenarios/real_toxicity_prompts_scenario.py
@@ -24,8 +24,8 @@ class RealToxicityPromptsScenario(Scenario):
     description = "Toxicity analysis of LM generations when fed naturally occurring, sentence-level prompts."
     tags = ["harms", "toxicity"]
 
-    def get_instances(self) -> List[Instance]:
-        data_path = os.path.join(self.output_path, "data")
+    def get_instances(self, output_path: str) -> List[Instance]:
+        data_path = os.path.join(output_path, "data")
         ensure_file_downloaded(
             source_url="https://ai2-public-datasets.s3.amazonaws.com/realtoxicityprompts/"
             "realtoxicityprompts-data.tar.gz",

--- a/src/helm/benchmark/scenarios/scenario.py
+++ b/src/helm/benchmark/scenarios/scenario.py
@@ -219,7 +219,7 @@ class Scenario(ABC):
         self.definition_path = "https://github.com/stanford-crfm/helm/blob/main/src/" + path
 
     @abstractmethod
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         """
         Does the main work in the `Scenario` (e.g., download datasets, convert
         it into a list of instances).

--- a/src/helm/benchmark/scenarios/scenario.py
+++ b/src/helm/benchmark/scenarios/scenario.py
@@ -200,11 +200,6 @@ class Scenario(ABC):
     tags: List[str] = field(init=False)
     """Extra metadata (e.g., whether this is a question answering or commonsense task)"""
 
-    # Set by Runner.
-    # TODO: ideally would pass this into `get_instances` to not have to mutate.
-    output_path: str = field(init=False, default="")
-    """Where downloaded data is cached (to be set by the `Runner`)"""
-
     definition_path: str = field(init=False)
     """Where the scenario subclass for `self` is defined."""
 

--- a/src/helm/benchmark/scenarios/self_instruct_scenario.py
+++ b/src/helm/benchmark/scenarios/self_instruct_scenario.py
@@ -19,10 +19,10 @@ class SelfInstructScenario(Scenario):
     description = "Self-instruct eval dataset"
     tags = ["instructions"]
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         # Download the raw data
         source_url = "https://raw.githubusercontent.com/yizhongw/self-instruct/main/human_eval/user_oriented_instructions.jsonl"  # noqa: E501
-        tasks_path: str = os.path.join(self.output_path, "user_oriented_instructions.jsonl")
+        tasks_path: str = os.path.join(output_path, "user_oriented_instructions.jsonl")
 
         ensure_file_downloaded(
             source_url=source_url,

--- a/src/helm/benchmark/scenarios/simple_scenarios.py
+++ b/src/helm/benchmark/scenarios/simple_scenarios.py
@@ -26,7 +26,7 @@ class Simple1Scenario(Scenario):
         self.num_train_instances = num_train_instances
         self.num_test_instances = num_test_instances
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         random.seed(1)
 
         def generate_seq() -> List[str]:

--- a/src/helm/benchmark/scenarios/summarization_scenario.py
+++ b/src/helm/benchmark/scenarios/summarization_scenario.py
@@ -91,7 +91,7 @@ class SummarizationScenario(Scenario):
         return False
 
     def _download_dataset(self, url, tag):
-        data_dir = os.path.join(self.output_path, "data")
+        data_dir = os.path.join(output_path, "data")
         ensure_directory_exists(data_dir)
         ensure_file_downloaded(source_url=url, target_path=os.path.join(data_dir, f"{tag}.pk"))
 
@@ -121,7 +121,7 @@ class SummarizationScenario(Scenario):
 
         return dataset, article_key, summary_key
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         dataset, article_key, summary_key = self._load_dataset(self.dataset_name)
 
         splits = {"train": TRAIN_SPLIT, "validation": VALID_SPLIT, "test": TEST_SPLIT}

--- a/src/helm/benchmark/scenarios/summarization_scenario.py
+++ b/src/helm/benchmark/scenarios/summarization_scenario.py
@@ -90,7 +90,7 @@ class SummarizationScenario(Scenario):
 
         return False
 
-    def _download_dataset(self, url, tag):
+    def _download_dataset(self, url, tag, output_path: str):
         data_dir = os.path.join(output_path, "data")
         ensure_directory_exists(data_dir)
         ensure_file_downloaded(source_url=url, target_path=os.path.join(data_dir, f"{tag}.pk"))
@@ -100,20 +100,20 @@ class SummarizationScenario(Scenario):
 
         return dataset
 
-    def _load_dataset(self, dataset_name: str):
+    def _load_dataset(self, dataset_name: str, output_path: str):
         if dataset_name == "xsum":
             url = "https://worksheets.codalab.org/rest/bundles/0xac5607f21bf945939edc56ea945496d5/contents/blob/"
-            dataset = self._download_dataset(url, "xsum")
+            dataset = self._download_dataset(url, "xsum", output_path)
             article_key = "document"
             summary_key = "summary"
         elif dataset_name == "xsum-sampled":
             url = "https://worksheets.codalab.org/rest/bundles/0xcfbb0ef1226040f78e58060c9e4d13cf/contents/blob/"
-            dataset = self._download_dataset(url, "xsum-sampled")
+            dataset = self._download_dataset(url, "xsum-sampled", output_path)
             article_key = "document"
             summary_key = "summary"
         elif dataset_name == "cnn-dm":
             url = "https://worksheets.codalab.org/rest/bundles/0x07630390bbda44879a2ad36e2125d64c/contents/blob/"
-            dataset = self._download_dataset(url, "cnndm")
+            dataset = self._download_dataset(url, "cnndm", output_path)
             article_key = "article"
             summary_key = "highlights"
         else:
@@ -122,7 +122,7 @@ class SummarizationScenario(Scenario):
         return dataset, article_key, summary_key
 
     def get_instances(self, output_path: str) -> List[Instance]:
-        dataset, article_key, summary_key = self._load_dataset(self.dataset_name)
+        dataset, article_key, summary_key = self._load_dataset(self.dataset_name, output_path)
 
         splits = {"train": TRAIN_SPLIT, "validation": VALID_SPLIT, "test": TEST_SPLIT}
 

--- a/src/helm/benchmark/scenarios/synthetic_efficiency_scenario.py
+++ b/src/helm/benchmark/scenarios/synthetic_efficiency_scenario.py
@@ -47,7 +47,7 @@ class SyntheticEfficiencyScenario(Scenario):
         self.num_instances: int = num_instances
         self.tokenizer: str = tokenizer
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         instances: List[Instance] = []
         assert self.tokenizer in [
             "huggingface/gpt2",
@@ -69,7 +69,7 @@ class SyntheticEfficiencyScenario(Scenario):
                 f"tokenizer={self.tokenizer.replace('/', '_')},"
                 f"id={instance_id}.txt"
             )
-            data_path: str = os.path.join(self.output_path, file_name)
+            data_path: str = os.path.join(output_path, file_name)
             ensure_file_downloaded(
                 source_url=f"https://worksheets.codalab.org/rest/bundles/0x17a361bc066b4b0e87d968069759d361/"
                 f"contents/blob/{file_name}",

--- a/src/helm/benchmark/scenarios/synthetic_reasoning_natural_scenario.py
+++ b/src/helm/benchmark/scenarios/synthetic_reasoning_natural_scenario.py
@@ -352,7 +352,7 @@ class SRNScenario(Scenario):
         )
         return rules, test_fact, test_rules_used, target_fact
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         # Read all the instances
         instances: List[Instance] = []
         random.seed(self.random_seed)

--- a/src/helm/benchmark/scenarios/synthetic_reasoning_scenario.py
+++ b/src/helm/benchmark/scenarios/synthetic_reasoning_scenario.py
@@ -139,7 +139,7 @@ class SyntheticReasoningScenario(Scenario):
         self.rng.shuffle(pattern)
         return pattern
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         # We fix the seed for data generation to ensure reproducibility.
         # Read all the instances
         instances: List[Instance] = []

--- a/src/helm/benchmark/scenarios/test_scenario.py
+++ b/src/helm/benchmark/scenarios/test_scenario.py
@@ -7,7 +7,7 @@ class TestScenario:
         self.scenario: Scenario = create_scenario(get_scenario_spec_tiny())
 
     def test_render_lines(self):
-        instances = self.scenario.get_instances()
+        instances = self.scenario.get_instances(output_path="")
         assert self.scenario.render_lines(instances) == [
             "name: simple1",
             "description: A simple scenario",

--- a/src/helm/benchmark/scenarios/the_pile_scenario.py
+++ b/src/helm/benchmark/scenarios/the_pile_scenario.py
@@ -51,7 +51,7 @@ class ThePileScenario(Scenario):
         self.subset = subset
 
     @htrack(None)
-    def load_and_cache_all_subsets(self):
+    def load_and_cache_all_subsets(self, output_path: str):
         data_path = os.path.join(output_path, "data")
         subsets = {subset: [] for subset in self.pile_subsets}
 
@@ -88,7 +88,7 @@ class ThePileScenario(Scenario):
 
         # If the target subset does not exist, load and cache all subsets to the directory
         if not os.path.exists(subset_path):
-            self.load_and_cache_all_subsets()
+            self.load_and_cache_all_subsets(output_path)
 
         # Read all the instances
         instances = []

--- a/src/helm/benchmark/scenarios/the_pile_scenario.py
+++ b/src/helm/benchmark/scenarios/the_pile_scenario.py
@@ -52,7 +52,7 @@ class ThePileScenario(Scenario):
 
     @htrack(None)
     def load_and_cache_all_subsets(self):
-        data_path = os.path.join(self.output_path, "data")
+        data_path = os.path.join(output_path, "data")
         subsets = {subset: [] for subset in self.pile_subsets}
 
         # Load all data into memory
@@ -68,23 +68,23 @@ class ThePileScenario(Scenario):
 
         # Write each subset to disk
         with htrack_block("Caching"):
-            hlog(f"Caching subsets to {self.output_path}")
+            hlog(f"Caching subsets to {output_path}")
             for subset in subsets:
-                subset_path = os.path.join(self.output_path, subset + ".csv")
+                subset_path = os.path.join(output_path, subset + ".csv")
                 with open(subset_path, "w") as f:
                     writer = csv.writer(f)
                     writer.writerows(subsets[subset])
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         # Download the raw data
-        data_path = os.path.join(self.output_path, "data")
+        data_path = os.path.join(output_path, "data")
         ensure_file_downloaded(
             source_url="https://the-eye.eu/public/AI/pile/test.jsonl.zst",
             target_path=data_path,
             unpack=True,
         )
 
-        subset_path = os.path.join(self.output_path, self.subset + ".csv")
+        subset_path = os.path.join(output_path, self.subset + ".csv")
 
         # If the target subset does not exist, load and cache all subsets to the directory
         if not os.path.exists(subset_path):

--- a/src/helm/benchmark/scenarios/the_pile_scenario.py
+++ b/src/helm/benchmark/scenarios/the_pile_scenario.py
@@ -51,7 +51,7 @@ class ThePileScenario(Scenario):
         self.subset = subset
 
     @htrack(None)
-    def load_and_cache_all_subsets(self, output_path: str):
+    def load_and_cache_all_subsets(self, output_path):
         data_path = os.path.join(output_path, "data")
         subsets = {subset: [] for subset in self.pile_subsets}
 

--- a/src/helm/benchmark/scenarios/truthful_qa_scenario.py
+++ b/src/helm/benchmark/scenarios/truthful_qa_scenario.py
@@ -64,7 +64,7 @@ class TruthfulQAScenario(Scenario):
         self.task = task
         assert self.task in self.TASK_NAMES
 
-    def download_dataset(self):
+    def download_dataset(self, output_path: str):
         """Downloads the TruthfulQA dataset."""
         # Download the raw data
         data_dir = os.path.join(output_path, "data")
@@ -72,7 +72,7 @@ class TruthfulQAScenario(Scenario):
         ensure_directory_exists(data_dir)
         ensure_file_downloaded(source_url=url, target_path=os.path.join(data_dir, self.DATASET_FILE_NAME))
 
-    def load_dataset(self) -> List[Dict[str, Any]]:
+    def load_dataset(self, output_path: str) -> List[Dict[str, Any]]:
         """Loads the dataset downloaded in download_dataset()."""
         file_path = os.path.join(output_path, "data", self.DATASET_FILE_NAME)
         data = []
@@ -137,8 +137,8 @@ class TruthfulQAScenario(Scenario):
             return instances
 
         # Body of the function
-        self.download_dataset()
-        data = self.load_dataset()
+        self.download_dataset(output_path)
+        data = self.load_dataset(output_path)
         split_k = int(len(data) * self.TRAIN_RATIO)
         train_instances: List[Instance] = get_split_instances(TRAIN_SPLIT, data[:split_k])
         valid_instances: List[Instance] = get_split_instances(VALID_SPLIT, data[split_k:])

--- a/src/helm/benchmark/scenarios/truthful_qa_scenario.py
+++ b/src/helm/benchmark/scenarios/truthful_qa_scenario.py
@@ -67,14 +67,14 @@ class TruthfulQAScenario(Scenario):
     def download_dataset(self):
         """Downloads the TruthfulQA dataset."""
         # Download the raw data
-        data_dir = os.path.join(self.output_path, "data")
+        data_dir = os.path.join(output_path, "data")
         url = "https://raw.githubusercontent.com/sylinrl/TruthfulQA/main/TruthfulQA.csv"
         ensure_directory_exists(data_dir)
         ensure_file_downloaded(source_url=url, target_path=os.path.join(data_dir, self.DATASET_FILE_NAME))
 
     def load_dataset(self) -> List[Dict[str, Any]]:
         """Loads the dataset downloaded in download_dataset()."""
-        file_path = os.path.join(self.output_path, "data", self.DATASET_FILE_NAME)
+        file_path = os.path.join(output_path, "data", self.DATASET_FILE_NAME)
         data = []
         with open(file_path, encoding="utf-8") as f:
             # Skip headers
@@ -93,7 +93,7 @@ class TruthfulQAScenario(Scenario):
                 data.append(data_point)
         return data
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         """Returns the instances for this scenario."""
 
         def format_str(unformatted_str: str) -> str:

--- a/src/helm/benchmark/scenarios/twitter_aae_scenario.py
+++ b/src/helm/benchmark/scenarios/twitter_aae_scenario.py
@@ -35,9 +35,9 @@ class TwitterAAEScenario(Scenario):
         assert demographic in ["aa", "white"], f"Unsupported demographic: {demographic}"
         self.demographic: str = demographic
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         # Download the raw data
-        data_path: str = os.path.join(self.output_path, f"{self.demographic}_tweets.csv")
+        data_path: str = os.path.join(output_path, f"{self.demographic}_tweets.csv")
         ensure_file_downloaded(
             source_url=CODALAB_URI_TEMPLATE.format(demographic=self.demographic),
             target_path=data_path,

--- a/src/helm/benchmark/scenarios/verifiability_judgment_scenario.py
+++ b/src/helm/benchmark/scenarios/verifiability_judgment_scenario.py
@@ -128,8 +128,8 @@ class VerifiabilityJudgementScenario(Scenario):
             file_instances.append(instance)
         return file_instances
 
-    def get_instances(self) -> List[Instance]:
-        data_path: str = os.path.join(self.output_path, "data")
+    def get_instances(self, output_path: str) -> List[Instance]:
+        data_path: str = os.path.join(output_path, "data")
 
         split_to_filesplit: Dict[str, str] = {TRAIN_SPLIT: "train", VALID_SPLIT: "dev", TEST_SPLIT: "test"}
 

--- a/src/helm/benchmark/scenarios/vicuna_scenario.py
+++ b/src/helm/benchmark/scenarios/vicuna_scenario.py
@@ -21,13 +21,13 @@ class VicunaScenario(Scenario):
         super().__init__()
         self.category: str = category
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         def matches_target_category(raw: dict) -> bool:
             return self.category == "all" or raw["category"] == self.category
 
         # Download the raw data
         source_url = "https://raw.githubusercontent.com/lm-sys/FastChat/main/fastchat/eval/table/question.jsonl"
-        data_path: str = os.path.join(self.output_path, "vicuna_questions.jsonl")
+        data_path: str = os.path.join(output_path, "vicuna_questions.jsonl")
 
         ensure_file_downloaded(
             source_url=source_url,

--- a/src/helm/benchmark/scenarios/vision_language/vqa_scenario.py
+++ b/src/helm/benchmark/scenarios/vision_language/vqa_scenario.py
@@ -58,11 +58,11 @@ class VQAScenario(Scenario):
     description = "Open-ended questions about images ([paper](https://arxiv.org/abs/1612.00837))."
     tags = ["vision-language", "visual question answering"]
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         instances: List[Instance] = []
         for split in [TRAIN_SPLIT, VALID_SPLIT]:
             # Download the questions and answers
-            split_path: str = os.path.join(self.output_path, split)
+            split_path: str = os.path.join(output_path, split)
             ensure_directory_exists(split_path)
             questions_path: str = os.path.join(split_path, "questions.json")
             ensure_file_downloaded(

--- a/src/helm/benchmark/scenarios/wikifact_scenario.py
+++ b/src/helm/benchmark/scenarios/wikifact_scenario.py
@@ -128,9 +128,9 @@ class WIKIFactScenario(Scenario):
         self.subject: str = subject
         assert subject in NAME_TO_PID, f"Invalid subject: {subject}"
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         # Download the raw data
-        data_path: str = os.path.join(self.output_path, "data")
+        data_path: str = os.path.join(output_path, "data")
         ensure_directory_exists(data_path)
 
         # Read all the instances

--- a/src/helm/benchmark/scenarios/wikitext_103_scenario.py
+++ b/src/helm/benchmark/scenarios/wikitext_103_scenario.py
@@ -23,9 +23,9 @@ class Wikitext103Scenario(Scenario):
     description = "The WikiText language modeling dataset containing over 103 million words"
     tags = ["language_modeling"]
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         # Download the raw data
-        data_path = os.path.join(self.output_path, "data")
+        data_path = os.path.join(output_path, "data")
         ensure_file_downloaded(
             source_url="https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-103-raw-v1.zip",
             target_path=data_path,

--- a/src/helm/benchmark/scenarios/wmt_14_scenario.py
+++ b/src/helm/benchmark/scenarios/wmt_14_scenario.py
@@ -58,7 +58,7 @@ class WMT14Scenario(Scenario):
                 deduplicated_dataset.append(example)
         return deduplicated_dataset
 
-    def get_instances(self) -> List[Instance]:
+    def get_instances(self, output_path: str) -> List[Instance]:
         hlog("Loading the HuggingFace dataset. The first time could take several minutes.")
         subset_name = f"{self.source_language if self.source_language!='en' else self.target_language}-en"
         hf_dataset: Any = load_dataset("wmt14", subset_name)

--- a/src/helm/benchmark/test_data_preprocessor.py
+++ b/src/helm/benchmark/test_data_preprocessor.py
@@ -12,7 +12,7 @@ def test_data_preprocessor():
     # Test that each Instance is given a unique ID and is preserved through data augmentation
     data_preprocessor = DataPreprocessor(DataAugmenterSpec())
     scenario: Scenario = create_scenario(get_scenario_spec1())
-    instances = with_instance_ids(scenario.get_instances())
+    instances = with_instance_ids(scenario.get_instances(output_path=""))
     instances: List[Instance] = data_preprocessor.preprocess(instances)
     for i, instance in enumerate(instances):
         assert instance.id == f"id{i}"
@@ -33,7 +33,7 @@ def test_data_preprocessor_with_data_augmentation():
     )
     data_preprocessor = DataPreprocessor(data_augmenter_spec)
     scenario: Scenario = create_scenario(get_scenario_spec1())
-    instances = with_instance_ids(scenario.get_instances())
+    instances = with_instance_ids(scenario.get_instances(output_path=""))
     instances: List[Instance] = data_preprocessor.preprocess(instances)
     assert len(instances) == 10 + 10 + 10  # original train + original eval + perturbed eval
 

--- a/src/helm/proxy/clients/huggingface_client.py
+++ b/src/helm/proxy/clients/huggingface_client.py
@@ -90,12 +90,12 @@ class HuggingFaceServer:
             stop_sequence_ids = self.tokenizer(
                 raw_request["stop_sequences"], return_token_type_ids=False, add_special_tokens=False
             )
-            assert len(stop_sequence_ids.input_ids) == 1, "Total number of stop sequences should be 1."
-            if len(stop_sequence_ids.input_ids[0]) == 1:
+            if len(stop_sequence_ids.input_ids) == 1 and len(stop_sequence_ids.input_ids[0]) == 1:
                 raw_request["eos_token_id"] = stop_sequence_ids.input_ids[0][0]
             else:
                 stopping_criteria = StoppingCriteriaList()
-                stopping_criteria.append(StopAtSpecificTokenCriteria(stop_sequence=stop_sequence_ids.input_ids[0]))
+                for stop_sequence_input_ids in stop_sequence_ids.input_ids:
+                    stopping_criteria.append(StopAtSpecificTokenCriteria(stop_sequence=stop_sequence_input_ids))
             del raw_request["stop_sequences"]
 
         # Strip out irrelevant parameters
@@ -201,10 +201,6 @@ class HuggingFaceClient(Client):
         # Embedding not supported for this model
         if request.embedding:
             return EMBEDDING_UNAVAILABLE_REQUEST_RESULT
-
-        # Only a single stop sequence is supported as we can only pass in a single value for `eos_token_id`
-        if len(request.stop_sequences) > 1:
-            raise ValueError("More than one stop sequence is not supported.")
 
         raw_request = {
             "engine": request.model_engine,


### PR DESCRIPTION
This resolves a TODO and makes the code easier to trace as we no longer have to rely on setting a member variable before calling a function.