### PR TITLE
Prevent LanguageModelingAdapter from evaling on TRAIN instances.

### DIFF
--- a/src/helm/benchmark/adaptation/adapters/language_modeling_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/language_modeling_adapter.py
@@ -34,9 +34,15 @@ class LanguageModelingAdapter(Adapter):
         # Pick out evaluation instances. This includes both valid and test splits.
         eval_instances: List[Instance] = [instance for instance in instances if instance.split in EVAL_SPLITS]
         hlog(f"{len(eval_instances)} eval instances")
-
+        # Since at least 2023-01-01, this adapter was using `instances` instead of `eval_instances`
+        # https://github.com/stanford-crfm/helm/commit/ac9892f7449418d32ab55843702db312b58003ed#diff-69871182494f0d9f4bc6aeea76e99c13edf0213e2c123432a63cd2024d66ffcaR39
+        # This assert is intended to identify run specs (if any) that had been producing incorrect results.
+        assert len(eval_instances) == len(instances), (
+            "LanguageModelingAdapter was incorrectly "
+            + "evaluating on TRAIN instances. Please file a ticket with your RunSpec."
+        )
         all_request_states: List[RequestState] = flatten_list(
-            parallel_map(self._generate_requests, instances, parallelism)
+            parallel_map(self._generate_requests, eval_instances, parallelism)
         )
         hlog(f"{len(all_request_states)} requests")
 

--- a/src/helm/benchmark/adaptation/adapters/language_modeling_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/language_modeling_adapter.py
@@ -38,8 +38,8 @@ class LanguageModelingAdapter(Adapter):
         # https://github.com/stanford-crfm/helm/commit/ac9892f7449418d32ab55843702db312b58003ed#diff-69871182494f0d9f4bc6aeea76e99c13edf0213e2c123432a63cd2024d66ffcaR39
         # This assert is intended to identify run specs (if any) that had been producing incorrect results.
         assert len(eval_instances) == len(instances), (
-            "LanguageModelingAdapter was incorrectly "
-            + "evaluating on TRAIN instances. Please file a ticket with your RunSpec."
+            "Non-evaluation instances were passed to LanguageModelingAdapter, but LanguageModelingAdapter "
+            + "expects evaluation instances only. Please open a GitHub issue with your RunSpec."
         )
         all_request_states: List[RequestState] = flatten_list(
             parallel_map(self._generate_requests, eval_instances, parallelism)

--- a/src/helm/benchmark/adaptation/adapters/test_language_modeling_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/test_language_modeling_adapter.py
@@ -7,7 +7,7 @@ from helm.common.request import Request
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from .adapter_factory import AdapterFactory, ADAPT_LANGUAGE_MODELING
 from .test_adapter import TestAdapter
-from helm.benchmark.scenarios.scenario import Instance, Input, Reference
+from helm.benchmark.scenarios.scenario import TEST_SPLIT, Instance, Input, Reference
 
 
 class TestLanguageModelingAdapter(TestAdapter):
@@ -81,6 +81,7 @@ class TestLanguageModelingAdapter(TestAdapter):
         instance: Instance = Instance(
             input=input_text,
             references=[reference],
+            split=TEST_SPLIT,
         )
         # Ensure the adapter returns the correct prompt
         request_states: List[RequestState] = adapter.adapt([instance], parallelism=1).request_states
@@ -93,6 +94,7 @@ class TestLanguageModelingAdapter(TestAdapter):
         instance_long: Instance = Instance(
             input=input_text_long,
             references=[reference],
+            split=TEST_SPLIT,
         )
         request_states_long: List[RequestState] = adapter.adapt([instance_long], parallelism=1).request_states
         request_long: Request = request_states_long[0].request


### PR DESCRIPTION
For all run_specs I can find except CLEVA, the language modeling scenario only produces TEST instances. For CLEVA, it appears to depend on if there is a 'train.jsonl' file.