### PR TITLE
Introduce TextPerturbation to allow Perturbation to stay fully generic.

### DIFF
--- a/src/helm/benchmark/augmentations/cleva_perturbation.py
+++ b/src/helm/benchmark/augmentations/cleva_perturbation.py
@@ -10,13 +10,13 @@ from helm.common.general import ensure_file_downloaded, ensure_directory_exists
 from helm.common.optional_dependencies import handle_module_not_found_error
 from helm.benchmark.scenarios.scenario import Input, Instance, Reference, Output
 from .perturbation_description import PerturbationDescription
-from .perturbation import Perturbation
+from .perturbation import Perturbation, TextPerturbation
 
 
 ############################################################
 
 
-class ChineseTyposPerturbation(Perturbation):
+class ChineseTyposPerturbation(TextPerturbation):
     """
     Chinese typos. For implementation details, see
     https://github.com/GEM-benchmark/NL-Augmenter/tree/main/nlaugmenter/transformations/chinese_butter_fingers_perturbation
@@ -271,7 +271,7 @@ class ChineseTyposPerturbation(Perturbation):
         return chars_with_similar_pinyin
 
 
-class ChineseSynonymPerturbation(Perturbation):
+class ChineseSynonymPerturbation(TextPerturbation):
     """
     Chinese synonyms. For implementation details, see
     https://github.com/GEM-benchmark/NL-Augmenter/blob/main/nlaugmenter/transformations/chinese_antonym_synonym_substitution
@@ -340,7 +340,7 @@ class ChineseSynonymPerturbation(Perturbation):
         return sample_list[index]
 
 
-class CLEVAMildMixPerturbation(Perturbation):
+class CLEVAMildMixPerturbation(TextPerturbation):
     """
     CLEVA robustness perturbation that composes several perturbations.
     """
@@ -370,7 +370,7 @@ class CLEVAMildMixPerturbation(Perturbation):
 ############################################################
 
 
-class ChineseGenderPerturbation(Perturbation):
+class ChineseGenderPerturbation(TextPerturbation):
     """Individual fairness perturbation for Chinese gender terms and pronouns."""
 
     name: str = "chinese_gender"
@@ -601,13 +601,6 @@ class ChinesePersonNamePerturbation(Perturbation):
         name = rng.choice(list(options))
         return name
 
-    def perturb(self, text: str, rng: Random) -> str:
-        """
-        Perturbing the text is handled in `perturb_with_persistency` to ensure that perturbed names
-        in `Instance`s and `Reference`s match.
-        """
-        raise NotImplementedError("Should never be called")
-
     def perturb_with_persistency(
         self, text: str, rng: Random, name_substitution_mapping: Dict[str, str], skipped_tokens: Set[str]
     ) -> str:
@@ -686,7 +679,7 @@ class ChinesePersonNamePerturbation(Perturbation):
         return tokens, tags
 
 
-class SimplifiedToTraditionalPerturbation(Perturbation):
+class SimplifiedToTraditionalPerturbation(TextPerturbation):
     """Individual fairness perturbation for Chinese simplified to Chinese traditional."""
 
     name: str = "simplified_to_traditional"
@@ -713,7 +706,7 @@ class SimplifiedToTraditionalPerturbation(Perturbation):
         return perturbed_text
 
 
-class MandarinToCantonesePerturbation(Perturbation):
+class MandarinToCantonesePerturbation(TextPerturbation):
     """
     Individual fairness perturbation for Mandarin to Cantonese translation.
     The implementation is inspired by https://justyy.com/tools/chinese-converter/

--- a/src/helm/benchmark/augmentations/contraction_expansion_perturbation.py
+++ b/src/helm/benchmark/augmentations/contraction_expansion_perturbation.py
@@ -5,7 +5,7 @@ import re
 from random import Random
 
 from helm.common.general import match_case
-from .perturbation import Perturbation
+from .perturbation import TextPerturbation
 from .perturbation_description import PerturbationDescription
 
 
@@ -92,7 +92,7 @@ CONTRACTION_MAP: Dict[str, str] = {
 
 # The implementations below are based on
 # https://github.com/GEM-benchmark/NL-Augmenter/blob/main/transformations/contraction_expansions/transformation.py
-class ContractionPerturbation(Perturbation):
+class ContractionPerturbation(TextPerturbation):
     """
     Contractions.
     Replaces each expansion with its contracted version.
