### PR TITLE
Fix incorrect tokenizers in clients returned by AutoClient

### DIFF
--- a/src/helm/benchmark/metrics/summarization_metrics.py
+++ b/src/helm/benchmark/metrics/summarization_metrics.py
@@ -5,6 +5,7 @@ import os
 import pickle
 
 import spacy
+import spacy.cli
 from typing import List, Dict, Optional
 from collections import defaultdict
 

--- a/src/helm/proxy/clients/ai21_client.py
+++ b/src/helm/proxy/clients/ai21_client.py
@@ -10,7 +10,6 @@ from helm.common.request import (
     Sequence,
     Token,
 )
-from helm.proxy.tokenizers.tokenizer import Tokenizer
 from .client import CachingClient, truncate_sequence, cleanup_str
 from .ai21_utils import AI21RequestError, handle_failed_request
 
@@ -24,8 +23,8 @@ class AI21Client(CachingClient):
     COMPLETION_URL_TEMPLATE: str = "https://api.ai21.com/studio/v1/{model}/complete"
     EXPERIMENTAL_COMPLETION_URL_TEMPLATE: str = "https://api.ai21.com/studio/v1/experimental/{model}/complete"
 
-    def __init__(self, api_key: str, tokenizer: Tokenizer, cache_config: CacheConfig, url: Optional[str] = None):
-        super().__init__(cache_config=cache_config, tokenizer=tokenizer)
+    def __init__(self, api_key: str, cache_config: CacheConfig, url: Optional[str] = None):
+        super().__init__(cache_config=cache_config)
         self.api_key = api_key
         self.url = url
 

--- a/src/helm/proxy/clients/aleph_alpha_client.py
+++ b/src/helm/proxy/clients/aleph_alpha_client.py
@@ -4,15 +4,14 @@ from typing import Any, Dict, List
 
 from helm.common.cache import CacheConfig
 from helm.common.request import wrap_request_time, Request, RequestResult, Sequence, Token
-from helm.proxy.tokenizers.tokenizer import Tokenizer
 from .client import CachingClient, truncate_sequence
 
 
 class AlephAlphaClient(CachingClient):
     COMPLETION_ENDPOINT: str = "complete"
 
