### PR TITLE
Move some perturbation, scenario and metrics datasets from CodaLab to GCS

### DIFF
--- a/src/helm/benchmark/augmentations/dialect_perturbation.py
+++ b/src/helm/benchmark/augmentations/dialect_perturbation.py
@@ -30,7 +30,7 @@ class DialectPerturbation(Perturbation):
 
     Keys are tuples of the form (source_class, target_class), such as
     ("SAE", "AAVE"). Mapping dictionaries are from the sources listed below,
-    converted to JSON and stored in CodaLab.
+    converted to JSON and stored in Google Cloud Storage.
 
         (1) SAE to AAVE dictionary is from Ziems et al. (2022)
 
@@ -39,7 +39,10 @@ class DialectPerturbation(Perturbation):
 
     """
     MAPPING_DICT_URIS = {
-        (SAE, AAVE): "https://worksheets.codalab.org/rest/bundles/0x3523e02bd46b42bcad783292b40b4e38/contents/blob/"
+        (SAE, AAVE): (
+            "https://storage.googleapis.com/crfm-helm-public/source_datasets/"
+            "augmentations/dialect_perturbation/SAE_to_AAVE_mapping.json"
+        )
     }
 
     @dataclass(frozen=True)

--- a/src/helm/benchmark/augmentations/person_name_perturbation.py
+++ b/src/helm/benchmark/augmentations/person_name_perturbation.py
@@ -30,10 +30,11 @@ class PersonNamePerturbation(Perturbation):
     LINE_SEP = "\n"
 
     """ Information needed to download person_names.txt """
-    CODALAB_URI_TEMPLATE: str = "https://worksheets.codalab.org/rest/bundles/{bundle}/contents/blob/"
-    CODALAB_BUNDLE: str = "0xa65e8f9a107c44f198eb4ad356bbda34"
     FILE_NAME: str = "person_names.txt"
-    SOURCE_URI: str = CODALAB_URI_TEMPLATE.format(bundle=CODALAB_BUNDLE)
+    SOURCE_URI: str = (
+        "https://storage.googleapis.com/crfm-helm-public/source_datasets/"
+        "augmentations/person_name_perturbation/person_names.txt"
+    )
     OUTPUT_PATH = os.path.join("benchmark_output", "perturbations", name)
 
     """ Name types """
@@ -79,7 +80,7 @@ class PersonNamePerturbation(Perturbation):
         If name_file_path isn't provided, we use our default name mapping
         file, which can be found at:
 
-            https://worksheets.codalab.org/rest/bundles/0xa65e8f9a107c44f198eb4ad356bbda34/contents/blob/
+            https://storage.googleapis.com/crfm-helm-public/source_datasets/augmentations/person_name_perturbation/person_names.txt
 
         The **available categories** in our default file and their values are as follows:
 
@@ -214,7 +215,7 @@ class PersonNamePerturbation(Perturbation):
         return possible_names
 
     def download_name_file(self) -> str:
-        """Download the name file from CodaLab"""
+        """Download the name file from Google Cloud Storage"""
         data_path = os.path.join(self.output_path, "data")
         file_path: str = os.path.join(data_path, self.FILE_NAME)
         ensure_directory_exists(data_path)

--- a/src/helm/benchmark/augmentations/synonym_perturbation.py
+++ b/src/helm/benchmark/augmentations/synonym_perturbation.py
@@ -40,10 +40,11 @@ class SynonymPerturbation(Perturbation):
     name: str = "synonym"
 
     # For downloading wordnet_synonyms.json
-    CODALAB_URI_TEMPLATE: str = "https://worksheets.codalab.org/rest/bundles/{bundle}/contents/blob/"
-    CODALAB_BUNDLE: str = "0x92a07ef9f82941e6a75b2f3b27961e8c"
     FILE_NAME: str = "wordnet_synonyms.json"
-    SOURCE_URI: str = CODALAB_URI_TEMPLATE.format(bundle=CODALAB_BUNDLE)
+    SOURCE_URI: str = (
+        "https://storage.googleapis.com/crfm-helm-public/source_datasets/"
+        "augmentations/synonym_perturbation/wordnet_synonyms.json"
+    )
 
     def __init__(self, prob: float):
         # Assign parameters to instance variables

--- a/src/helm/benchmark/metrics/summarization_metrics.py
+++ b/src/helm/benchmark/metrics/summarization_metrics.py
@@ -23,12 +23,11 @@ from .summac.model_summac import SummaCZS
 from bert_score import BERTScorer
 
 
-QAFACTEVAL_CODALAB_LINK: str = (
-    "https://worksheets.codalab.org/rest/bundles/0xf4de83c1f0d34d7999480223e8f5ab87/contents/blob/"
+QAFACTEVAL_URL: str = (
+    "https://storage.googleapis.com/crfm-helm-public/source_datasets/metrics/summarization_metrics/qafacteval.pk"
 )
-HUMAN_EVAL_CODALAB_LINK: str = (
-    "https://worksheets.codalab.org/rest/bundles/0x3fb04ae3ae024c369d048f6c2cdf16cb/"
-    "contents/blob/codalab_merged_results/{file_name}"
+HUMAN_EVAL_URL: str = (
+    "https://storage.cloud.google.com/crfm-helm-public/source_datasets/metrics/summarization_metrics/{file_name}"
 )
 
 
@@ -79,7 +78,7 @@ class SummarizationMetric(Metric):
 
     def _load_qafacteval(self, eval_cache_path: str):
         target_path: str = os.path.join(eval_cache_path, "qafacteval.pk")
-        ensure_file_downloaded(source_url=QAFACTEVAL_CODALAB_LINK, target_path=target_path)
+        ensure_file_downloaded(source_url=QAFACTEVAL_URL, target_path=target_path)
 
         with open(target_path, "rb") as fin:
             qafacteval_scores = pickle.load(fin)
@@ -271,7 +270,7 @@ class SummarizationHumanEvalAnalyzer:
 
         tasks_by_id = defaultdict(list)
 
-        download_filename = HUMAN_EVAL_CODALAB_LINK.format(file_name=filename)
+        download_filename = HUMAN_EVAL_URL.format(file_name=filename)
         filename = os.path.join(self.eval_download_path, filename)
         ensure_file_downloaded(source_url=download_filename, target_path=filename)
         mturk_data = pandas.read_csv(filename)

--- a/src/helm/benchmark/scenarios/summarization_scenario.py
+++ b/src/helm/benchmark/scenarios/summarization_scenario.py
@@ -107,12 +107,18 @@ class SummarizationScenario(Scenario):
             article_key = "document"
             summary_key = "summary"
         elif dataset_name == "xsum-sampled":
-            url = "https://worksheets.codalab.org/rest/bundles/0xcfbb0ef1226040f78e58060c9e4d13cf/contents/blob/"
+            url = (
+                "https://storage.googleapis.com/crfm-helm-public/source_datasets/"
+                "scenarios/summarization_scenario/xsum-sampled.pk"
+            )
             dataset = self._download_dataset(url, "xsum-sampled", output_path)
             article_key = "document"
             summary_key = "summary"
         elif dataset_name == "cnn-dm":
-            url = "https://worksheets.codalab.org/rest/bundles/0x07630390bbda44879a2ad36e2125d64c/contents/blob/"
+            url = (
+                "https://storage.cloud.google.com/crfm-helm-public/source_datasets/"
+                "scenarios/summarization_scenario/cnndm.pk"
+            )
             dataset = self._download_dataset(url, "cnndm", output_path)
             article_key = "article"
             summary_key = "highlights"

--- a/src/helm/benchmark/scenarios/summarization_scenario.py
+++ b/src/helm/benchmark/scenarios/summarization_scenario.py
@@ -102,7 +102,10 @@ class SummarizationScenario(Scenario):
 
     def _load_dataset(self, dataset_name: str, output_path: str):
         if dataset_name == "xsum":
-            url = "https://worksheets.codalab.org/rest/bundles/0xac5607f21bf945939edc56ea945496d5/contents/blob/"
+            url = (
+                "https://storage.googleapis.com/crfm-helm-public/source_datasets/"
+                "scenarios/summarization_scenario/xsum.pk"
+            )
             dataset = self._download_dataset(url, "xsum", output_path)
             article_key = "document"
             summary_key = "summary"


### PR DESCRIPTION
This affects `dialect_perburbation`, `synonym_perturbation`, `person_name_perturbation`, `summarization_scenario` and `summarization_metrics`.

Addresses #1930