### PR TITLE
Suggestions for optional dependencies

### DIFF
--- a/src/helm/benchmark/presentation/create_plots.py
+++ b/src/helm/benchmark/presentation/create_plots.py
@@ -21,7 +21,7 @@ try:
     import matplotlib.pyplot as plt
     import seaborn as sns
 except ModuleNotFoundError as e:
-    handle_module_not_found_error(e)
+    handle_module_not_found_error(e, ["plots"])
 
 
 sns.set_style("whitegrid")

--- a/src/helm/common/optional_dependencies.py
+++ b/src/helm/common/optional_dependencies.py
@@ -1,10 +1,16 @@
+from typing import List, Optional
+
+
 class OptionalDependencyNotInstalled(Exception):
     pass
 
 
-def handle_module_not_found_error(e: ModuleNotFoundError):
+def handle_module_not_found_error(e: ModuleNotFoundError, suggestions: Optional[List[str]] = None):
     # TODO: Ask user to install more specific optional dependencies
     # e.g. crfm-helm[plots] or crfm-helm[server]
+    suggested_commands = " or ".join(
+        [f"`pip install crfm-helm[{suggestion}]`" for suggestion in (suggestions or []) + ["all"]]
+    )
     raise OptionalDependencyNotInstalled(
-        f"Optional dependency {e.name} is not installed. " "Please run `pip install crfm-helm[all]` to install it."
+        f"Optional dependency {e.name} is not installed. Please run {suggested_commands} to install it."
     ) from e


### PR DESCRIPTION
Add suggestions for what `pip install` command to run to get optional dependencies.

Example error message:

```Optional dependency seaborn is not installed. Please run `pip install crfm-helm[plots]` or `pip install crfm-helm[all]` to install it.```