### PR TITLE
Increase timeout in http_model_client.py

### DIFF
--- a/src/helm/proxy/clients/http_model_client.py
+++ b/src/helm/proxy/clients/http_model_client.py
@@ -29,7 +29,7 @@ class HTTPModelClient(Client):
         self,
         cache_config: CacheConfig,
         base_url: str = "http://localhost:8080",
-        timeout: int = 300,
+        timeout: int = 3000,
         do_cache: bool = False,
     ):
         self.cache: Optional[Cache] = Cache(cache_config) if do_cache else None


### PR DESCRIPTION
Some users are reporting timeouts with 70b models, we're capping running times by saying the total runtime of docker image needs to be 2h but people are free to take longer on individual examples if they so choose

```
We are trying to use llama 70b, but occasionally encounter the following request problems during the reasoning process: Request error: HTTPConnectionPool(host='localhost', port=8080): Read timed out. (read timeout=300), Can the single request time be extended? Or do we have to complete it in 300 seconds? Thank you for your help
```