### PR TITLE
Simplify the incremental release frontend

### DIFF
--- a/src/helm/benchmark/server.py
+++ b/src/helm/benchmark/server.py
@@ -63,7 +63,7 @@ def main():
         "--release",
         type=str,
         default=None,
-        help="Experimental: The release to serve. If unset, serve the latest suite instead.",
+        help="Experimental: The release to serve. If unset, don't serve a release, and serve the latest suite instead.",
     )
     args = parser.parse_args()
 
@@ -80,9 +80,13 @@ def main():
     app.config["helm.staticpath"] = static_path
 
     if urllib.parse.urlparse(args.output_path).scheme in ["http", "https"]:
+        # Output path is a URL, so set the output path base URL in the frontend to that URL
+        # so that the frontend reads from that URL directly.
         app.config["helm.outputpath"] = None
         app.config["helm.outputurl"] = args.output_path
     else:
+        # Output path is a location on disk, so set the output path base URL to /benchmark_output
+        # and then serve files from the location on disk at that URL.
         app.config["helm.outputpath"] = path.abspath(args.output_path)
         app.config["helm.outputurl"] = "benchmark_output"
 

--- a/src/helm/benchmark/server.py
+++ b/src/helm/benchmark/server.py
@@ -13,9 +13,13 @@ from bottle import Bottle, static_file
 app = Bottle()
 
 
-@app.get("/benchmark_output/using_release")
-def serve_release():
-    return {"use_release": use_release}
+@app.get("/config.js")
+def serve_config():
+    return (
+        'window.BENCHMARK_OUTPUT_BASE_URL = "benchmark_output";\n'
+        'window.SUITE = "latest";\n'
+        "window.RELEASE = null;\n"
+    )
 
 
 @app.get("/benchmark_output/<filename:path>")

