### PR TITLE
Move early return to the start of run_one.

### DIFF
--- a/src/helm/benchmark/slurm_runner.py
+++ b/src/helm/benchmark/slurm_runner.py
@@ -131,7 +131,7 @@ class SlurmRunner(Runner):
         # When running with multiple models, sorting by RunSpec.name is a heuristic that tries to
         # spread out the load evenly across multiple models, in order to avoid overloading any single model.
         for run_spec in sorted(run_specs, key=lambda run_spec: run_spec.name):
-            if self.skip_completed_runs and self._is_run_completed(run_spec):
+            if self.skip_completed_runs and self._is_run_completed(self._get_run_path(run_spec)):
                 skipped_run_specs.append(run_spec)
             else:
                 queued_run_specs.append(run_spec)


### PR DESCRIPTION
Minor code health improvement. Has some trivial other improvements:

1. Before, an empty `scenario_output_path` directory would be created if it was missing.
2. There is now a single place where `run_path` is created, instead of relying on two places using the same strategy.
3. Skip doing string building for instance caching that we don't use.