### PR TITLE
Move generate_requests down to InContextLearningAdapter

### DIFF
--- a/src/helm/benchmark/adaptation/adapters/adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/adapter.py
@@ -4,7 +4,6 @@ from typing import List
 import numpy as np
 
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
-from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.adaptation.scenario_state import ScenarioState
 from helm.benchmark.scenarios.scenario import Instance, TRAIN_SPLIT, EVAL_SPLITS
 from helm.benchmark.window_services.tokenizer_service import TokenizerService
@@ -30,13 +29,6 @@ class Adapter(ABC):
         """
         Takes a a list of `Instance`s and returns a `ScenarioState` with the
         list of corresponding `RequestState`s.
-        """
-        pass
-
-    @abstractmethod
-    def generate_requests(self, eval_instance: Instance) -> List[RequestState]:
-        """
-        Given a validation or test `Instance`, generates one or more `RequestState`s.
         """
         pass
 

--- a/src/helm/benchmark/adaptation/adapters/in_context_learning_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/in_context_learning_adapter.py
@@ -1,5 +1,5 @@
 import random
-from abc import ABC
+from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import replace
 from itertools import cycle
@@ -19,6 +19,13 @@ class InContextLearningAdapter(Adapter, ABC):
     An `Adapter`, guided by the `AdapterSpec`, takes a `Scenario` and produces
     a `ScenarioState`. It has additional logic surrounding in-context examples.
     """
+
+    @abstractmethod
+    def generate_requests(self, eval_instance: Instance) -> List[RequestState]:
+        """
+        Given a validation or test `Instance`, generates one or more `RequestState`s.
+        """
+        pass
 
     @htrack(None)
     def adapt(self, instances: List[Instance], parallelism: int) -> ScenarioState:

--- a/src/helm/benchmark/adaptation/adapters/language_modeling_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/language_modeling_adapter.py
@@ -36,13 +36,13 @@ class LanguageModelingAdapter(Adapter):
         hlog(f"{len(eval_instances)} eval instances")
 
         all_request_states: List[RequestState] = flatten_list(
-            parallel_map(self.generate_requests, instances, parallelism)
+            parallel_map(self._generate_requests, instances, parallelism)
         )
         hlog(f"{len(all_request_states)} requests")
 
         return ScenarioState(self.adapter_spec, all_request_states)
 
-    def generate_requests(self, eval_instance: Instance) -> List[RequestState]:
+    def _generate_requests(self, eval_instance: Instance) -> List[RequestState]:
         """
         Adapted from https://github.com/EleutherAI/lm_perplexity/blob/main/lm_perplexity/utils.py.
         """

--- a/src/helm/benchmark/adaptation/adapters/test_generation_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/test_generation_adapter.py
@@ -1,7 +1,16 @@
 # mypy: check_untyped_defs = False
 from typing import List
 
-from helm.benchmark.scenarios.scenario import CORRECT_TAG, create_scenario, Instance, Reference, Input, Output
+from helm.benchmark.scenarios.scenario import (
+    CORRECT_TAG,
+    TEST_SPLIT,
+    TRAIN_SPLIT,
+    create_scenario,
+    Instance,
+    Reference,
+    Input,
+    Output,
+)
 from helm.benchmark.run_specs import get_scenario_spec1, get_adapter_spec1
 from helm.benchmark.adaptation.prompt import Prompt
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
@@ -136,9 +145,11 @@ class TestGenerationAdapter(TestAdapter):
             previous_train_instances.append(train_instances)
 
     def test_multiple_correct_reference(self):
-        adapter_spec = AdapterSpec(method=ADAPT_GENERATION, model="openai/ada", max_train_instances=2)
+        adapter_spec = AdapterSpec(
+            method=ADAPT_GENERATION, model="openai/ada", max_train_instances=2, sample_train=False
+        )
         adapter = AdapterFactory.get_adapter(adapter_spec, self.tokenizer_service)
-        adapter.train_instances = [
+        train_instances = [
             Instance(
                 Input(text="Second reference is correct"),
                 references=[
@@ -146,6 +157,7 @@ class TestGenerationAdapter(TestAdapter):
                     Reference(Output(text="Second"), tags=[CORRECT_TAG]),
                     Reference(Output(text="Third"), tags=[]),
                 ],
+                split=TRAIN_SPLIT,
             ),
             Instance(
                 Input(text="First and second references are correct"),
@@ -154,9 +166,9 @@ class TestGenerationAdapter(TestAdapter):
                     Reference(Output(text="Second"), tags=[CORRECT_TAG]),
                     Reference(Output(text="Third"), tags=[]),
                 ],
+                split=TRAIN_SPLIT,
             ),
         ]
-        adapter.train_trial_index = 0
         eval_instance = Instance(
             Input(text="First reference is correct"),
             references=[
@@ -164,8 +176,9 @@ class TestGenerationAdapter(TestAdapter):
                 Reference(Output(text="Second"), tags=[]),
                 Reference(Output(text="Third"), tags=[]),
             ],
+            split=TEST_SPLIT,
         )
-        actual_instances = adapter.generate_requests(eval_instance)
+        actual_instances = adapter.adapt(train_instances + [eval_instance], parallelism=1).request_states
         assert len(actual_instances) == 1
         assert actual_instances[0].request.prompt == (
             "Input: Second reference is correct\n"
@@ -177,9 +190,11 @@ class TestGenerationAdapter(TestAdapter):
         )
 
     def test_multiple_correct_reference_multi_label(self):
-        adapter_spec = AdapterSpec(method=ADAPT_GENERATION, model="openai/ada", max_train_instances=2, multi_label=True)
+        adapter_spec = AdapterSpec(
+            method=ADAPT_GENERATION, model="openai/ada", max_train_instances=2, multi_label=True, sample_train=False
+        )
         adapter = AdapterFactory.get_adapter(adapter_spec, self.tokenizer_service)
-        adapter.train_instances = [
+        train_instances = [
             Instance(
                 Input(text="Second reference is correct"),
                 references=[
@@ -187,6 +202,7 @@ class TestGenerationAdapter(TestAdapter):
                     Reference(Output(text="Second"), tags=[CORRECT_TAG]),
                     Reference(Output(text="Third"), tags=[]),
                 ],
+                split=TRAIN_SPLIT,
             ),
             Instance(
                 Input(text="First and second references are correct"),
@@ -195,9 +211,9 @@ class TestGenerationAdapter(TestAdapter):
                     Reference(Output(text="Second"), tags=[CORRECT_TAG]),
                     Reference(Output(text="Third"), tags=[]),
                 ],
+                split=TRAIN_SPLIT,
             ),
         ]
-        adapter.train_trial_index = 0
         eval_instance = Instance(
             Input(text="First reference is correct"),
             references=[
@@ -205,8 +221,9 @@ class TestGenerationAdapter(TestAdapter):
                 Reference(Output(text="Second"), tags=[]),
                 Reference(Output(text="Third"), tags=[]),
             ],
+            split=TEST_SPLIT,
         )
-        actual_instances = adapter.generate_requests(eval_instance)
+        actual_instances = adapter.adapt(train_instances + [eval_instance], parallelism=1).request_states
         assert len(actual_instances) == 1
         assert actual_instances[0].request.prompt == (
             "Input: Second reference is correct\n"

--- a/src/helm/benchmark/adaptation/adapters/test_language_modeling_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/test_language_modeling_adapter.py
@@ -83,7 +83,7 @@ class TestLanguageModelingAdapter(TestAdapter):
             references=[reference],
         )
         # Ensure the adapter returns the correct prompt
-        request_states: List[RequestState] = adapter.generate_requests(instance)
+        request_states: List[RequestState] = adapter.adapt([instance], parallelism=1).request_states
         request: Request = request_states[0].request
         # The prompt should be "<|endoftext|>Excuse me, do you have the time?"
         assert request.prompt == "<|endoftext|>Excuse me, do you have the time?"
@@ -94,7 +94,7 @@ class TestLanguageModelingAdapter(TestAdapter):
             input=input_text_long,
             references=[reference],
         )
-        request_states_long: List[RequestState] = adapter.generate_requests(instance_long)
+        request_states_long: List[RequestState] = adapter.adapt([instance_long], parallelism=1).request_states
         request_long: Request = request_states_long[0].request
         # Count the number of tokens of the prompt
         num_tokens = len(adapter.window_service.encode(request_long.prompt).token_values)
@@ -111,7 +111,7 @@ class TestLanguageModelingAdapter(TestAdapter):
         adapter_2 = AdapterFactory.get_adapter(adapter_spec_2_, self.tokenizer_service)
 
         # Step 2.1. Check that if the prompt is not too long, it is not truncated
-        request_state_2: List[RequestState] = adapter_2.generate_requests(instance)
+        request_state_2: List[RequestState] = adapter_2.adapt([instance], parallelism=1).request_states
         request_2: Request = request_state_2[0].request
         # The prompt should be unchanged
         assert request_2.prompt == "<|endoftext|>Excuse me, do you have the time?"
@@ -119,7 +119,7 @@ class TestLanguageModelingAdapter(TestAdapter):
 
         # Step 2.2. Check that if the prompt + max_tokens is too long, it is truncated
         # but that we keep the same number of tokens as in the previous test
-        request_states_long_2: List[RequestState] = adapter_2.generate_requests(instance_long)
+        request_states_long_2: List[RequestState] = adapter_2.adapt([instance_long], parallelism=1).request_states
         request_long_2: Request = request_states_long_2[0].request
         # Count the number of tokens of the prompt
         num_tokens_2 = len(adapter_2.window_service.encode(request_long_2.prompt).token_values)


### PR DESCRIPTION
Clients of adapter should use "adapt" instead. Furthermore, InContextLearningAdapter actually needs two more arguments to generate requests: training instances and train_trial_index. In a followup PR I'll add those so they aren't passed via "self".