@@ -132,7 +132,7 @@ class ContractionPerturbation(Perturbation):
         return self.reverse_contraction_pattern.sub(cont, text)
 
 
-class ExpansionPerturbation(Perturbation):
+class ExpansionPerturbation(TextPerturbation):
     """
     Expansions.
     Replaces each contraction with its expanded version.

--- a/src/helm/benchmark/augmentations/contrast_sets_perturbation.py
+++ b/src/helm/benchmark/augmentations/contrast_sets_perturbation.py
@@ -81,6 +81,3 @@ class ContrastSetsPerturbation(Perturbation):
             references=perturbed_references,
             perturbation=description,
         )
-
-    def perturb(self, text: str, rng: Random) -> str:  # we need this since parent method is abstract
-        raise NotImplementedError("Should never be called since apply() was overridden")

--- a/src/helm/benchmark/augmentations/dialect_perturbation.py
+++ b/src/helm/benchmark/augmentations/dialect_perturbation.py
@@ -8,10 +8,10 @@ from typing import Dict, Optional, List
 
 from helm.common.general import match_case, ensure_file_downloaded
 from .perturbation_description import PerturbationDescription
-from .perturbation import Perturbation
+from .perturbation import TextPerturbation
 
 
-class DialectPerturbation(Perturbation):
+class DialectPerturbation(TextPerturbation):
     """Individual fairness perturbation for dialect."""
 
     """ Short unique identifier of the perturbation (e.g., extra_space) """

--- a/src/helm/benchmark/augmentations/extra_space_perturbation.py
+++ b/src/helm/benchmark/augmentations/extra_space_perturbation.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass
 from random import Random
 
-from .perturbation import Perturbation
+from .perturbation import TextPerturbation
 from .perturbation_description import PerturbationDescription
 
 
-class ExtraSpacePerturbation(Perturbation):
+class ExtraSpacePerturbation(TextPerturbation):
     """
     A toy perturbation that replaces existing spaces in the text with
     `num_spaces` number of spaces.

--- a/src/helm/benchmark/augmentations/filler_words_perturbation.py
+++ b/src/helm/benchmark/augmentations/filler_words_perturbation.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from .perturbation import Perturbation
+from .perturbation import TextPerturbation
 from .perturbation_description import PerturbationDescription
 
 from random import Random
@@ -31,7 +31,7 @@ UNCERTAIN_PHRASES = ["maybe", "perhaps", "probably", "possibly", "most likely"]
 FILL_PHRASE = ["uhm", "umm", "ahh", "err", "actually", "obviously", "naturally", "like", "you know"]
 
 
-class FillerWordsPerturbation(Perturbation):
+class FillerWordsPerturbation(TextPerturbation):
     """
     Randomly inserts filler words and phrases in the sentence.
     Perturbation example:

--- a/src/helm/benchmark/augmentations/gender_perturbation.py
+++ b/src/helm/benchmark/augmentations/gender_perturbation.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional, Tuple
 
 from helm.common.general import match_case
 from .perturbation_description import PerturbationDescription
-from .perturbation import Perturbation
+from .perturbation import TextPerturbation
 
 
 """ Gender term mappings """
@@ -62,7 +62,7 @@ GENDER_PRONOUN_MAPPINGS: List[Tuple[str, ...]] = [
 ]
 
 
-class GenderPerturbation(Perturbation):
+class GenderPerturbation(TextPerturbation):
     """Individual fairness perturbation for gender terms and pronouns."""
 
     """ Short unique identifier of the perturbation (e.g., extra_space) """

--- a/src/helm/benchmark/augmentations/lowercase_perturbation.py
+++ b/src/helm/benchmark/augmentations/lowercase_perturbation.py
@@ -1,10 +1,10 @@
 from random import Random
 
-from .perturbation import Perturbation
+from .perturbation import TextPerturbation
 from .perturbation_description import PerturbationDescription
 
 
-class LowerCasePerturbation(Perturbation):
+class LowerCasePerturbation(TextPerturbation):
     """
     Simple perturbation turning input and references into lowercase.
     """

--- a/src/helm/benchmark/augmentations/mild_mix_perturbation.py
+++ b/src/helm/benchmark/augmentations/mild_mix_perturbation.py
@@ -1,14 +1,14 @@
 from random import Random
 
 from .perturbation_description import PerturbationDescription
-from .perturbation import Perturbation
+from .perturbation import TextPerturbation
 from .lowercase_perturbation import LowerCasePerturbation
 from .contraction_expansion_perturbation import ContractionPerturbation
 from .space_perturbation import SpacePerturbation
 from .misspelling_perturbation import MisspellingPerturbation
 
 
-class MildMixPerturbation(Perturbation):
+class MildMixPerturbation(TextPerturbation):
     """
     Canonical robustness perturbation that composes several perturbations.
     These perturbations are chosen to be reasonable.

