### PR TITLE
Remove basic_metrics dependency on CLEVA optional dependencies

### DIFF
--- a/src/helm/benchmark/metrics/basic_metrics.py
+++ b/src/helm/benchmark/metrics/basic_metrics.py
@@ -32,11 +32,11 @@ from helm.benchmark.window_services.tokenizer_service import TokenizerService
 from helm.benchmark.scenarios.scenario import CORRECT_TAG, Instance, Reference
 from helm.benchmark.scenarios.math_scenario import is_equiv, is_equiv_chain_of_thought
 from helm.benchmark.scenarios.code_scenario import CodeReference
+from helm.benchmark.metrics.cleva_metrics_helper import ChineseTokenizer
 from . import code_metrics_helper
 from .metric import Metric, get_unique_stat_by_name
 from .metric_name import MetricName
 from .metric_service import MetricService
-from .cleva_harms_metrics import ChineseTokenizer
 from .statistic import Stat
 
 
@@ -266,12 +266,12 @@ def bleu_1(gold: str, pred: str) -> float:
 
 
 def chinese_bleu_1(gold: str, pred: str) -> float:
-    char_tokenizer = ChineseTokenizer(method="char")
+    char_tokenizer = ChineseTokenizer()
     return sentence_bleu([char_tokenizer.tokenize(gold)], char_tokenizer.tokenize(pred), weights=(1, 0, 0, 0))
 
 
 def get_chinese_rouge_function(rouge_type: str) -> Callable[[str, str], float]:
-    char_tokenizer = ChineseTokenizer(method="char")
+    char_tokenizer = ChineseTokenizer()
     scorer = rouge_scorer.RougeScorer([rouge_type], use_stemmer=True, tokenizer=char_tokenizer)
     return partial(rouge_score, scorer=scorer, rouge_type=rouge_type)
 

--- a/src/helm/benchmark/metrics/cleva_harms_metrics.py
+++ b/src/helm/benchmark/metrics/cleva_harms_metrics.py
@@ -10,6 +10,7 @@ from helm.common.request import RequestResult
 from helm.common.hierarchical_logger import hlog
 from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
+from helm.benchmark.metrics.cleva_metrics_helper import ChineseTokenizer
 from helm.proxy.clients.perspective_api_client import PerspectiveAPIClientCredentialsError
 from helm.common.general import ensure_file_downloaded, ensure_directory_exists
 from helm.common.optional_dependencies import handle_module_not_found_error
@@ -225,23 +226,6 @@ class CLEVAToxicityMetric(ToxicityMetric):
         ]
 
         return stats
-
-
-class ChineseTokenizer:
-    """Chinese tokenizer."""
-
-    METHOD_LIST = ["char"]
-
-    def __init__(self, method: str = "char") -> None:
-        # We use "char" by default as we would like to get rid of the dependency on word segmentation methods
-        assert method in self.METHOD_LIST
-        self.method = method
-
-    def tokenize(self, text: str) -> List[str]:
-        if self.method == "char":
-            return [c for c in text]
-        else:
-            raise ValueError(f"Unknown Chinese tokenization method '{self.method}'")
 
 
 class CLEVACopyrightMetric(BasicCopyrightMetric):

--- a/src/helm/benchmark/metrics/cleva_metrics_helper.py
+++ b/src/helm/benchmark/metrics/cleva_metrics_helper.py
@@ -1,0 +1,11 @@
+from typing import List
+
+
+class ChineseTokenizer:
+    """Chinese tokenizer.
+
+    Used by CLEVA for computing metrics on Chinese text."""
+
+    def tokenize(self, text: str) -> List[str]:
+        # Tokenize by characters to avoid a dependency on word segmentation methods.
+        return [c for c in text]


### PR DESCRIPTION
Previously, basic_metrics imported `cleva_harms_metrics`, which imported the optional dependency `jieba`. This prevented the `helm-run` from working without `crfm-helm[cleva]` installed.