--- a/src/helm/benchmark/static/benchmarking.js
+++ b/src/helm/benchmark/static/benchmarking.js
@@ -790,20 +790,30 @@ $(function () {
       return JSON.stringify(instance);
     }
 
-    const suite = getSuiteForRun(runNameToSuite, runSpec.name);
-
     // Paths (parallel arrays corresponding to `runSpecs`)
     const statsPaths = runSpecs.map((runSpec) => {
-      return statsJsonUrl(suite, runSpec.name);
+      return statsJsonUrl(
+        getSuiteForRun(runNameToSuite, runSpec.name),
+        runSpec.name,
+      );
     });
     const scenarioStatePaths = runSpecs.map((runSpec) => {
-      return scenarioStateJsonUrl(suite, runSpec.name);
+      return scenarioStateJsonUrl(
+        getSuiteForRun(runNameToSuite, runSpec.name),
+        runSpec.name,
+      );
     });
     const runSpecPaths = runSpecs.map((runSpec) => {
-      return runSpecJsonUrl(suite, runSpec.name);
+      return runSpecJsonUrl(
+        getSuiteForRun(runNameToSuite, runSpec.name),
+        runSpec.name,
+      );
     });
     const predictionsPaths = runSpecs.map((runSpec) => {
-      return predictionsJsonUrl(suite, runSpec.name);
+      return predictionsJsonUrl(
+        getSuiteForRun(runNameToSuite, runSpec.name),
+        runSpec.name,
+      );
     });
 
     // Figure out short names for the runs based on where they differ
@@ -1575,6 +1585,15 @@ $(function () {
   //////////////////////////////////////////////////////////////////////////////
   const $main = $("#main");
   const $summary = $("#summary");
+
+  // Allow overriding release or suite with URL params for debugging.
+  if (urlParams.release) {
+    window.RELEASE = urlParams.release;
+    window.SUITE = null;
+  } else if (urlParams.suite) {
+    window.RELEASE = null;
+    window.SUITE = urlParams.suite;
+  }
 
   // Extra function wrapper to preserve indentation for review
   // TODO: Remove before merging.

--- a/src/helm/benchmark/static/benchmarking.js
+++ b/src/helm/benchmark/static/benchmarking.js
@@ -1595,118 +1595,112 @@ $(function () {
     window.SUITE = urlParams.suite;
   }
 
-  // Extra function wrapper to preserve indentation for review
-  // TODO: Remove before merging.
-  (function () {
-    const schemaPromise = $.get("schema.yaml", {}, (response) => {
-      const raw = jsyaml.load(response);
-      console.log("schema", raw);
-      schema = new Schema(raw);
-    });
+  const schemaPromise = $.get("schema.yaml", {}, (response) => {
+    const raw = jsyaml.load(response);
+    console.log("schema", raw);
+    schema = new Schema(raw);
+  });
 
-    const summaryPromise = $.get(summaryJsonUrl(), {}, (response) => {
-      console.log("summary", response);
-      summary = response;
-      if (window.RELEASE) {
-        $summary.append(
-          `Release ${summary.release} (last updated ${summary.date})`,
-        );
-      } else {
-        $summary.append(
-          `Suite ${summary.suite} (last updated ${summary.date})`,
-        );
-      }
-    });
+  const summaryPromise = $.get(summaryJsonUrl(), {}, (response) => {
+    console.log("summary", response);
+    summary = response;
+    if (window.RELEASE) {
+      $summary.append(
+        `Release ${summary.release} (last updated ${summary.date})`,
+      );
+    } else {
+      $summary.append(`Suite ${summary.suite} (last updated ${summary.date})`);
+    }
+  });
 
-    $.when(schemaPromise, summaryPromise).then(() => {
-      if (urlParams.models) {
-        // Models
+  $.when(schemaPromise, summaryPromise).then(() => {
+    if (urlParams.models) {
+      // Models
+      $main.empty();
+      $main.append(renderHeader("Models", renderModels()));
+      refreshHashLocation();
+    } else if (urlParams.scenarios) {
+      // Models
+      $main.empty();
+      $main.append(renderHeader("Scenarios", renderScenarios()));
+      refreshHashLocation();
+    } else if (urlParams.plots) {
+      // Plots
+      $main.empty();
+      $main.append(renderHeader("Plots", renderPlots()));
+      refreshHashLocation();
+    } else if (
+      urlParams.runSpec ||
+      urlParams.runSpecs ||
+      urlParams.runSpecRegex
+    ) {
+      // Predictions for a set of run specs (matching a regular expression)
+      $main.text("Loading runs...");
+      $.getJSON(runSpecsJsonUrl(), {}, (response) => {
         $main.empty();
-        $main.append(renderHeader("Models", renderModels()));
+        const runSpecs = response;
+        console.log("runSpecs", runSpecs);
+        let matcher;
+        if (urlParams.runSpec) {
+          // Exactly one
+          matcher = (runSpec) => runSpec.name === urlParams.runSpec;
+        } else if (urlParams.runSpecs) {
+          // List
+          const selectedRunSpecs = JSON.parse(urlParams.runSpecs);
+          matcher = (runSpec) => selectedRunSpecs.includes(runSpec.name);
+        } else if (urlParams.runSpecRegex) {
+          // Regular expression
+          const regex = new RegExp("^" + urlParams.runSpecRegex + "$");
+          matcher = (runSpec) => regex.test(runSpec.name);
+        } else {
+          throw "Internal error";
+        }
+        const matchedRunSpecs = runSpecs.filter(matcher);
+        if (matchedRunSpecs.length === 0) {
+          $main.append(renderError("No matching runs"));
+        } else {
+          const getRunToRunSuitesPromise = window.RELEASE
+            ? $.get(runsToRunSuitesJsonUrl(), {})
+            : $.Deferred().resolve({});
+          getRunToRunSuitesPromise.then((runNameToSuite) => {
+            $main.append(renderRunsDetailed(matchedRunSpecs, runNameToSuite));
+          });
+        }
         refreshHashLocation();
-      } else if (urlParams.scenarios) {
-        // Models
+      });
+    } else if (urlParams.runs) {
+      // All runs (with search)
+      $main.text("Loading runs...");
+      $.getJSON(runSpecsJsonUrl(), {}, (runSpecs) => {
         $main.empty();
-        $main.append(renderHeader("Scenarios", renderScenarios()));
+        console.log("runSpecs", runSpecs);
+        $main.append(renderHeader("Runs", renderRunsOverview(runSpecs)));
+      });
+    } else if (urlParams.groups) {
+      // All groups
+      $main.text("Loading groups...");
+      const path = groupsJsonUrl();
+      $.getJSON(path, {}, (tables) => {
+        $main.empty();
+        console.log("groups", tables);
+        $main.append(renderTables(tables, path));
         refreshHashLocation();
-      } else if (urlParams.plots) {
-        // Plots
+      });
+    } else if (urlParams.group) {
+      // Specific group
+      $main.text("Loading group...");
+      const path = groupJsonUrl(urlParams.group);
+      $.getJSON(path, {}, (tables) => {
         $main.empty();
-        $main.append(renderHeader("Plots", renderPlots()));
+        console.log("group", tables);
+        $main.append(renderGroupHeader());
+        $main.append(renderTables(tables, path));
         refreshHashLocation();
-      } else if (
-        urlParams.runSpec ||
-        urlParams.runSpecs ||
-        urlParams.runSpecRegex
-      ) {
-        // Predictions for a set of run specs (matching a regular expression)
-        $main.text("Loading runs...");
-        $.getJSON(runSpecsJsonUrl(), {}, (response) => {
-          $main.empty();
-          const runSpecs = response;
-          console.log("runSpecs", runSpecs);
-          let matcher;
-          if (urlParams.runSpec) {
-            // Exactly one
-            matcher = (runSpec) => runSpec.name === urlParams.runSpec;
-          } else if (urlParams.runSpecs) {
-            // List
-            const selectedRunSpecs = JSON.parse(urlParams.runSpecs);
-            matcher = (runSpec) => selectedRunSpecs.includes(runSpec.name);
-          } else if (urlParams.runSpecRegex) {
-            // Regular expression
-            const regex = new RegExp("^" + urlParams.runSpecRegex + "$");
-            matcher = (runSpec) => regex.test(runSpec.name);
-          } else {
-            throw "Internal error";
-          }
-          const matchedRunSpecs = runSpecs.filter(matcher);
-          if (matchedRunSpecs.length === 0) {
-            $main.append(renderError("No matching runs"));
-          } else {
-            const getRunToRunSuitesPromise = window.RELEASE
-              ? $.get(runsToRunSuitesJsonUrl(), {})
-              : $.Deferred().resolve({});
-            getRunToRunSuitesPromise.then((runNameToSuite) => {
-              $main.append(renderRunsDetailed(matchedRunSpecs, runNameToSuite));
-            });
-          }
-          refreshHashLocation();
-        });
-      } else if (urlParams.runs) {
-        // All runs (with search)
-        $main.text("Loading runs...");
-        $.getJSON(runSpecsJsonUrl(), {}, (runSpecs) => {
-          $main.empty();
-          console.log("runSpecs", runSpecs);
-          $main.append(renderHeader("Runs", renderRunsOverview(runSpecs)));
-        });
-      } else if (urlParams.groups) {
-        // All groups
-        $main.text("Loading groups...");
-        const path = groupsJsonUrl();
-        $.getJSON(path, {}, (tables) => {
-          $main.empty();
-          console.log("groups", tables);
-          $main.append(renderTables(tables, path));
-          refreshHashLocation();
-        });
-      } else if (urlParams.group) {
-        // Specific group
-        $main.text("Loading group...");
-        const path = groupJsonUrl(urlParams.group);
-        $.getJSON(path, {}, (tables) => {
-          $main.empty();
-          console.log("group", tables);
-          $main.append(renderGroupHeader());
-          $main.append(renderTables(tables, path));
-          refreshHashLocation();
-        });
-      } else {
-        // Main landing page
-        $main.empty();
-        $main.append(renderMainPage());
-      }
-    });
-  })();
+      });
+    } else {
+      // Main landing page
+      $main.empty();
+      $main.append(renderMainPage());
+    }
+  });
 });

--- a/src/helm/benchmark/static/benchmarking.js
+++ b/src/helm/benchmark/static/benchmarking.js
@@ -1576,112 +1576,118 @@ $(function () {
   const $main = $("#main");
   const $summary = $("#summary");
 
-  const schemaPromise = $.get("schema.yaml", {}, (response) => {
-    const raw = jsyaml.load(response);
-    console.log("schema", raw);
-    schema = new Schema(raw);
-  });
+  // Extra function wrapper to preserve indentation for review
+  // TODO: Remove before merging.
+  (function () {
+    const schemaPromise = $.get("schema.yaml", {}, (response) => {
+      const raw = jsyaml.load(response);
+      console.log("schema", raw);
+      schema = new Schema(raw);
+    });
 
-  const summaryPromise = $.get(summaryJsonUrl(), {}, (response) => {
-    console.log("summary", response);
-    summary = response;
-    if (window.RELEASE) {
-      $summary.append(
-        `Release ${summary.release} (last updated ${summary.date})`,
-      );
-    } else {
-      $summary.append(`Suite ${summary.suite} (last updated ${summary.date})`);
-    }
-  });
+    const summaryPromise = $.get(summaryJsonUrl(), {}, (response) => {
+      console.log("summary", response);
+      summary = response;
+      if (window.RELEASE) {
+        $summary.append(
+          `Release ${summary.release} (last updated ${summary.date})`,
+        );
+      } else {
+        $summary.append(
+          `Suite ${summary.suite} (last updated ${summary.date})`,
+        );
+      }
+    });
 
-  $.when(schemaPromise, summaryPromise).then(() => {
-    if (urlParams.models) {
-      // Models
-      $main.empty();
-      $main.append(renderHeader("Models", renderModels()));
-      refreshHashLocation();
-    } else if (urlParams.scenarios) {
-      // Models
-      $main.empty();
-      $main.append(renderHeader("Scenarios", renderScenarios()));
-      refreshHashLocation();
-    } else if (urlParams.plots) {
-      // Plots
-      $main.empty();
-      $main.append(renderHeader("Plots", renderPlots()));
-      refreshHashLocation();
-    } else if (
-      urlParams.runSpec ||
-      urlParams.runSpecs ||
-      urlParams.runSpecRegex
-    ) {
-      // Predictions for a set of run specs (matching a regular expression)
-      $main.text("Loading runs...");
-      $.getJSON(runSpecsJsonUrl(), {}, (response) => {
+    $.when(schemaPromise, summaryPromise).then(() => {
+      if (urlParams.models) {
+        // Models
         $main.empty();
-        const runSpecs = response;
-        console.log("runSpecs", runSpecs);
-        let matcher;
-        if (urlParams.runSpec) {
-          // Exactly one
-          matcher = (runSpec) => runSpec.name === urlParams.runSpec;
-        } else if (urlParams.runSpecs) {
-          // List
-          const selectedRunSpecs = JSON.parse(urlParams.runSpecs);
-          matcher = (runSpec) => selectedRunSpecs.includes(runSpec.name);
-        } else if (urlParams.runSpecRegex) {
-          // Regular expression
-          const regex = new RegExp("^" + urlParams.runSpecRegex + "$");
-          matcher = (runSpec) => regex.test(runSpec.name);
-        } else {
-          throw "Internal error";
-        }
-        const matchedRunSpecs = runSpecs.filter(matcher);
-        if (matchedRunSpecs.length === 0) {
-          $main.append(renderError("No matching runs"));
-        } else {
-          const getRunToRunSuitesPromise = window.RELEASE
-            ? $.get(runsToRunSuitesJsonUrl(), {})
-            : $.Deferred().resolve({});
-          getRunToRunSuitesPromise.then((runNameToSuite) => {
-            $main.append(renderRunsDetailed(matchedRunSpecs, runNameToSuite));
-          });
-        }
+        $main.append(renderHeader("Models", renderModels()));
         refreshHashLocation();
-      });
-    } else if (urlParams.runs) {
-      // All runs (with search)
-      $main.text("Loading runs...");
-      $.getJSON(runSpecsJsonUrl(), {}, (runSpecs) => {
+      } else if (urlParams.scenarios) {
+        // Models
         $main.empty();
-        console.log("runSpecs", runSpecs);
-        $main.append(renderHeader("Runs", renderRunsOverview(runSpecs)));
-      });
-    } else if (urlParams.groups) {
-      // All groups
-      $main.text("Loading groups...");
-      const path = groupsJsonUrl();
-      $.getJSON(path, {}, (tables) => {
-        $main.empty();
-        console.log("groups", tables);
-        $main.append(renderTables(tables, path));
+        $main.append(renderHeader("Scenarios", renderScenarios()));
         refreshHashLocation();
-      });
-    } else if (urlParams.group) {
-      // Specific group
-      $main.text("Loading group...");
-      const path = groupJsonUrl(urlParams.group);
-      $.getJSON(path, {}, (tables) => {
+      } else if (urlParams.plots) {
+        // Plots
         $main.empty();
-        console.log("group", tables);
-        $main.append(renderGroupHeader());
-        $main.append(renderTables(tables, path));
+        $main.append(renderHeader("Plots", renderPlots()));
         refreshHashLocation();
-      });
-    } else {
-      // Main landing page
-      $main.empty();
-      $main.append(renderMainPage());
-    }
-  });
+      } else if (
+        urlParams.runSpec ||
+        urlParams.runSpecs ||
+        urlParams.runSpecRegex
+      ) {
+        // Predictions for a set of run specs (matching a regular expression)
+        $main.text("Loading runs...");
+        $.getJSON(runSpecsJsonUrl(), {}, (response) => {
+          $main.empty();
+          const runSpecs = response;
+          console.log("runSpecs", runSpecs);
+          let matcher;
+          if (urlParams.runSpec) {
+            // Exactly one
+            matcher = (runSpec) => runSpec.name === urlParams.runSpec;
+          } else if (urlParams.runSpecs) {
+            // List
+            const selectedRunSpecs = JSON.parse(urlParams.runSpecs);
+            matcher = (runSpec) => selectedRunSpecs.includes(runSpec.name);
+          } else if (urlParams.runSpecRegex) {
+            // Regular expression
+            const regex = new RegExp("^" + urlParams.runSpecRegex + "$");
+            matcher = (runSpec) => regex.test(runSpec.name);
+          } else {
+            throw "Internal error";
+          }
+          const matchedRunSpecs = runSpecs.filter(matcher);
+          if (matchedRunSpecs.length === 0) {
+            $main.append(renderError("No matching runs"));
+          } else {
+            const getRunToRunSuitesPromise = window.RELEASE
+              ? $.get(runsToRunSuitesJsonUrl(), {})
+              : $.Deferred().resolve({});
+            getRunToRunSuitesPromise.then((runNameToSuite) => {
+              $main.append(renderRunsDetailed(matchedRunSpecs, runNameToSuite));
+            });
+          }
+          refreshHashLocation();
+        });
+      } else if (urlParams.runs) {
+        // All runs (with search)
+        $main.text("Loading runs...");
+        $.getJSON(runSpecsJsonUrl(), {}, (runSpecs) => {
+          $main.empty();
+          console.log("runSpecs", runSpecs);
+          $main.append(renderHeader("Runs", renderRunsOverview(runSpecs)));
+        });
+      } else if (urlParams.groups) {
+        // All groups
+        $main.text("Loading groups...");
+        const path = groupsJsonUrl();
+        $.getJSON(path, {}, (tables) => {
+          $main.empty();
+          console.log("groups", tables);
+          $main.append(renderTables(tables, path));
+          refreshHashLocation();
+        });
+      } else if (urlParams.group) {
+        // Specific group
+        $main.text("Loading group...");
+        const path = groupJsonUrl(urlParams.group);
+        $.getJSON(path, {}, (tables) => {
+          $main.empty();
+          console.log("group", tables);
+          $main.append(renderGroupHeader());
+          $main.append(renderTables(tables, path));
+          refreshHashLocation();
+        });
+      } else {
+        // Main landing page
+        $main.empty();
+        $main.append(renderMainPage());
+      }
+    });
+  })();
 });

--- a/src/helm/benchmark/static/config.js
+++ b/src/helm/benchmark/static/config.js
@@ -1,0 +1,3 @@
+window.BENCHMARK_OUTPUT_BASE_URL = "benchmark_output";
+window.SUITE = "latest";
+window.RELEASE = null;

--- a/src/helm/benchmark/static/index.html
+++ b/src/helm/benchmark/static/index.html
@@ -58,9 +58,9 @@
             gtag('config', 'G-T0MW28MP3W');
     </script>
       *GTAG* -->
+    <script src="config.js"></script>
     <script src="general.js"></script>
     <script src="utils.js"></script>
-    <script src="json-urls-root.js"></script>
     <script src="json-urls.js"></script>
     <script src="benchmarking.js"></script>
     <script src="plot-captions.js"></script>

--- a/src/helm/benchmark/static/json-urls-root.js
+++ b/src/helm/benchmark/static/json-urls-root.js
@@ -1,2 +1,0 @@
-// Base URL for benchmark_output JSON files
-const BENCHMARK_OUTPUT_BASE_URL = "benchmark_output";

--- a/src/helm/benchmark/static/json-urls.js
+++ b/src/helm/benchmark/static/json-urls.js
@@ -21,7 +21,7 @@ function runSpecsJsonUrl() {
 }
 
 function groupsMetadataJsonUrl() {
-  return `${versionBaseUrl(version, using_release)}/groups_metadata.json`;
+  return `${versionBaseUrl()}/groups_metadata.json`;
 }
 
 function groupsJsonUrl() {
@@ -32,34 +32,34 @@ function groupJsonUrl(groupName) {
   return `${versionBaseUrl()}/groups/${groupName}.json`;
 }
 
-function runSpecJsonUrl(runSpecName) {
+function runSpecJsonUrl(suite, runSpecName) {
   return `${BENCHMARK_OUTPUT_BASE_URL}/runs/${suite}/${runSpecName}/run_spec.json`;
 }
 
-function scenarioJsonUrl(runSpecName) {
+function scenarioJsonUrl(suite, runSpecName) {
   return `${BENCHMARK_OUTPUT_BASE_URL}/runs/${suite}/${runSpecName}/scenario.json`;
 }
 
-function scenarioStateJsonUrl(runSpecName) {
+function scenarioStateJsonUrl(suite, runSpecName) {
   return `${BENCHMARK_OUTPUT_BASE_URL}/runs/${suite}/${runSpecName}/scenario_state.json`;
 }
 
-function statsJsonUrl(runSpecName) {
+function statsJsonUrl(suite, runSpecName) {
   return `${BENCHMARK_OUTPUT_BASE_URL}/runs/${suite}/${runSpecName}/stats.json`;
 }
 
-function instancesJsonUrl(runSpecName) {
+function instancesJsonUrl(suite, runSpecName) {
   return `${BENCHMARK_OUTPUT_BASE_URL}/runs/${suite}/${runSpecName}/instances.json`;
 }
 
-function predictionsJsonUrl(runSpecName) {
+function predictionsJsonUrl(suite, runSpecName) {
   return `${BENCHMARK_OUTPUT_BASE_URL}/runs/${suite}/${runSpecName}/display_predictions.json`;
 }
 
-function requestsJsonUrl(runSpecName) {
+function requestsJsonUrl(suite, runSpecName) {
   return `${BENCHMARK_OUTPUT_BASE_URL}/runs/${suite}/${runSpecName}/display_requests.json`;
 }
 
-function plotUrl(plotName) {
+function plotUrl(suite, plotName) {
   return `${BENCHMARK_OUTPUT_BASE_URL}/runs/${suite}/plots/${plotName}.png`;
 }

--- a/src/helm/benchmark/static/json-urls.js
+++ b/src/helm/benchmark/static/json-urls.js
@@ -1,71 +1,65 @@
 ////////////////////////////////////////////////////////////
 // Helper functions for getting URLs of JSON files
-function baseUrlWithDirectories(version, using_release) {
-  parent_directory = using_release ? "releases" : "runs";
-  return `${BENCHMARK_OUTPUT_BASE_URL}/${parent_directory}/${version}`;
+function versionBaseUrl() {
+  if (window.RELEASE) {
+    return `${BENCHMARK_OUTPUT_BASE_URL}/releases/${window.RELEASE}`;
+  } else {
+    return `${BENCHMARK_OUTPUT_BASE_URL}/runs/${window.SUITE}`;
+  }
 }
 
-function summaryJsonUrl(version, using_release) {
-  return `${baseUrlWithDirectories(version, using_release)}/summary.json`;
+function summaryJsonUrl() {
+  return `${versionBaseUrl()}/summary.json`;
 }
 
-function runsToRunSuitesJsonUrl(version, using_release) {
-  return `${baseUrlWithDirectories(
-    version,
-    using_release,
-  )}/runs_to_run_suites.json`;
+function runsToRunSuitesJsonUrl() {
+  return `${versionBaseUrl()}/runs_to_run_suites.json`;
 }
 
-function runSpecsJsonUrl(version, using_release) {
-  return `${baseUrlWithDirectories(version, using_release)}/run_specs.json`;
+function runSpecsJsonUrl() {
+  return `${versionBaseUrl()}/run_specs.json`;
 }
 
-function groupsMetadataJsonUrl(version, using_release) {
-  return `${baseUrlWithDirectories(
-    version,
-    using_release,
-  )}/groups_metadata.json`;
+function groupsMetadataJsonUrl() {
+  return `${versionBaseUrl(version, using_release)}/groups_metadata.json`;
 }
 
-function groupsJsonUrl(version, using_release) {
-  return `${baseUrlWithDirectories(version, using_release)}/groups.json`;
+function groupsJsonUrl() {
+  return `${versionBaseUrl()}/groups.json`;
 }
 
-function groupJsonUrl(version, using_release, groupName) {
-  return `${baseUrlWithDirectories(
-    version,
-    using_release,
-  )}/groups/${groupName}.json`;
+function groupJsonUrl(groupName) {
+  return `${versionBaseUrl()}/groups/${groupName}.json`;
 }
 
-function runSpecJsonUrl(suite, runSpecName) {
+function runSpecJsonUrl(runSpecName) {
   return `${BENCHMARK_OUTPUT_BASE_URL}/runs/${suite}/${runSpecName}/run_spec.json`;
 }
 
-function scenarioJsonUrl(suite, runSpecName) {
+function scenarioJsonUrl(runSpecName) {
   return `${BENCHMARK_OUTPUT_BASE_URL}/runs/${suite}/${runSpecName}/scenario.json`;
 }
 
-function scenarioStateJsonUrl(suite, runSpecName) {
+function scenarioStateJsonUrl(runSpecName) {
   return `${BENCHMARK_OUTPUT_BASE_URL}/runs/${suite}/${runSpecName}/scenario_state.json`;
 }
 
-function statsJsonUrl(suite, runSpecName) {
+function statsJsonUrl(runSpecName) {
   return `${BENCHMARK_OUTPUT_BASE_URL}/runs/${suite}/${runSpecName}/stats.json`;
 }
 
-function instancesJsonUrl(suite, runSpecName) {
+function instancesJsonUrl(runSpecName) {
   return `${BENCHMARK_OUTPUT_BASE_URL}/runs/${suite}/${runSpecName}/instances.json`;
 }
 
-function predictionsJsonUrl(suite, runSpecName) {
+function predictionsJsonUrl(runSpecName) {
   return `${BENCHMARK_OUTPUT_BASE_URL}/runs/${suite}/${runSpecName}/display_predictions.json`;
 }
 
-function requestsJsonUrl(suite, runSpecName) {
+function requestsJsonUrl(runSpecName) {
   return `${BENCHMARK_OUTPUT_BASE_URL}/runs/${suite}/${runSpecName}/display_requests.json`;
 }
 
-function plotUrl(suite, plotName) {
+function plotUrl(plotName) {
   return `${BENCHMARK_OUTPUT_BASE_URL}/runs/${suite}/plots/${plotName}.png`;
 }

--- a/src/helm/benchmark/static/utils.js
+++ b/src/helm/benchmark/static/utils.js
@@ -280,5 +280,6 @@ function renderItems(items) {
 }
 
 function getSuiteForRun(runNameToSuite, runName) {
-  return window.VERSION ? runNameToSuite[runName] : window.SUITE;
+  suite = window.RELEASE ? runNameToSuite[runName] : window.SUITE;
+  return suite;
 }

--- a/src/helm/benchmark/static/utils.js
+++ b/src/helm/benchmark/static/utils.js
@@ -279,6 +279,6 @@ function renderItems(items) {
   return $result;
 }
 
-function getRunSuite(using_release, version, runsToRunSuites, runSpecName) {
-  return using_release ? runsToRunSuites[runSpecName] : version;
+function getSuiteForRun(runNameToSuite, runName) {
+  return window.VERSION ? runNameToSuite[runName] : window.SUITE;
 }


### PR DESCRIPTION
- Fixed an issue where copying the static directory as a static site did not work due to there being no `using_release` file
- Removed fetch of `using_release`
- Only fetch the map of run names to suites if needed
- Moved suite, release and benchmark output path configuration into `config.js`
- Allow `helm-server` to serve a suite or release as given by flags
- Allow `helm-server` to serve using a remote `benchmark_output` URL as given by the flag