-    def __init__(self, api_key: str, tokenizer: Tokenizer, cache_config: CacheConfig):
-        super().__init__(cache_config=cache_config, tokenizer=tokenizer)
+    def __init__(self, api_key: str, cache_config: CacheConfig):
+        super().__init__(cache_config=cache_config)
         self.api_key: str = api_key
 
     def _send_request(self, endpoint: str, raw_request: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/helm/proxy/clients/anthropic_client.py
+++ b/src/helm/proxy/clients/anthropic_client.py
@@ -57,7 +57,8 @@ class AnthropicClient(CachingClient):
     PROMPT_ANSWER_START: str = "The answer is "
 
     def __init__(self, tokenizer: Tokenizer, cache_config: CacheConfig, api_key: Optional[str] = None):
-        super().__init__(cache_config=cache_config, tokenizer=tokenizer)
+        super().__init__(cache_config=cache_config)
+        self.tokenizer = tokenizer
         self.api_key: Optional[str] = api_key
         self._client = anthropic.Client(api_key) if api_key else None
 
@@ -241,7 +242,7 @@ class AnthropicLegacyClient(CachingClient):
 
     def __init__(self, api_key: str, tokenizer: Tokenizer, cache_config: CacheConfig):
         hlog("This client is deprecated. Please use AnthropicClient instead.")
-        super().__init__(cache_config=cache_config, tokenizer=tokenizer)
+        super().__init__(cache_config=cache_config)
         self.api_key = api_key
 
     def make_request(self, request: Request) -> RequestResult:

--- a/src/helm/proxy/clients/auto_client.py
+++ b/src/helm/proxy/clients/auto_client.py
@@ -1,6 +1,11 @@
 import os
 from dataclasses import replace
+<<<<<<< HEAD
 from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional
+=======
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional
+>>>>>>> Fixes
 
 from retrying import Attempt, RetryError
 
@@ -19,14 +24,21 @@ from helm.common.tokenization_request import (
 )
 from helm.proxy.clients.client import Client
 from helm.proxy.critique.critique_client import CritiqueClient
+from helm.proxy.clients.huggingface_client import HuggingFaceClient
+from helm.proxy.clients.http_model_client import HTTPModelClient
 from helm.proxy.clients.toxicity_classifier_client import ToxicityClassifierClient
 from helm.proxy.retry import NonRetriableException, retry_request
+<<<<<<< HEAD
 from helm.proxy.tokenizers.auto_tokenizer import AutoTokenizer
 from helm.proxy.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer
 
 
 if TYPE_CHECKING:
     import helm.proxy.clients.huggingface_client
+=======
+from helm.proxy.tokenizers.tokenizer import Tokenizer
+from helm.proxy.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer
+>>>>>>> Fixes
 
 
 class AuthenticationError(NonRetriableException):
@@ -43,9 +55,9 @@ class AutoClient(Client):
         self.mongo_uri = mongo_uri
         self.clients: Dict[str, Client] = {}
         # self._huggingface_client is lazily instantiated by get_huggingface_client()
-        self._huggingface_client: Optional["helm.proxy.clients.huggingface_client.HuggingFaceClient"] = None
+        self._huggingface_client: Optional[HuggingFaceClient] = None
         # self._huggingface_tokenizer is lazily instantiated by get_huggingface_tokenizer()
-        self._huggingface_tokenizer: Optional["helm.proxy.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"] = None
+        self._huggingface_tokenizer: Optional[HuggingFaceTokenizer] = None
         # self._critique_client is lazily instantiated by get_critique_client()
         self._critique_client: Optional[CritiqueClient] = None
         hlog(f"AutoClient: cache_path = {cache_path}")
@@ -126,7 +138,106 @@ class AutoClient(Client):
             # Notify our user that we failed to make the request even after retrying.
             return replace(last_attempt.value, error=f"{retry_error}. Error: {last_attempt.value.error}")
 
+<<<<<<< HEAD
     # TODO: remove this method after a few weeks (2023-11-09)
+=======
+    def _get_tokenizer(self, tokenizer_name: str) -> Tokenizer:
+        # First try to find the tokenizer in the cache
+        tokenizer: Optional[Tokenizer] = self.tokenizers.get(tokenizer_name)
+        if tokenizer is not None:
+            return tokenizer
+
+        # Otherwise, create the tokenizer
+        organization: str = tokenizer_name.split("/")[0]
+        cache_config: CacheConfig = self._build_cache_config(organization)
+
+        # TODO: Migrate all clients to use tokenizer configs
+        tokenizer_config = get_tokenizer_config(tokenizer_name)
+        if tokenizer_config:
+            tokenizer_spec = inject_object_spec_args(
+                tokenizer_config.tokenizer_spec, constant_bindings={"cache_config": cache_config}
+            )
+            return create_object(tokenizer_spec)
+        elif organization in [
+            "gooseai",
+            "huggingface",
+            "microsoft",
+            "google",
+            "writer",  # Palmyra
+            "nvidia",
+            "EleutherAI",
+            "facebook",
+            "meta-llama",
+            "hf-internal-testing",
+            "mistralai",
+            "HuggingFaceM4",
+            # Together
+            "together",
+            "databricks",
+            "eleutherai",
+            "lmsys",
+            "meta",
+            "mosaicml",
+            "stabilityai",
+            "stanford",
+            "tiiuae",
+            "bigcode",
+            "bigscience",
+        ]:
+            tokenizer = HuggingFaceTokenizer(cache_config=cache_config)
+        elif organization == "neurips":
+            from helm.proxy.tokenizers.http_model_tokenizer import HTTPModelTokenizer
+
+            tokenizer = HTTPModelTokenizer(cache_config=cache_config)
+        elif organization == "openai":
+            from helm.proxy.tokenizers.tiktoken_tokenizer import TiktokenTokenizer
+
+            tokenizer = TiktokenTokenizer(cache_config=cache_config)
+        elif organization == "AlephAlpha":
+            from helm.proxy.tokenizers.aleph_alpha_tokenizer import AlephAlphaTokenizer
+
+            tokenizer = AlephAlphaTokenizer(api_key=self.credentials["alephAlphaKey"], cache_config=cache_config)
+        elif organization == "ai21":
+            from helm.proxy.tokenizers.ai21_tokenizer import AI21Tokenizer
+
+            tokenizer = AI21Tokenizer(api_key=self.credentials["ai21ApiKey"], cache_config=cache_config)
+        elif organization == "cohere":
+            from helm.proxy.tokenizers.cohere_tokenizer import CohereTokenizer
+
+            tokenizer = CohereTokenizer(api_key=self.credentials["cohereApiKey"], cache_config=cache_config)
+        elif organization == "anthropic":
+            from helm.proxy.tokenizers.anthropic_tokenizer import AnthropicTokenizer
+
+            tokenizer = AnthropicTokenizer(cache_config=cache_config)
+        elif organization == "simple":
+            from helm.proxy.tokenizers.simple_tokenizer import SimpleTokenizer
+
+            tokenizer = SimpleTokenizer()
+        elif organization == "lightningai":
+            from helm.proxy.tokenizers.lit_gpt_tokenizer import LitGPTTokenizer
+
+            tokenizer = LitGPTTokenizer(
+                cache_config=cache_config,
+                checkpoint_dir=Path(os.environ.get("LIT_GPT_CHECKPOINT_DIR", "")),
+            )
+        elif organization == "TsinghuaKEG":
+            from helm.proxy.tokenizers.ice_tokenizer import ICETokenizer
+
+            tokenizer = ICETokenizer(cache_config=cache_config)
+        elif organization == "Yandex":
+            from helm.proxy.tokenizers.yalm_tokenizer import YaLMTokenizer
+
+            tokenizer = YaLMTokenizer(cache_config=cache_config)
+
+        if tokenizer is None:
+            raise ValueError(f"Could not find tokenizer for model: {tokenizer_name}")
+
+        # Cache the tokenizer
+        self.tokenizers[tokenizer_name] = tokenizer
+
+        return tokenizer
+
+>>>>>>> Fixes
     def tokenize(self, request: TokenizationRequest) -> TokenizationRequestResult:
         raise NotImplementedError(
             "AutoClient.tokenize() is not supported anymore." "Use AutoTokenizer.tokenize() instead."
@@ -196,10 +307,8 @@ class AutoClient(Client):
             )
         return self._critique_client
 
-    def get_huggingface_client(self) -> "helm.proxy.clients.huggingface_client.HuggingFaceClient":
+    def get_huggingface_client(self) -> HuggingFaceClient:
         """Get the Hugging Face client."""
-        from helm.proxy.clients.huggingface_client import HuggingFaceClient
-
         if self._huggingface_client:
             assert isinstance(self._huggingface_client, HuggingFaceClient)
             return self._huggingface_client
@@ -208,10 +317,8 @@ class AutoClient(Client):
         self._huggingface_client = HuggingFaceClient(tokenizer=tokenizer, cache_config=cache_config)
         return self._huggingface_client
 
-    def get_huggingface_tokenizer(self) -> "helm.proxy.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer":
+    def get_huggingface_tokenizer(self) -> HuggingFaceTokenizer:
         """Get the Hugging Face client."""
-        from helm.proxy.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer
-
         if self._huggingface_tokenizer:
             assert isinstance(self._huggingface_tokenizer, HuggingFaceTokenizer)
             return self._huggingface_tokenizer

--- a/src/helm/proxy/clients/auto_client.py
+++ b/src/helm/proxy/clients/auto_client.py
@@ -17,7 +17,6 @@ from helm.proxy.clients.huggingface_client import HuggingFaceClient
 from helm.proxy.clients.toxicity_classifier_client import ToxicityClassifierClient
 from helm.proxy.retry import NonRetriableException, retry_request
 from helm.proxy.tokenizers.auto_tokenizer import AutoTokenizer
-from helm.proxy.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer
 
 
 class AuthenticationError(NonRetriableException):
@@ -35,8 +34,6 @@ class AutoClient(Client):
         self.clients: Dict[str, Client] = {}
         # self._huggingface_client is lazily instantiated by get_huggingface_client()
         self._huggingface_client: Optional[HuggingFaceClient] = None
-        # self._huggingface_tokenizer is lazily instantiated by get_huggingface_tokenizer()
-        self._huggingface_tokenizer: Optional[HuggingFaceTokenizer] = None
         # self._critique_client is lazily instantiated by get_critique_client()
         self._critique_client: Optional[CritiqueClient] = None
         hlog(f"AutoClient: cache_path = {cache_path}")
@@ -89,6 +86,7 @@ class AutoClient(Client):
 
         # Cache the client
         self.clients[model_deployment_name] = client
+
         return client
 
     def make_request(self, request: Request) -> RequestResult:
@@ -185,12 +183,3 @@ class AutoClient(Client):
         cache_config = build_cache_config(self.cache_path, self.mongo_uri, "huggingface")
         self._huggingface_client = HuggingFaceClient(cache_config=cache_config)
         return self._huggingface_client
-
-    def get_huggingface_tokenizer(self) -> HuggingFaceTokenizer:
-        """Get the Hugging Face client."""
-        if self._huggingface_tokenizer:
-            assert isinstance(self._huggingface_tokenizer, HuggingFaceTokenizer)
-            return self._huggingface_tokenizer
-        cache_config = build_cache_config(self.cache_path, self.mongo_uri, "huggingface")
-        self._huggingface_tokenizer = HuggingFaceTokenizer(cache_config=cache_config)
-        return self._huggingface_tokenizer

--- a/src/helm/proxy/clients/auto_client.py
+++ b/src/helm/proxy/clients/auto_client.py
@@ -1,11 +1,6 @@
 import os
 from dataclasses import replace
-<<<<<<< HEAD
-from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional
-=======
-from pathlib import Path
 from typing import Any, Dict, Mapping, Optional
->>>>>>> Fixes
 
 from retrying import Attempt, RetryError
 
@@ -16,29 +11,13 @@ from helm.common.cache import CacheConfig
 from helm.common.hierarchical_logger import hlog
 from helm.common.object_spec import create_object, inject_object_spec_args
 from helm.common.request import Request, RequestResult
-from helm.common.tokenization_request import (
-    DecodeRequest,
-    DecodeRequestResult,
-    TokenizationRequest,
-    TokenizationRequestResult,
-)
 from helm.proxy.clients.client import Client
 from helm.proxy.critique.critique_client import CritiqueClient
 from helm.proxy.clients.huggingface_client import HuggingFaceClient
-from helm.proxy.clients.http_model_client import HTTPModelClient
 from helm.proxy.clients.toxicity_classifier_client import ToxicityClassifierClient
 from helm.proxy.retry import NonRetriableException, retry_request
-<<<<<<< HEAD
 from helm.proxy.tokenizers.auto_tokenizer import AutoTokenizer
 from helm.proxy.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer
-
-
-if TYPE_CHECKING:
-    import helm.proxy.clients.huggingface_client
-=======
-from helm.proxy.tokenizers.tokenizer import Tokenizer
-from helm.proxy.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer
->>>>>>> Fixes
 
 
 class AuthenticationError(NonRetriableException):
@@ -138,115 +117,6 @@ class AutoClient(Client):
             # Notify our user that we failed to make the request even after retrying.
             return replace(last_attempt.value, error=f"{retry_error}. Error: {last_attempt.value.error}")
 
-<<<<<<< HEAD
-    # TODO: remove this method after a few weeks (2023-11-09)
-=======
-    def _get_tokenizer(self, tokenizer_name: str) -> Tokenizer:
-        # First try to find the tokenizer in the cache
-        tokenizer: Optional[Tokenizer] = self.tokenizers.get(tokenizer_name)
-        if tokenizer is not None:
-            return tokenizer
-
-        # Otherwise, create the tokenizer
-        organization: str = tokenizer_name.split("/")[0]
-        cache_config: CacheConfig = self._build_cache_config(organization)
-
-        # TODO: Migrate all clients to use tokenizer configs
-        tokenizer_config = get_tokenizer_config(tokenizer_name)
-        if tokenizer_config:
-            tokenizer_spec = inject_object_spec_args(
-                tokenizer_config.tokenizer_spec, constant_bindings={"cache_config": cache_config}
-            )
-            return create_object(tokenizer_spec)
-        elif organization in [
-            "gooseai",
-            "huggingface",
-            "microsoft",
-            "google",
-            "writer",  # Palmyra
-            "nvidia",
-            "EleutherAI",
-            "facebook",
-            "meta-llama",
-            "hf-internal-testing",
-            "mistralai",
-            "HuggingFaceM4",
-            # Together
-            "together",
-            "databricks",
-            "eleutherai",
-            "lmsys",
-            "meta",
-            "mosaicml",
-            "stabilityai",
-            "stanford",
-            "tiiuae",
-            "bigcode",
-            "bigscience",
-        ]:
-            tokenizer = HuggingFaceTokenizer(cache_config=cache_config)
-        elif organization == "neurips":
-            from helm.proxy.tokenizers.http_model_tokenizer import HTTPModelTokenizer
-
-            tokenizer = HTTPModelTokenizer(cache_config=cache_config)
-        elif organization == "openai":
-            from helm.proxy.tokenizers.tiktoken_tokenizer import TiktokenTokenizer
-
-            tokenizer = TiktokenTokenizer(cache_config=cache_config)
-        elif organization == "AlephAlpha":
-            from helm.proxy.tokenizers.aleph_alpha_tokenizer import AlephAlphaTokenizer
-
-            tokenizer = AlephAlphaTokenizer(api_key=self.credentials["alephAlphaKey"], cache_config=cache_config)
-        elif organization == "ai21":
-            from helm.proxy.tokenizers.ai21_tokenizer import AI21Tokenizer
-
-            tokenizer = AI21Tokenizer(api_key=self.credentials["ai21ApiKey"], cache_config=cache_config)
-        elif organization == "cohere":
-            from helm.proxy.tokenizers.cohere_tokenizer import CohereTokenizer
-
-            tokenizer = CohereTokenizer(api_key=self.credentials["cohereApiKey"], cache_config=cache_config)
-        elif organization == "anthropic":
-            from helm.proxy.tokenizers.anthropic_tokenizer import AnthropicTokenizer
-
-            tokenizer = AnthropicTokenizer(cache_config=cache_config)
-        elif organization == "simple":
-            from helm.proxy.tokenizers.simple_tokenizer import SimpleTokenizer
-
-            tokenizer = SimpleTokenizer()
-        elif organization == "lightningai":
-            from helm.proxy.tokenizers.lit_gpt_tokenizer import LitGPTTokenizer
-
-            tokenizer = LitGPTTokenizer(
-                cache_config=cache_config,
-                checkpoint_dir=Path(os.environ.get("LIT_GPT_CHECKPOINT_DIR", "")),
-            )
-        elif organization == "TsinghuaKEG":
-            from helm.proxy.tokenizers.ice_tokenizer import ICETokenizer
-
-            tokenizer = ICETokenizer(cache_config=cache_config)
-        elif organization == "Yandex":
-            from helm.proxy.tokenizers.yalm_tokenizer import YaLMTokenizer
-
-            tokenizer = YaLMTokenizer(cache_config=cache_config)
-
-        if tokenizer is None:
-            raise ValueError(f"Could not find tokenizer for model: {tokenizer_name}")
-
-        # Cache the tokenizer
-        self.tokenizers[tokenizer_name] = tokenizer
-
-        return tokenizer
-
->>>>>>> Fixes
-    def tokenize(self, request: TokenizationRequest) -> TokenizationRequestResult:
-        raise NotImplementedError(
-            "AutoClient.tokenize() is not supported anymore." "Use AutoTokenizer.tokenize() instead."
-        )
-
-    # TODO: remove this method after a few weeks (2023-11-09)
-    def decode(self, request: DecodeRequest) -> DecodeRequestResult:
-        raise NotImplementedError("AutoClient.decode() is not supported anymore." "Use AutoTokenizer.decode() instead.")
-
     def get_toxicity_classifier_client(self) -> ToxicityClassifierClient:
         """Get the toxicity classifier client. We currently only support Perspective API."""
         from helm.proxy.clients.perspective_api_client import PerspectiveAPIClient
@@ -313,8 +183,7 @@ class AutoClient(Client):
             assert isinstance(self._huggingface_client, HuggingFaceClient)
             return self._huggingface_client
         cache_config = build_cache_config(self.cache_path, self.mongo_uri, "huggingface")
-        tokenizer = HuggingFaceTokenizer(cache_config)
-        self._huggingface_client = HuggingFaceClient(tokenizer=tokenizer, cache_config=cache_config)
+        self._huggingface_client = HuggingFaceClient(cache_config=cache_config)
         return self._huggingface_client
 
     def get_huggingface_tokenizer(self) -> HuggingFaceTokenizer:
@@ -322,6 +191,6 @@ class AutoClient(Client):
         if self._huggingface_tokenizer:
             assert isinstance(self._huggingface_tokenizer, HuggingFaceTokenizer)
             return self._huggingface_tokenizer
-        cache_config = self._build_cache_config("huggingface")
+        cache_config = build_cache_config(self.cache_path, self.mongo_uri, "huggingface")
         self._huggingface_tokenizer = HuggingFaceTokenizer(cache_config=cache_config)
         return self._huggingface_tokenizer

--- a/src/helm/proxy/clients/auto_client.py
+++ b/src/helm/proxy/clients/auto_client.py
@@ -96,7 +96,6 @@ class AutoClient(Client):
 
         # Cache the client
         self.clients[model_deployment_name] = client
-
         return client
 
     def make_request(self, request: Request) -> RequestResult:

--- a/src/helm/proxy/clients/auto_client.py
+++ b/src/helm/proxy/clients/auto_client.py
@@ -44,6 +44,10 @@ class AutoClient(Client):
         self.clients: Dict[str, Client] = {}
         # self._huggingface_client is lazily instantiated by get_huggingface_client()
         self._huggingface_client: Optional["helm.proxy.clients.huggingface_client.HuggingFaceClient"] = None
+        # self._huggingface_tokenizer is lazily instantiated by get_huggingface_tokenizer()
+        self._huggingface_tokenizer: Optional[
+            "helm.proxy.tokenizers.huggingface_tokenizers.HuggingFaceTokenizer"
+        ] = None
         # self._critique_client is lazily instantiated by get_critique_client()
         self._critique_client: Optional[CritiqueClient] = None
         hlog(f"AutoClient: cache_path = {cache_path}")
@@ -205,3 +209,14 @@ class AutoClient(Client):
         tokenizer = HuggingFaceTokenizer(cache_config)
         self._huggingface_client = HuggingFaceClient(tokenizer=tokenizer, cache_config=cache_config)
         return self._huggingface_client
+
+    def get_huggingface_tokenizer(self) -> "helm.proxy.tokenizers.huggingface_tokenizers.HuggingFaceTokenizer":
+        """Get the Hugging Face client."""
+        from helm.proxy.tokenizers.huggingface_tokenizers import HuggingFaceTokenizer
+
+        if self._huggingface_tokenizer:
+            assert isinstance(self._huggingface_tokenizer, HuggingFaceTokenizer)
+            return self._huggingface_tokenizer
+        cache_config = self._build_cache_config("huggingface")
+        self._huggingface_tokenizer = HuggingFaceTokenizer(cache_config=cache_config)
+        return self._huggingface_tokenizer

--- a/src/helm/proxy/clients/auto_client.py
+++ b/src/helm/proxy/clients/auto_client.py
@@ -45,9 +45,7 @@ class AutoClient(Client):
         # self._huggingface_client is lazily instantiated by get_huggingface_client()
         self._huggingface_client: Optional["helm.proxy.clients.huggingface_client.HuggingFaceClient"] = None
         # self._huggingface_tokenizer is lazily instantiated by get_huggingface_tokenizer()
-        self._huggingface_tokenizer: Optional[
-            "helm.proxy.tokenizers.huggingface_tokenizers.HuggingFaceTokenizer"
-        ] = None
+        self._huggingface_tokenizer: Optional["helm.proxy.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"] = None
         # self._critique_client is lazily instantiated by get_critique_client()
         self._critique_client: Optional[CritiqueClient] = None
         hlog(f"AutoClient: cache_path = {cache_path}")
@@ -210,9 +208,9 @@ class AutoClient(Client):
         self._huggingface_client = HuggingFaceClient(tokenizer=tokenizer, cache_config=cache_config)
         return self._huggingface_client
 
-    def get_huggingface_tokenizer(self) -> "helm.proxy.tokenizers.huggingface_tokenizers.HuggingFaceTokenizer":
+    def get_huggingface_tokenizer(self) -> "helm.proxy.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer":
         """Get the Hugging Face client."""
-        from helm.proxy.tokenizers.huggingface_tokenizers import HuggingFaceTokenizer
+        from helm.proxy.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer
 
         if self._huggingface_tokenizer:
             assert isinstance(self._huggingface_tokenizer, HuggingFaceTokenizer)

--- a/src/helm/proxy/clients/client.py
+++ b/src/helm/proxy/clients/client.py
@@ -12,7 +12,6 @@ from helm.common.tokenization_request import (
     DecodeRequestResult,
 )
 from helm.common.cache import Cache, CacheConfig
-from helm.proxy.tokenizers.tokenizer import Tokenizer
 
 
 class Client(ABC):
@@ -54,7 +53,7 @@ class Client(ABC):
 
 
 class CachingClient(Client):
-    def __init__(self, cache_config: CacheConfig, tokenizer: Tokenizer) -> None:
+    def __init__(self, cache_config: CacheConfig) -> None:
         """Initializes the client.
 
         For most clients, both the cache config and tokenizer are required.
@@ -63,7 +62,6 @@ class CachingClient(Client):
         the request is made.
         """
         self.cache = Cache(cache_config) if cache_config is not None else None
-        self.tokenizer = tokenizer
 
     @staticmethod
     def make_cache_key(raw_request: Dict, request: Request) -> Dict:
@@ -79,14 +77,10 @@ class CachingClient(Client):
         return cache_key
 
     def tokenize(self, request: TokenizationRequest) -> TokenizationRequestResult:
-        # Deprecated - use `self.tokenizer.tokenize` instead. Warn the user.
-        hlog("WARNING: CachingClient.tokenize is deprecated, use self.tokenizer.tokenize instead")
-        return self.tokenizer.tokenize(request)
+        raise NotImplementedError("CachingClient.tokenize() is not supported, use self.tokenizer.tokenize instead")
 
     def decode(self, request: DecodeRequest) -> DecodeRequestResult:
-        # Deprecated - use `self.tokenizer.decode` instead. Warn the user.
-        hlog("WARNING: CachingClient.decode is deprecated, use self.tokenizer.decode instead")
-        return self.tokenizer.decode(request)
+        raise NotImplementedError("CachingClient.decode() is not supported, use self.tokenizer.decode instead")
 
 
 def truncate_sequence(sequence: Sequence, request: Request, print_warning: bool = True) -> Sequence:

--- a/src/helm/proxy/clients/client.py
+++ b/src/helm/proxy/clients/client.py
@@ -5,12 +5,6 @@ from typing import Dict, List, Optional
 from helm.common.hierarchical_logger import hlog
 from helm.common.media_object import MultimediaObject, TEXT_TYPE
 from helm.common.request import Request, RequestResult, Sequence, Token
-from helm.common.tokenization_request import (
-    TokenizationRequest,
-    TokenizationRequestResult,
-    DecodeRequest,
-    DecodeRequestResult,
-)
 from helm.common.cache import Cache, CacheConfig
 
 
@@ -47,12 +41,6 @@ class CachingClient(Client):
         else:
             cache_key = raw_request
         return cache_key
-
-    def tokenize(self, request: TokenizationRequest) -> TokenizationRequestResult:
-        raise NotImplementedError("CachingClient.tokenize() is not supported, use self.tokenizer.tokenize instead")
-
-    def decode(self, request: DecodeRequest) -> DecodeRequestResult:
-        raise NotImplementedError("CachingClient.decode() is not supported, use self.tokenizer.decode instead")
 
 
 def truncate_sequence(sequence: Sequence, request: Request, print_warning: bool = True) -> Sequence:

--- a/src/helm/proxy/clients/client.py
+++ b/src/helm/proxy/clients/client.py
@@ -15,34 +15,6 @@ from helm.common.cache import Cache, CacheConfig
 
 
 class Client(ABC):
-    # TODO: This method should be removed.
-    # This only kept for the AutoClient. Eventually, we should introduce an
-    # AutoTokenizer or TokenizerFactory class.
-    @abstractmethod
-    def tokenize(self, request: TokenizationRequest) -> TokenizationRequestResult:
-        """Tokenizes `request.text` using `request.tokenizer`.
-
-        This simply calls the `tokenize` method of the tokenizer.
-        Some exceptions can be made (but should be avoided).
-        This is the case for the auto client, which needs to handle
-        tokenization for multiple tokenizers.
-        """
-        pass
-
-    # TODO: This method should be removed.
-    # This only kept for the AutoClient. Eventually, we should introduce an
-    # AutoTokenizer or TokenizerFactory class.
-    @abstractmethod
-    def decode(self, request: DecodeRequest) -> DecodeRequestResult:
-        """Decodes `request.tokens` using `request.tokenizer`.
-
-        This simply calls the `decode` method of the tokenizer.
-        Some exceptions can be made (but should be avoided).
-        This is the case for the auto client, which needs to handle
-        tokenization for multiple tokenizers.
-        """
-        pass
-
     @abstractmethod
     def make_request(self, request: Request) -> RequestResult:
         """Makes a request to the model.

--- a/src/helm/proxy/clients/cohere_client.py
+++ b/src/helm/proxy/clients/cohere_client.py
@@ -12,7 +12,6 @@ from helm.common.request import (
     Token,
 )
 from helm.benchmark.model_deployment_registry import get_model_deployments_by_host_organization
-from helm.proxy.tokenizers.tokenizer import Tokenizer
 from .client import CachingClient, truncate_sequence
 from .cohere_utils import get_cohere_url, DEFAULT_COHERE_API_VERSION
 
@@ -21,8 +20,8 @@ class CohereClient(CachingClient):
     ORGANIZATION: str = "cohere"
     GENERATE_ENDPOINT: str = "generate"
 
-    def __init__(self, api_key: str, tokenizer: Tokenizer, cache_config: CacheConfig):
-        super().__init__(cache_config=cache_config, tokenizer=tokenizer)
+    def __init__(self, api_key: str, cache_config: CacheConfig):
+        super().__init__(cache_config=cache_config)
         self.api_key: str = api_key
 
     def make_request(self, request: Request) -> RequestResult:

--- a/src/helm/proxy/clients/google_client.py
+++ b/src/helm/proxy/clients/google_client.py
@@ -2,7 +2,6 @@ from typing import List, Dict
 
 from helm.common.cache import CacheConfig
 from helm.common.request import Request, RequestResult, Sequence, Token
-from helm.proxy.tokenizers.tokenizer import Tokenizer
 from .client import CachingClient, truncate_sequence
 
 
@@ -28,8 +27,8 @@ class GoogleClient(CachingClient):
             "top_p": request.top_p,
         }
 
-    def __init__(self, tokenizer: Tokenizer, cache_config: CacheConfig):
-        super().__init__(cache_config=cache_config, tokenizer=tokenizer)
+    def __init__(self, cache_config: CacheConfig):
+        super().__init__(cache_config=cache_config)
 
     def make_request(self, request: Request) -> RequestResult:
         raw_request = GoogleClient.convert_to_raw_request(request)

--- a/src/helm/proxy/clients/goose_ai_client.py
+++ b/src/helm/proxy/clients/goose_ai_client.py
@@ -11,7 +11,6 @@ from helm.common.request import (
     Sequence,
     Token,
 )
-from helm.proxy.tokenizers.tokenizer import Tokenizer
 from .client import CachingClient, truncate_sequence
 from .openai_client import ORIGINAL_COMPLETION_ATTRIBUTES
 
@@ -23,8 +22,8 @@ class GooseAIClient(CachingClient):
     - Supported models: https://goose.ai/docs/models
     """
 
-    def __init__(self, api_key: str, tokenizer: Tokenizer, cache_config: CacheConfig, org_id: Optional[str] = None):
-        super().__init__(cache_config=cache_config, tokenizer=tokenizer)
+    def __init__(self, api_key: str, cache_config: CacheConfig, org_id: Optional[str] = None):
+        super().__init__(cache_config=cache_config)
         self.org_id: Optional[str] = org_id
         self.api_key: str = api_key
         self.api_base: str = "https://api.goose.ai/v1"

--- a/src/helm/proxy/clients/http_model_client.py
+++ b/src/helm/proxy/clients/http_model_client.py
@@ -10,7 +10,6 @@ from helm.common.request import (
     Token,
     EMBEDDING_UNAVAILABLE_REQUEST_RESULT,
 )
-from helm.proxy.tokenizers.tokenizer import Tokenizer
 from .client import CachingClient
 
 import requests
@@ -21,13 +20,12 @@ class HTTPModelClient(CachingClient):
 
     def __init__(
         self,
-        tokenizer: Tokenizer,
         cache_config: CacheConfig,
         base_url: str = "http://localhost:8080",
         timeout: int = 3000,
         do_cache: bool = False,
     ):
-        super().__init__(cache_config=cache_config, tokenizer=tokenizer)
+        super().__init__(cache_config=cache_config)
         self.base_url = (
             base_url if not os.environ.get("HELM_HTTP_MODEL_BASE_URL") else os.environ["HELM_HTTP_MODEL_BASE_URL"]
         )

--- a/src/helm/proxy/clients/huggingface_client.py
+++ b/src/helm/proxy/clients/huggingface_client.py
@@ -19,7 +19,6 @@ from helm.common.request import (
 )
 from .client import CachingClient, truncate_sequence
 from helm.proxy.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer, resolve_alias
-from helm.proxy.tokenizers.tokenizer import Tokenizer
 from threading import Lock
 
 
@@ -173,12 +172,11 @@ class HuggingFaceServerFactory:
 class HuggingFaceClient(CachingClient):
     def __init__(
         self,
-        tokenizer: Tokenizer,
         cache_config: CacheConfig,
         pretrained_model_name_or_path: Optional[str] = None,
         revision: Optional[str] = None,
     ):
-        super().__init__(cache_config=cache_config, tokenizer=tokenizer)
+        super().__init__(cache_config=cache_config)
         self._pretrained_model_name_or_path = pretrained_model_name_or_path
         self._revision = revision
 

--- a/src/helm/proxy/clients/lit_gpt_client.py
+++ b/src/helm/proxy/clients/lit_gpt_client.py
@@ -88,8 +88,8 @@ class LitGPTClient(CachingClient):
 
     def __init__(
         self,
-        cache_config: CacheConfig,
         tokenizer: Tokenizer,
+        cache_config: CacheConfig,
         checkpoint_dir: Path = Path(""),
         precision: str = "bf16-true",
         device: str = "auto",

--- a/src/helm/proxy/clients/lit_gpt_client.py
+++ b/src/helm/proxy/clients/lit_gpt_client.py
@@ -88,8 +88,8 @@ class LitGPTClient(CachingClient):
 
     def __init__(
         self,
-        tokenizer: Tokenizer,
         cache_config: CacheConfig,
+        tokenizer: Tokenizer,
         checkpoint_dir: Path = Path(""),
         precision: str = "bf16-true",
         device: str = "auto",
@@ -97,7 +97,8 @@ class LitGPTClient(CachingClient):
         strategy: str = "auto",
         quantize: Optional[QuantizationType] = None,
     ):
-        super().__init__(cache_config=cache_config, tokenizer=tokenizer)
+        super().__init__(cache_config=cache_config)
+        self.tokenizer = tokenizer
         lit_gpt = LitGPT(checkpoint_dir, precision, device, devices, strategy, quantize)
         self.model = lit_gpt.model
         self.fabric = lit_gpt.fabric

--- a/src/helm/proxy/clients/megatron_client.py
+++ b/src/helm/proxy/clients/megatron_client.py
@@ -2,6 +2,7 @@ import json
 import requests
 from typing import Any, Dict, List
 import traceback
+from helm.common.cache import CacheConfig
 
 from helm.common.request import (
     wrap_request_time,
@@ -12,11 +13,11 @@ from helm.common.request import (
     Token,
 )
 from helm.common.tokenization_request import TokenizationRequest
-from helm.proxy.clients.huggingface_client import HuggingFaceClient
 from helm.proxy.clients.client import CachingClient, truncate_sequence
+from helm.proxy.tokenizers.tokenizer import Tokenizer
 
 
-class MegatronClient(HuggingFaceClient):
+class MegatronClient(CachingClient):
     """Client for remote Megatron-LM server.
 
     This client expects an external Megatron-LM server to be run on localhost:5000. See the
@@ -24,6 +25,10 @@ class MegatronClient(HuggingFaceClient):
 
     https://github.com/NVIDIA/Megatron-LM#gpt-text-generation
     """
+
+    def __init__(self, tokenizer: Tokenizer, cache_config: CacheConfig):
+        super().__init__(cache_config=cache_config)
+        self.tokenizer = tokenizer
 
     def _send_request(self, raw_request: Dict[str, Any]) -> Dict[str, Any]:
         response = requests.request(

--- a/src/helm/proxy/clients/microsoft_client.py
+++ b/src/helm/proxy/clients/microsoft_client.py
@@ -13,7 +13,6 @@ from helm.common.request import (
     Sequence,
     Token,
 )
-from helm.proxy.tokenizers.tokenizer import Tokenizer
 from .client import CachingClient, truncate_sequence
 from .openai_client import ORIGINAL_COMPLETION_ATTRIBUTES
 
@@ -47,12 +46,11 @@ class MicrosoftClient(CachingClient):
     def __init__(
         self,
         lock_file_path: str,
-        tokenizer: Tokenizer,
         cache_config: CacheConfig,
         api_key: Optional[str] = None,
         org_id: Optional[str] = None,
     ):
-        super().__init__(cache_config=cache_config, tokenizer=tokenizer)
+        super().__init__(cache_config=cache_config)
 
         # Adapted from their documentation: https://github.com/microsoft/turing-academic-TNLG
         class EngineAPIResource(engine_api_resource.EngineAPIResource):

--- a/src/helm/proxy/clients/openai_client.py
+++ b/src/helm/proxy/clients/openai_client.py
@@ -33,7 +33,8 @@ class OpenAIClient(CachingClient):
         api_key: Optional[str] = None,
         org_id: Optional[str] = None,
     ):
-        super().__init__(cache_config=cache_config, tokenizer=tokenizer)
+        super().__init__(cache_config=cache_config)
+        self.tokenizer = tokenizer
         self.org_id: Optional[str] = org_id
         self.api_key: Optional[str] = api_key
         self.api_base: str = "https://api.openai.com/v1"

--- a/src/helm/proxy/clients/palmyra_client.py
+++ b/src/helm/proxy/clients/palmyra_client.py
@@ -28,9 +28,9 @@ def _is_content_moderation_failure(response: Dict) -> bool:
 
 
 class PalmyraClient(CachingClient):
-    def __init__(self, api_key: str, tokenizer: Tokenizer, cache_config: CacheConfig):
-        super().__init__(cache_config=cache_config, tokenizer=tokenizer)
+    def __init__(self, cache_config: CacheConfig, tokenizer: Tokenizer, api_key: str):
         self.api_key: str = api_key
+        self.tokenizer = tokenizer
 
     def _send_request(self, model_name: str, raw_request: Dict[str, Any]) -> Dict[str, Any]:
         response = requests.request(

--- a/src/helm/proxy/clients/palmyra_client.py
+++ b/src/helm/proxy/clients/palmyra_client.py
@@ -28,7 +28,8 @@ def _is_content_moderation_failure(response: Dict) -> bool:
 
 
 class PalmyraClient(CachingClient):
-    def __init__(self, cache_config: CacheConfig, tokenizer: Tokenizer, api_key: str):
+    def __init__(self, tokenizer: Tokenizer, cache_config: CacheConfig, api_key: str):
+        super().__init__(cache_config=cache_config)
         self.api_key: str = api_key
         self.tokenizer = tokenizer
 

--- a/src/helm/proxy/clients/simple_client.py
+++ b/src/helm/proxy/clients/simple_client.py
@@ -3,15 +3,14 @@ from typing import List, Dict
 from helm.common.cache import CacheConfig
 from helm.common.request import wrap_request_time, Request, RequestResult, Sequence, Token
 from helm.proxy.tokenizers.simple_tokenizer import SimpleTokenizer
-from helm.proxy.tokenizers.tokenizer import Tokenizer
 from .client import CachingClient
 
 
 class SimpleClient(CachingClient):
     """Implements some "models" that just generate silly things quickly just to debug the infrastructure."""
 
-    def __init__(self, tokenizer: Tokenizer, cache_config: CacheConfig):
-        super().__init__(cache_config=cache_config, tokenizer=tokenizer)
+    def __init__(self, cache_config: CacheConfig):
+        super().__init__(cache_config=cache_config)
 
     def make_request(self, request: Request) -> RequestResult:
         raw_request = {

--- a/src/helm/proxy/clients/test_huggingface_client.py
+++ b/src/helm/proxy/clients/test_huggingface_client.py
@@ -1,17 +1,9 @@
-# mypy: check_untyped_defs = False
 import os
 import pytest
 import tempfile
 
 from helm.common.cache import SqliteCacheConfig
 from helm.common.request import Request, RequestResult
-from helm.common.tokenization_request import (
-    DecodeRequest,
-    DecodeRequestResult,
-    TokenizationRequest,
-    TokenizationRequestResult,
-)
-from helm.proxy.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer
 from .huggingface_client import HuggingFaceClient
 
 
@@ -19,42 +11,10 @@ class TestHuggingFaceClient:
     def setup_method(self, method):
         cache_file = tempfile.NamedTemporaryFile(delete=False)
         self.cache_path: str = cache_file.name
-        self.client = HuggingFaceClient(
-            tokenizer=HuggingFaceTokenizer(SqliteCacheConfig(self.cache_path)),
-            cache_config=SqliteCacheConfig(self.cache_path),
-        )
+        self.client = HuggingFaceClient(cache_config=SqliteCacheConfig(self.cache_path))
 
     def teardown_method(self, method):
         os.remove(self.cache_path)
-
-    def test_tokenize(self):
-        request = TokenizationRequest(text="I am a computer scientist.")
-        result: TokenizationRequestResult = self.client.tokenizer.tokenize(request)
-        assert not result.cached, "First time making the tokenize request. Result should not be cached"
-        result: TokenizationRequestResult = self.client.tokenizer.tokenize(request)
-        assert result.cached, "Result should be cached"
-        assert result.raw_tokens == ["I", " am", " a", " computer", " scientist", "."]
-
-    def test_encode(self):
-        request = TokenizationRequest(text="I am a computer scientist.", encode=True, truncation=True, max_length=1)
-        result: TokenizationRequestResult = self.client.tokenizer.tokenize(request)
-        assert not result.cached, "First time making the tokenize request. Result should not be cached"
-        result: TokenizationRequestResult = self.client.tokenizer.tokenize(request)
-        assert result.cached, "Result should be cached"
-        assert result.raw_tokens == [40]
-
-        request = TokenizationRequest(text="I am a computer scientist.", encode=True, truncation=True, max_length=1024)
-        result = self.client.tokenizer.tokenize(request)
-        assert not result.cached, "First time making this particular request. Result should not be cached"
-        assert result.raw_tokens == [40, 716, 257, 3644, 11444, 13]
-
-    def test_decode(self):
-        request = DecodeRequest(tokens=[40, 716, 257, 3644, 11444, 13])
-        result: DecodeRequestResult = self.client.tokenizer.decode(request)
-        assert not result.cached, "First time making the decode request. Result should not be cached"
-        result: DecodeRequestResult = self.client.tokenizer.decode(request)
-        assert result.cached, "Result should be cached"
-        assert result.text == "I am a computer scientist."
 
     def test_gpt2(self):
         prompt: str = "I am a computer scientist."

--- a/src/helm/proxy/clients/test_together_client.py
+++ b/src/helm/proxy/clients/test_together_client.py
@@ -4,7 +4,6 @@ import tempfile
 
 from helm.common.cache import SqliteCacheConfig
 from helm.common.request import Request
-from helm.proxy.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer
 
 from .together_client import TogetherClient, TogetherClientError
 
@@ -13,10 +12,7 @@ class TestTogetherClient:
     def setup_method(self, method):
         cache_file = tempfile.NamedTemporaryFile(delete=False)
         self.cache_path: str = cache_file.name
-        self.client = TogetherClient(
-            tokenizer=HuggingFaceTokenizer(SqliteCacheConfig(self.cache_path)),
-            cache_config=SqliteCacheConfig(self.cache_path),
-        )
+        self.client = TogetherClient(cache_config=SqliteCacheConfig(self.cache_path))
 
     def teardown_method(self, method):
         os.remove(self.cache_path)

--- a/src/helm/proxy/clients/together_client.py
+++ b/src/helm/proxy/clients/together_client.py
@@ -6,7 +6,6 @@ from retrying import retry
 
 from helm.common.cache import CacheConfig
 from helm.common.request import wrap_request_time, Request, RequestResult, Sequence, Token
-from helm.proxy.tokenizers.tokenizer import Tokenizer
 from .client import CachingClient, truncate_sequence, cleanup_str
 
 
@@ -166,8 +165,8 @@ class TogetherClient(CachingClient):
         }
         return _rewrite_raw_request_for_model_tags(raw_request, request.model_engine)
 
-    def __init__(self, tokenizer: Tokenizer, cache_config: CacheConfig, api_key: Optional[str] = None):
-        super().__init__(cache_config=cache_config, tokenizer=tokenizer)
+    def __init__(self, cache_config: CacheConfig, api_key: Optional[str] = None):
+        super().__init__(cache_config=cache_config)
         # TODO: the endpoint currently doesn't require an API key. When an API key is not specified
         #       in credentials.conf, we rely on offline evaluation only.
         self.api_key: Optional[str] = api_key

--- a/src/helm/proxy/clients/vision_language/idefics_client.py
+++ b/src/helm/proxy/clients/vision_language/idefics_client.py
@@ -55,7 +55,8 @@ class IDEFICSClient(CachingClient):
     BAD_WORD_TOKENS: List[str] = ["<image>", "<fake_token_around_image>"]
 
     def __init__(self, tokenizer: Tokenizer, cache_config: CacheConfig):
-        super().__init__(cache_config=cache_config, tokenizer=tokenizer)
+        super().__init__(cache_config=cache_config)
+        self.tokenizer = tokenizer
         self._device: str = get_torch_device_name()
 
     def _get_model(self, checkpoint: str) -> LoadedIDEFICSModelProcessor:

--- a/src/helm/proxy/services/server_service.py
+++ b/src/helm/proxy/services/server_service.py
@@ -49,7 +49,7 @@ class ServerService(Service):
 
         self.client = AutoClient(credentials, cache_path, mongo_uri)
         self.tokenizer = AutoTokenizer(credentials, cache_path, mongo_uri)
-        self.token_counter = AutoTokenCounter(self.client.get_huggingface_client())
+        self.token_counter = AutoTokenCounter(self.client.get_huggingface_tokenizer())
         self.accounts = Accounts(accounts_path, root_mode=root_mode)
         # Lazily instantiated by get_toxicity_scores()
         self.toxicity_classifier_client: Optional[ToxicityClassifierClient] = None

--- a/src/helm/proxy/services/server_service.py
+++ b/src/helm/proxy/services/server_service.py
@@ -1,6 +1,7 @@
 import os
 import signal
 from typing import List, Optional
+from helm.common.cache_utils import build_cache_config
 
 from helm.common.critique_request import CritiqueRequest, CritiqueRequestResult
 from helm.common.authentication import Authentication
@@ -25,6 +26,7 @@ from helm.proxy.query import Query, QueryResult
 from helm.proxy.retry import retry_request
 from helm.proxy.token_counters.auto_token_counter import AutoTokenCounter
 from helm.proxy.tokenizers.auto_tokenizer import AutoTokenizer
+from helm.proxy.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer
 from .service import (
     Service,
     CACHE_DIR,
@@ -49,7 +51,8 @@ class ServerService(Service):
 
         self.client = AutoClient(credentials, cache_path, mongo_uri)
         self.tokenizer = AutoTokenizer(credentials, cache_path, mongo_uri)
-        self.token_counter = AutoTokenCounter(self.tokenizer.get_huggingface_tokenizer())
+        cache_config = build_cache_config(cache_path, mongo_uri, "huggingface")
+        self.token_counter = AutoTokenCounter(HuggingFaceTokenizer(cache_config=cache_config))
         self.accounts = Accounts(accounts_path, root_mode=root_mode)
         # Lazily instantiated by get_toxicity_scores()
         self.toxicity_classifier_client: Optional[ToxicityClassifierClient] = None

--- a/src/helm/proxy/services/server_service.py
+++ b/src/helm/proxy/services/server_service.py
@@ -49,7 +49,7 @@ class ServerService(Service):
 
         self.client = AutoClient(credentials, cache_path, mongo_uri)
         self.tokenizer = AutoTokenizer(credentials, cache_path, mongo_uri)
-        self.token_counter = AutoTokenCounter(self.client.get_huggingface_tokenizer())
+        self.token_counter = AutoTokenCounter(self.tokenizer.get_huggingface_tokenizer())
         self.accounts = Accounts(accounts_path, root_mode=root_mode)
         # Lazily instantiated by get_toxicity_scores()
         self.toxicity_classifier_client: Optional[ToxicityClassifierClient] = None

--- a/src/helm/proxy/token_counters/auto_token_counter.py
+++ b/src/helm/proxy/token_counters/auto_token_counter.py
@@ -1,7 +1,7 @@
 from typing import Dict, List
 
 from helm.common.request import Request, Sequence
-from helm.proxy.clients.huggingface_client import HuggingFaceClient
+from helm.proxy.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer
 from .ai21_token_counter import AI21TokenCounter
 from .cohere_token_counter import CohereTokenCounter
 from .free_token_counter import FreeTokenCounter
@@ -13,16 +13,16 @@ from .token_counter import TokenCounter
 class AutoTokenCounter(TokenCounter):
     """Automatically count tokens based on the organization."""
 
-    def __init__(self, huggingface_client: HuggingFaceClient):
+    def __init__(self, huggingface_tokenizer: HuggingFaceTokenizer):
         self.token_counters: Dict[str, TokenCounter] = {}
-        self.huggingface_client: HuggingFaceClient = huggingface_client
+        self.huggingface_tokenizer: HuggingFaceTokenizer = huggingface_tokenizer
 
     def get_token_counter(self, organization: str) -> TokenCounter:
         """Return a token counter based on the organization."""
         token_counter = self.token_counters.get(organization)
         if token_counter is None:
             if organization == "openai":
-                token_counter = OpenAITokenCounter(self.huggingface_client)
+                token_counter = OpenAITokenCounter(self.huggingface_tokenizer)
             elif organization == "ai21":
                 token_counter = AI21TokenCounter()
             elif organization == "gooseai":

--- a/src/helm/proxy/token_counters/openai_token_counter.py
+++ b/src/helm/proxy/token_counters/openai_token_counter.py
@@ -15,11 +15,8 @@ class OpenAITokenCounter(TokenCounter):
         Counts the total number of tokens using the suggestion here:
         https://community.openai.com/t/how-do-i-calculate-the-pricing-for-generation-of-text/11662/5
         """
-<<<<<<< HEAD
-        tokenized_prompt: TokenizationRequestResult = self.huggingface_client.tokenizer.tokenize(
-=======
+
         tokenized_prompt: TokenizationRequestResult = self.huggingface_tokenizer.tokenize(
->>>>>>> Fix test_openai_token_counter
             TokenizationRequest(request.prompt)
         )
         # Number of tokens in the prompt + number of tokens in all the completions

--- a/src/helm/proxy/token_counters/openai_token_counter.py
+++ b/src/helm/proxy/token_counters/openai_token_counter.py
@@ -2,20 +2,24 @@ from typing import List
 
 from helm.common.request import Request, Sequence
 from helm.common.tokenization_request import TokenizationRequest, TokenizationRequestResult
-from helm.proxy.clients.huggingface_client import HuggingFaceClient
+from helm.proxy.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer
 from .token_counter import TokenCounter
 
 
 class OpenAITokenCounter(TokenCounter):
-    def __init__(self, huggingface_client: HuggingFaceClient):
-        self.huggingface_client: HuggingFaceClient = huggingface_client
+    def __init__(self, huggingface_tokenizer: HuggingFaceTokenizer):
+        self.huggingface_tokenizer: HuggingFaceTokenizer = huggingface_tokenizer
 
     def count_tokens(self, request: Request, completions: List[Sequence]) -> int:
         """
         Counts the total number of tokens using the suggestion here:
         https://community.openai.com/t/how-do-i-calculate-the-pricing-for-generation-of-text/11662/5
         """
+<<<<<<< HEAD
         tokenized_prompt: TokenizationRequestResult = self.huggingface_client.tokenizer.tokenize(
+=======
+        tokenized_prompt: TokenizationRequestResult = self.huggingface_tokenizer.tokenize(
+>>>>>>> Fix test_openai_token_counter
             TokenizationRequest(request.prompt)
         )
         # Number of tokens in the prompt + number of tokens in all the completions

--- a/src/helm/proxy/token_counters/openai_token_counter.py
+++ b/src/helm/proxy/token_counters/openai_token_counter.py
@@ -15,7 +15,6 @@ class OpenAITokenCounter(TokenCounter):
         Counts the total number of tokens using the suggestion here:
         https://community.openai.com/t/how-do-i-calculate-the-pricing-for-generation-of-text/11662/5
         """
-
         tokenized_prompt: TokenizationRequestResult = self.huggingface_tokenizer.tokenize(
             TokenizationRequest(request.prompt)
         )

--- a/src/helm/proxy/token_counters/test_openai_token_counter.py
+++ b/src/helm/proxy/token_counters/test_openai_token_counter.py
@@ -4,7 +4,7 @@ from typing import List
 
 from helm.common.cache import SqliteCacheConfig
 from helm.common.request import Request, Sequence, Token
-from helm.proxy.clients.huggingface_client import HuggingFaceClient
+from helm.proxy.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer
 from .openai_token_counter import OpenAITokenCounter
 
 
@@ -21,7 +21,7 @@ class TestOpenAITokenCounter:
     def setup_method(self, method):
         self.cache_path: str = tempfile.NamedTemporaryFile(delete=False).name
         self.token_counter = OpenAITokenCounter(
-            HuggingFaceClient(
+            HuggingFaceTokenizer(
                 cache_config=SqliteCacheConfig(self.cache_path),
             )
         )

--- a/src/helm/proxy/token_counters/test_openai_token_counter.py
+++ b/src/helm/proxy/token_counters/test_openai_token_counter.py
@@ -5,7 +5,6 @@ from typing import List
 from helm.common.cache import SqliteCacheConfig
 from helm.common.request import Request, Sequence, Token
 from helm.proxy.clients.huggingface_client import HuggingFaceClient
-from helm.proxy.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer
 from .openai_token_counter import OpenAITokenCounter
 
 
@@ -23,7 +22,6 @@ class TestOpenAITokenCounter:
         self.cache_path: str = tempfile.NamedTemporaryFile(delete=False).name
         self.token_counter = OpenAITokenCounter(
             HuggingFaceClient(
-                tokenizer=HuggingFaceTokenizer(cache_config=SqliteCacheConfig(self.cache_path)),
                 cache_config=SqliteCacheConfig(self.cache_path),
             )
         )

--- a/src/helm/proxy/tokenizers/auto_tokenizer.py
+++ b/src/helm/proxy/tokenizers/auto_tokenizer.py
@@ -15,7 +15,6 @@ from helm.common.tokenization_request import (
     TokenizationRequest,
     TokenizationRequestResult,
 )
-from helm.proxy.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer
 from helm.proxy.tokenizers.tokenizer import Tokenizer
 
 
@@ -26,8 +25,6 @@ class AutoTokenizer(Tokenizer):
         self.credentials = credentials
         self.cache_path = cache_path
         self.mongo_uri = mongo_uri
-        # self._huggingface_tokenizer is lazily instantiated by get_huggingface_tokenizer()
-        self._huggingface_tokenizer: Optional[HuggingFaceTokenizer] = None
         self.tokenizers: Dict[str, Tokenizer] = {}
         hlog(f"AutoTokenizer: cache_path = {cache_path}")
         hlog(f"AutoTokenizer: mongo_uri = {mongo_uri}")
@@ -90,12 +87,3 @@ class AutoTokenizer(Tokenizer):
             retry_error: str = f"Failed to decode after retrying {last_attempt.attempt_number} times"
             hlog(retry_error)
             return replace(last_attempt.value, error=f"{retry_error}. Error: {last_attempt.value.error}")
-
-    def get_huggingface_tokenizer(self) -> HuggingFaceTokenizer:
-        """Get the Hugging Face client."""
-        if self._huggingface_tokenizer:
-            assert isinstance(self._huggingface_tokenizer, HuggingFaceTokenizer)
-            return self._huggingface_tokenizer
-        cache_config = build_cache_config(self.cache_path, self.mongo_uri, "huggingface")
-        self._huggingface_tokenizer = HuggingFaceTokenizer(cache_config=cache_config)
-        return self._huggingface_tokenizer

--- a/src/helm/proxy/tokenizers/test_anthropic_tokenizer.py
+++ b/src/helm/proxy/tokenizers/test_anthropic_tokenizer.py
@@ -30,7 +30,7 @@ class TestAnthropicTokenizer:
         result: TokenizationRequestResult = self.tokenizer.tokenize(request)
         assert not result.cached, "First time making the tokenize request. Result should not be cached"
         assert result.raw_tokens == self.TEST_TOKENS
-        result: TokenizationRequestResult = self.tokenizer.tokenize(request)
+        result = self.tokenizer.tokenize(request)
         assert result.cached, "Result should be cached"
         assert result.raw_tokens == self.TEST_TOKENS
 
@@ -39,7 +39,7 @@ class TestAnthropicTokenizer:
         result: TokenizationRequestResult = self.tokenizer.tokenize(request)
         assert not result.cached, "First time making the tokenize request. Result should not be cached"
         assert result.raw_tokens == [self.TEST_ENCODED[0]]
-        result: TokenizationRequestResult = self.tokenizer.tokenize(request)
+        result = self.tokenizer.tokenize(request)
         assert result.cached, "Result should be cached"
         assert result.raw_tokens == [self.TEST_ENCODED[0]]
 
@@ -53,6 +53,6 @@ class TestAnthropicTokenizer:
         result: DecodeRequestResult = self.tokenizer.decode(request)
         assert not result.cached, "First time making the decode request. Result should not be cached"
         assert result.text == self.TEST_PROMPT
-        result: DecodeRequestResult = self.tokenizer.decode(request)
+        result = self.tokenizer.decode(request)
         assert result.cached, "Result should be cached"
         assert result.text == self.TEST_PROMPT

--- a/src/helm/proxy/tokenizers/test_anthropic_tokenizer.py
+++ b/src/helm/proxy/tokenizers/test_anthropic_tokenizer.py
@@ -1,4 +1,3 @@
-# mypy: check_untyped_defs = False
 import os
 import tempfile
 from typing import List
@@ -10,7 +9,7 @@ from helm.common.tokenization_request import (
     TokenizationRequest,
     TokenizationRequestResult,
 )
-from .anthropic_tokenizer import AnthropicTokenizer
+from helm.proxy.tokenizers.anthropic_tokenizer import AnthropicTokenizer
 
 
 class TestAnthropicTokenizer:

--- a/src/helm/proxy/tokenizers/test_huggingface_tokenizer.py
+++ b/src/helm/proxy/tokenizers/test_huggingface_tokenizer.py
@@ -2,7 +2,6 @@ import os
 import tempfile
 from typing import Optional
 
-
 from helm.common.cache import SqliteCacheConfig
 from helm.common.general import singleton
 from helm.common.tokenization_request import (

--- a/src/helm/proxy/tokenizers/test_huggingface_tokenizer.py
+++ b/src/helm/proxy/tokenizers/test_huggingface_tokenizer.py
@@ -14,7 +14,7 @@ from helm.common.tokenization_request import (
 from .huggingface_tokenizer import HuggingFaceTokenizer
 
 
-class TestHuggingFaceCachingTokenizer:
+class TestHuggingFaceGPT2Tokenizer:
     def setup_method(self, method):
         cache_file = tempfile.NamedTemporaryFile(delete=False)
         self.cache_path: str = cache_file.name
@@ -24,7 +24,7 @@ class TestHuggingFaceCachingTokenizer:
         os.remove(self.cache_path)
 
     def test_tokenize(self):
-        request = TokenizationRequest(text="I am a computer scientist.")
+        request = TokenizationRequest(text="I am a computer scientist.", tokenizer="huggingface/gpt2")
         result: TokenizationRequestResult = self.tokenizer.tokenize(request)
         assert not result.cached, "First time making the tokenize request. Result should not be cached"
         result = self.tokenizer.tokenize(request)
@@ -32,20 +32,28 @@ class TestHuggingFaceCachingTokenizer:
         assert result.raw_tokens == ["I", " am", " a", " computer", " scientist", "."]
 
     def test_encode(self):
-        request = TokenizationRequest(text="I am a computer scientist.", encode=True, truncation=True, max_length=1)
+        request = TokenizationRequest(
+            text="I am a computer scientist.", tokenizer="huggingface/gpt2", encode=True, truncation=True, max_length=1
+        )
         result: TokenizationRequestResult = self.tokenizer.tokenize(request)
         assert not result.cached, "First time making the tokenize request. Result should not be cached"
         result = self.tokenizer.tokenize(request)
         assert result.cached, "Result should be cached"
         assert result.raw_tokens == [40]
 
-        request = TokenizationRequest(text="I am a computer scientist.", encode=True, truncation=True, max_length=1024)
+        request = TokenizationRequest(
+            text="I am a computer scientist.",
+            tokenizer="huggingface/gpt2",
+            encode=True,
+            truncation=True,
+            max_length=1024,
+        )
         result = self.tokenizer.tokenize(request)
         assert not result.cached, "First time making this particular request. Result should not be cached"
         assert result.raw_tokens == [40, 716, 257, 3644, 11444, 13]
 
     def test_decode(self):
-        request = DecodeRequest(tokens=[40, 716, 257, 3644, 11444, 13])
+        request = DecodeRequest(tokens=[40, 716, 257, 3644, 11444, 13], tokenizer="huggingface/gpt2")
         result: DecodeRequestResult = self.tokenizer.decode(request)
         assert not result.cached, "First time making the decode request. Result should not be cached"
         result = self.tokenizer.decode(request)


### PR DESCRIPTION
#1874 introduced a bug in which a few of clients (Megatron, Palmyra, any model created through `ModelDeployment`) were assigned the incorrect tokenizer. This fixes the bug and also makes `tokenizer()` and `decode()` unsupported on `CachingClient`.