--- a/src/helm/benchmark/augmentations/misspelling_perturbation.py
+++ b/src/helm/benchmark/augmentations/misspelling_perturbation.py
@@ -6,13 +6,13 @@ from random import Random
 from typing import Dict, List
 
 from helm.common.general import match_case
-from .perturbation import Perturbation
+from .perturbation import TextPerturbation
 from .perturbation_description import PerturbationDescription
 
 
 # The implementation below is based on the following list of common misspellings:
 # https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines
-class MisspellingPerturbation(Perturbation):
+class MisspellingPerturbation(TextPerturbation):
     """
     Replaces words randomly with common misspellings, from a list of common misspellings.
 

--- a/src/helm/benchmark/augmentations/person_name_perturbation.py
+++ b/src/helm/benchmark/augmentations/person_name_perturbation.py
@@ -263,13 +263,6 @@ class PersonNamePerturbation(Perturbation):
         name = rng.choice(list(options))
         return name
 
-    def perturb(self, text: str, rng: Random) -> str:
-        """
-        Perturbing the text is handled in `perturb_with_persistency` to ensure that perturbed names
-        in `Instance`s and `Reference`s match.
-        """
-        raise NotImplementedError("Should never be called")
-
     def perturb_with_persistency(
         self, text: str, rng: Random, name_substitution_mapping: Dict[str, str], skipped_tokens: Set[str]
     ) -> str:

--- a/src/helm/benchmark/augmentations/space_perturbation.py
+++ b/src/helm/benchmark/augmentations/space_perturbation.py
@@ -2,11 +2,11 @@ from dataclasses import dataclass
 from random import Random
 import re
 
-from .perturbation import Perturbation
+from .perturbation import TextPerturbation
 from .perturbation_description import PerturbationDescription
 
 
-class SpacePerturbation(Perturbation):
+class SpacePerturbation(TextPerturbation):
     """
     A simple perturbation that replaces existing spaces with 0-max_spaces spaces (thus potentially merging words).
     """

--- a/src/helm/benchmark/augmentations/synonym_perturbation.py
+++ b/src/helm/benchmark/augmentations/synonym_perturbation.py
@@ -11,10 +11,10 @@ import spacy
 
 from helm.common.general import match_case, ensure_file_downloaded
 from .perturbation_description import PerturbationDescription
-from .perturbation import Perturbation
+from .perturbation import TextPerturbation
 
 
-class SynonymPerturbation(Perturbation):
+class SynonymPerturbation(TextPerturbation):
     """
     Synonyms. For implementation details, see
     https://github.com/GEM-benchmark/NL-Augmenter/blob/main/nlaugmenter/transformations/synonym_substitution/transformation.py

--- a/src/helm/benchmark/augmentations/typos_perturbation.py
+++ b/src/helm/benchmark/augmentations/typos_perturbation.py
@@ -2,10 +2,10 @@ from dataclasses import dataclass
 from random import Random
 
 from .perturbation_description import PerturbationDescription
-from .perturbation import Perturbation
+from .perturbation import TextPerturbation
 
 
-class TyposPerturbation(Perturbation):
+class TyposPerturbation(TextPerturbation):
     """
     Typos. For implementation details, see
     https://github.com/GEM-benchmark/NL-Augmenter/tree/main/transformations/butter_fingers_perturbation


### PR DESCRIPTION
Previously the `perturb` method needed to be overwritten even if the derived class had no use for it. By introducing an intermediate abstract class (TextPerturbation), implementations can choose between the simple `perturb` interface and taking ownership of `apply` directly.