### PR TITLE
Update get leaderboard tutorial

### DIFF
--- a/docs/get_helm_rank.md
+++ b/docs/get_helm_rank.md
@@ -1,25 +1,27 @@
 # Get Your Model's Leaderboard Rank
 
-This tutorial will show you how to locally insert your model into the HELM (Core-scenarios) ranking, with in 3 steps:
+This tutorial will show you how to locally add your model into the HELM leaderboard, with in 3 steps:
 
 ## Download HELM leaderboard results
 
 First, in order to compare your model to the latest and greatest models found in the [HELM leaderboard](https://crfm.stanford.edu/helm/latest/?group=core_scenarios), use the following command to obtain a zip file of all previous HELM results
 
 ```bash
-wget file.zip
+export LEADERBOARD_VERSION=v0.3.0
 ```
 
-Once downloaded, expand the file into HELM's results directory (`v1` in this case):
+Downloaded, expand the file into HELMs results dir:
 
 ```bash
-unzip file.zip -d
-path_to_your_helm_repo/benchmark_output/runs/v1 
+curl -O https://storage.googleapis.com/crfm-helm-public/benchmark_output/archives/$LEADERBOARD_VERSION/run_stats.zip &&\
+mkdir -p benchmark_output/runs/$LEADERBOARD_VERSION && unzip run_stats.zip -d benchmark_output/runs/$LEADERBOARD_VERSION
 ```
 
-## Run Efficient-HELM (Core-scenarios)
+now that the files are in your results directory, all HELM models will be shown in your UI along with your model.
 
-According to [Efficient Benchmarking (of Language Models)](https://arxiv.org/pdf/2308.11696.pdf), which systematically analysed benchmark design choices using the HELM benchmark as an example, one can run the HELM benchmark with a fraction of the examples and still get a reliable estimation of a full run (Perlitz et al., 2023).  
+## Run Efficient-HELM
+
+According to [Efficient Benchmarking (of Language Models)](https://arxiv.org/pdf/2308.11696.pdf) a paper from IBM, which systematically analysed benchmark design choices using the HELM benchmark as an example, one can run the HELM benchmark with a fraction of the examples and still get a reliable estimation of a full run (Perlitz et al., 2023).  
 
 Specifically, the authors calculated the CI $95\%$ of Rank Location from the real ranks as a function of the number of examples used per scenario and came up with the following tradeoffs[^1]:
 
@@ -32,21 +34,41 @@ Specifically, the authors calculated the CI $95\%$ of Rank Location from the rea
 |        $1000$         |           $\pm1$           |   $\times4$   |
 |          All          |           $\pm1$           |   $\times1$   |
 
-Choose your tradeoff; how accurate do you need your rank? how much time (compute) do you want to wait (spend)? 
-Once you have chosen, (for example, if you are OK with $\pm5$) you can obtain results using the following command:
 
+Choose your point on your tradeoff, how accurate do you need your rank? how much time do you want to wait? Once you have chosen, download the config and define your model
 ```bash
-helm-run --conf-paths run_specs_core_scenarios_10 --suite v1
+export EXAMPLES_PER_SCENARIO=10 && \
+export MODEL_TO_RUN=huggingface/gpt2
 ```
 
-In case you require something more accurate, replace `run_specs_core_scenarios_10` with, for example, `run_specs_core_scenarios_100` etc.
+That's it, run the following to get the config file:
+
+```bash
+wget https://raw.githubusercontent.com/stanford-crfm/helm/main/src/helm/benchmark/presentation/run_specs_core_scenarios_$EXAMPLES_PER_SCENARIO.conf -O run_specs_$EXAMPLES_PER_SCENARIO.conf
+```
+
+and this one to run the benchmark (will take some time in the first time since all the data has to be prepared):
+
+```bash
+helm-run \
+--conf-paths run_specs_$EXAMPLES_PER_SCENARIO.conf \
+--suite $LEADERBOARD_VERSION \
+--max-eval-instances $EXAMPLES_PER_SCENARIO \
+--enable-huggingface-models $MODEL_TO_RUN \
+--cache-instances \
+--num-train-trials 1 \
+--skip-completed-runs
+```
+
+This will take some time the first time running since all the data (regardless of the number of examples chosen) is downloaded and prepared.
+
 
 ## Summarize and serve your results
 
 To view how your model fits in with the latest leaderboard, process and aggregate your results with:
 
 ```bash
-helm-summarize --suite v1
+helm-summarize --suite $LEADERBOARD_VERSION
 ```
 
 And serve with:

--- a/docs/get_helm_rank.md
+++ b/docs/get_helm_rank.md
@@ -54,7 +54,7 @@ helm-run \
 --conf-paths run_specs_$EXAMPLES_PER_SCENARIO.conf \
 --suite $LEADERBOARD_VERSION \
 --max-eval-instances $EXAMPLES_PER_SCENARIO \
---enable-huggingface-models $MODEL_TO_RUN \
+--models-to-run $MODEL_TO_RUN \
 --cache-instances \
 --num-train-trials 1 \
 --skip-completed-runs

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -18,3 +18,4 @@ helm-server
 
 Then go to http://localhost:8000/ in your browser.
 
+**Next steps:** click [here](get_helm_rank.md) to find out how to to run the full benchmark and get your model's leaderboard rank.

--- a/src/helm/benchmark/presentation/run_display.py
+++ b/src/helm/benchmark/presentation/run_display.py
@@ -176,6 +176,10 @@ def write_run_display_json(run_path: str, run_spec: RunSpec, schema: Schema, ski
     ):
         hlog(f"Skipping writing display JSON for run {run_spec.name} because all output display JSON files exist.")
         return
+    if not os.path.exists(instances_file_path):
+        hlog(f"Skipping writing display JSON for run {run_spec.name} because no instance.json file exists.")
+        return
+
     scenario_state = _read_scenario_state(run_path)
     per_instance_stats = _read_per_instance_stats(run_path)
 

--- a/src/helm/benchmark/presentation/run_specs_core_scenarios_10.conf
+++ b/src/helm/benchmark/presentation/run_specs_core_scenarios_10.conf
@@ -4,33 +4,33 @@ entries: [
 
   ## Reading comprehension
 
-  {description: "boolq:model=text,data_augmentation=canonical,max_eval_instances=10", priority: 1}
-  {description: "narrative_qa:model=text,data_augmentation=canonical,max_eval_instances=10", priority: 2}
-  {description: "quac:model=text,data_augmentation=canonical,max_eval_instances=10", priority: 1}
+  {description: "boolq:model=text,max_eval_instances=10", priority: 1}
+  {description: "narrative_qa:model=text,max_eval_instances=10", priority: 2}
+  {description: "quac:model=text,max_eval_instances=10", priority: 1}
 
   ## Reading comprehension and closedbook QA variants
 
-  {description: "natural_qa:model=text,mode=openbook_longans,data_augmentation=canonical,max_eval_instances=10", priority: 1}
-  {description: "natural_qa:model=text,mode=closedbook,data_augmentation=canonical,max_eval_instances=10", priority: 1}
+  {description: "natural_qa:model=text,mode=openbook_longans,max_eval_instances=10", priority: 1}
+  {description: "natural_qa:model=text,mode=closedbook,max_eval_instances=10", priority: 1}
 
   ## Closed-book QA with multiple choice
 
   # Adaptation method is set to ADAPT_MULTIPLE_CHOICE_SEPARATE_CALIBRATED and echo=True
-  {description: "commonsense:model=full_functionality_text,dataset=hellaswag,method=multiple_choice_separate_original,data_augmentation=canonical,max_eval_instances=10", priority: 1}
-  {description: "commonsense:model=full_functionality_text,dataset=openbookqa,method=multiple_choice_separate_calibrated,data_augmentation=canonical,max_eval_instances=10", priority: 2}
-  {description: "truthful_qa:model=text,task=mc_single,data_augmentation=canonical,max_eval_instances=10", priority: 1}
+  {description: "commonsense:model=full_functionality_text,dataset=hellaswag,method=multiple_choice_separate_original,max_eval_instances=10", priority: 1}
+  {description: "commonsense:model=full_functionality_text,dataset=openbookqa,method=multiple_choice_separate_calibrated,max_eval_instances=10", priority: 2}
+  {description: "truthful_qa:model=text,task=mc_single,max_eval_instances=10", priority: 1}
 
-  {description: "mmlu:model=text,subject=abstract_algebra,data_augmentation=canonical,max_eval_instances=2", priority: 2}
-  {description: "mmlu:model=text,subject=college_chemistry,data_augmentation=canonical,max_eval_instances=2", priority: 2}
-  {description: "mmlu:model=text,subject=computer_security,data_augmentation=canonical,max_eval_instances=2", priority: 2}
-  {description: "mmlu:model=text,subject=econometrics,data_augmentation=canonical,max_eval_instances=2", priority: 2}
-  {description: "mmlu:model=text,subject=us_foreign_policy,data_augmentation=canonical,max_eval_instances=2", priority: 2}
+  {description: "mmlu:model=text,subject=abstract_algebra,max_eval_instances=2", priority: 2}
+  {description: "mmlu:model=text,subject=college_chemistry,max_eval_instances=2", priority: 2}
+  {description: "mmlu:model=text,subject=computer_security,max_eval_instances=2", priority: 2}
+  {description: "mmlu:model=text,subject=econometrics,max_eval_instances=2", priority: 2}
+  {description: "mmlu:model=text,subject=us_foreign_policy,max_eval_instances=2", priority: 2}
   
   ##### Information Retrieval #####
   # Scenarios: MS Marco (Regular), MS MARCO (TREC)
 
-  {description: "msmarco:model=full_functionality_text,data_augmentation=canonical,track=regular,valid_topk=30,max_eval_instances=10", priority: 2}
-  {description: "msmarco:model=full_functionality_text,data_augmentation=canonical,track=trec,valid_topk=30,max_eval_instances=10", priority: 1}
+  {description: "msmarco:model=full_functionality_text,track=regular,valid_topk=30,max_eval_instances=10", priority: 2}
+  {description: "msmarco:model=full_functionality_text,track=trec,valid_topk=30,max_eval_instances=10", priority: 1}
 
   ##### Summarization #####
   # Scenarios: XSUM, CNN/DM
@@ -42,36 +42,36 @@ entries: [
   ##### Sentiment Analysis #####
   # Scenarios: IMDB
 
-  {description: "imdb:model=text,data_augmentation=canonical,max_eval_instances=10", priority: 1}
+  {description: "imdb:model=text,max_eval_instances=10", priority: 1}
 
 
   ##### (Miscellaneous) Text Classification #####
   # Scenarios: RAFT
 
-  {description: "raft:subset=ade_corpus_v2,model=text,data_augmentation=canonical,max_eval_instances=1", priority: 2}
-  {description: "raft:subset=banking_77,model=text,data_augmentation=canonical,max_eval_instances=1", priority: 2}
-  {description: "raft:subset=neurips_impact_statement_risks,model=text,data_augmentation=canonical,max_eval_instances=1", priority: 2}
-  {description: "raft:subset=one_stop_english,model=text,data_augmentation=canonical,max_eval_instances=1", priority: 2}
-  {description: "raft:subset=overruling,model=text,data_augmentation=canonical,max_eval_instances=1", priority: 2}
-  {description: "raft:subset=semiconductor_org_types,model=text,data_augmentation=canonical,max_eval_instances=1", priority: 2}
-  {description: "raft:subset=tweet_eval_hate,model=text,data_augmentation=canonical,max_eval_instances=1", priority: 2}
-  {description: "raft:subset=twitter_complaints,model=text,data_augmentation=canonical,max_eval_instances=1", priority: 2}
-  {description: "raft:subset=systematic_review_inclusion,model=text,data_augmentation=canonical,max_eval_instances=1", priority: 2}
-  {description: "raft:subset=tai_safety_research,model=text,data_augmentation=canonical,max_eval_instances=1", priority: 2}
-  {description: "raft:subset=terms_of_service,model=text,data_augmentation=canonical,max_eval_instances=1", priority: 2}
+  {description: "raft:subset=ade_corpus_v2,model=text,max_eval_instances=1", priority: 2}
+  {description: "raft:subset=banking_77,model=text,max_eval_instances=1", priority: 2}
+  {description: "raft:subset=neurips_impact_statement_risks,model=text,max_eval_instances=1", priority: 2}
+  {description: "raft:subset=one_stop_english,model=text,max_eval_instances=1", priority: 2}
+  {description: "raft:subset=overruling,model=text,max_eval_instances=1", priority: 2}
+  {description: "raft:subset=semiconductor_org_types,model=text,max_eval_instances=1", priority: 2}
+  {description: "raft:subset=tweet_eval_hate,model=text,max_eval_instances=1", priority: 2}
+  {description: "raft:subset=twitter_complaints,model=text,max_eval_instances=1", priority: 2}
+  {description: "raft:subset=systematic_review_inclusion,model=text,max_eval_instances=1", priority: 2}
+  {description: "raft:subset=tai_safety_research,model=text,max_eval_instances=1", priority: 2}
+  {description: "raft:subset=terms_of_service,model=text,max_eval_instances=1", priority: 2}
 
 
   ##### Toxicity Detection #####
   # Scenarios: CivilComments
 
-  {description: "civil_comments:model=text,demographic=all,data_augmentation=canonical,max_eval_instances=1", priority: 1}
-  {description: "civil_comments:model=text,demographic=male,data_augmentation=canonical,max_eval_instances=1", priority: 2}
-  {description: "civil_comments:model=text,demographic=female,data_augmentation=canonical,max_eval_instances=1", priority: 2}
-  {description: "civil_comments:model=text,demographic=LGBTQ,data_augmentation=canonical,max_eval_instances=1", priority: 2}
-  {description: "civil_comments:model=text,demographic=christian,data_augmentation=canonical,max_eval_instances=1", priority: 2}
-  {description: "civil_comments:model=text,demographic=muslim,data_augmentation=canonical,max_eval_instances=1", priority: 2}
-  {description: "civil_comments:model=text,demographic=other_religions,data_augmentation=canonical,max_eval_instances=1", priority: 2}
-  {description: "civil_comments:model=text,demographic=black,data_augmentation=canonical,max_eval_instances=1", priority: 2}
-  {description: "civil_comments:model=text,demographic=white,data_augmentation=canonical,max_eval_instances=2", priority: 2}
+  {description: "civil_comments:model=text,demographic=all,max_eval_instances=1", priority: 1}
+  {description: "civil_comments:model=text,demographic=male,max_eval_instances=1", priority: 2}
+  {description: "civil_comments:model=text,demographic=female,max_eval_instances=1", priority: 2}
+  {description: "civil_comments:model=text,demographic=LGBTQ,max_eval_instances=1", priority: 2}
+  {description: "civil_comments:model=text,demographic=christian,max_eval_instances=1", priority: 2}
+  {description: "civil_comments:model=text,demographic=muslim,max_eval_instances=1", priority: 2}
+  {description: "civil_comments:model=text,demographic=other_religions,max_eval_instances=1", priority: 2}
+  {description: "civil_comments:model=text,demographic=black,max_eval_instances=1", priority: 2}
+  {description: "civil_comments:model=text,demographic=white,max_eval_instances=2", priority: 2}
 
 ]

--- a/src/helm/benchmark/presentation/run_specs_core_scenarios_100.conf
+++ b/src/helm/benchmark/presentation/run_specs_core_scenarios_100.conf
@@ -4,33 +4,33 @@ entries: [
 
   ## Reading comprehension
 
-  {description: "boolq:model=text,data_augmentation=canonical,max_eval_instances=100", priority: 1}
-  {description: "narrative_qa:model=text,data_augmentation=canonical,max_eval_instances=100", priority: 2}
-  {description: "quac:model=text,data_augmentation=canonical,max_eval_instances=100", priority: 1}
+  {description: "boolq:model=text,max_eval_instances=100", priority: 1}
+  {description: "narrative_qa:model=text,max_eval_instances=100", priority: 2}
+  {description: "quac:model=text,max_eval_instances=100", priority: 1}
 
   ## Reading comprehension and closedbook QA variants
 
-  {description: "natural_qa:model=text,mode=openbook_longans,data_augmentation=canonical,max_eval_instances=100", priority: 1}
-  {description: "natural_qa:model=text,mode=closedbook,data_augmentation=canonical,max_eval_instances=100", priority: 1}
+  {description: "natural_qa:model=text,mode=openbook_longans,max_eval_instances=100", priority: 1}
+  {description: "natural_qa:model=text,mode=closedbook,max_eval_instances=100", priority: 1}
 
   ## Closed-book QA with multiple choice
 
   # Adaptation method is set to ADAPT_MULTIPLE_CHOICE_SEPARATE_CALIBRATED and echo=True
-  {description: "commonsense:model=full_functionality_text,dataset=hellaswag,method=multiple_choice_separate_original,data_augmentation=canonical,max_eval_instances=100", priority: 1}
-  {description: "commonsense:model=full_functionality_text,dataset=openbookqa,method=multiple_choice_separate_calibrated,data_augmentation=canonical,max_eval_instances=100", priority: 2}
-  {description: "truthful_qa:model=text,task=mc_single,data_augmentation=canonical,max_eval_instances=100", priority: 1}
+  {description: "commonsense:model=full_functionality_text,dataset=hellaswag,method=multiple_choice_separate_original,max_eval_instances=100", priority: 1}
+  {description: "commonsense:model=full_functionality_text,dataset=openbookqa,method=multiple_choice_separate_calibrated,max_eval_instances=100", priority: 2}
+  {description: "truthful_qa:model=text,task=mc_single,max_eval_instances=100", priority: 1}
 
-  {description: "mmlu:model=text,subject=abstract_algebra,data_augmentation=canonical,max_eval_instances=20", priority: 2}
-  {description: "mmlu:model=text,subject=college_chemistry,data_augmentation=canonical,max_eval_instances=20", priority: 2}
-  {description: "mmlu:model=text,subject=computer_security,data_augmentation=canonical,max_eval_instances=20", priority: 2}
-  {description: "mmlu:model=text,subject=econometrics,data_augmentation=canonical,max_eval_instances=20", priority: 2}
-  {description: "mmlu:model=text,subject=us_foreign_policy,data_augmentation=canonical,max_eval_instances=20", priority: 2}
+  {description: "mmlu:model=text,subject=abstract_algebra,max_eval_instances=20", priority: 2}
+  {description: "mmlu:model=text,subject=college_chemistry,max_eval_instances=20", priority: 2}
+  {description: "mmlu:model=text,subject=computer_security,max_eval_instances=20", priority: 2}
+  {description: "mmlu:model=text,subject=econometrics,max_eval_instances=20", priority: 2}
+  {description: "mmlu:model=text,subject=us_foreign_policy,max_eval_instances=20", priority: 2}
   
   ##### Information Retrieval #####
   # Scenarios: MS Marco (Regular), MS MARCO (TREC)
 
-  {description: "msmarco:model=full_functionality_text,data_augmentation=canonical,track=regular,valid_topk=30,max_eval_instances=100", priority: 2}
-  {description: "msmarco:model=full_functionality_text,data_augmentation=canonical,track=trec,valid_topk=30,max_eval_instances=100", priority: 1}
+  {description: "msmarco:model=full_functionality_text,track=regular,valid_topk=30,max_eval_instances=100", priority: 2}
+  {description: "msmarco:model=full_functionality_text,track=trec,valid_topk=30,max_eval_instances=100", priority: 1}
 
   ##### Summarization #####
   # Scenarios: XSUM, CNN/DM
@@ -42,36 +42,36 @@ entries: [
   ##### Sentiment Analysis #####
   # Scenarios: IMDB
 
-  {description: "imdb:model=text,data_augmentation=canonical,max_eval_instances=100", priority: 1}
+  {description: "imdb:model=text,max_eval_instances=100", priority: 1}
 
 
   ##### (Miscellaneous) Text Classification #####
   # Scenarios: RAFT
 
-  {description: "raft:subset=ade_corpus_v2,model=text,data_augmentation=canonical,max_eval_instances=9", priority: 2}
-  {description: "raft:subset=banking_77,model=text,data_augmentation=canonical,max_eval_instances=9", priority: 2}
-  {description: "raft:subset=neurips_impact_statement_risks,model=text,data_augmentation=canonical,max_eval_instances=9", priority: 2}
-  {description: "raft:subset=one_stop_english,model=text,data_augmentation=canonical,max_eval_instances=9", priority: 2}
-  {description: "raft:subset=overruling,model=text,data_augmentation=canonical,max_eval_instances=9", priority: 2}
-  {description: "raft:subset=semiconductor_org_types,model=text,data_augmentation=canonical,max_eval_instances=9", priority: 2}
-  {description: "raft:subset=tweet_eval_hate,model=text,data_augmentation=canonical,max_eval_instances=9", priority: 2}
-  {description: "raft:subset=twitter_complaints,model=text,data_augmentation=canonical,max_eval_instances=9", priority: 2}
-  {description: "raft:subset=systematic_review_inclusion,model=text,data_augmentation=canonical,max_eval_instances=9", priority: 2}
-  {description: "raft:subset=tai_safety_research,model=text,data_augmentation=canonical,max_eval_instances=9", priority: 2}
-  {description: "raft:subset=terms_of_service,model=text,data_augmentation=canonical,max_eval_instances=10", priority: 2}
+  {description: "raft:subset=ade_corpus_v2,model=text,max_eval_instances=9", priority: 2}
+  {description: "raft:subset=banking_77,model=text,max_eval_instances=9", priority: 2}
+  {description: "raft:subset=neurips_impact_statement_risks,model=text,max_eval_instances=9", priority: 2}
+  {description: "raft:subset=one_stop_english,model=text,max_eval_instances=9", priority: 2}
+  {description: "raft:subset=overruling,model=text,max_eval_instances=9", priority: 2}
+  {description: "raft:subset=semiconductor_org_types,model=text,max_eval_instances=9", priority: 2}
+  {description: "raft:subset=tweet_eval_hate,model=text,max_eval_instances=9", priority: 2}
+  {description: "raft:subset=twitter_complaints,model=text,max_eval_instances=9", priority: 2}
+  {description: "raft:subset=systematic_review_inclusion,model=text,max_eval_instances=9", priority: 2}
+  {description: "raft:subset=tai_safety_research,model=text,max_eval_instances=9", priority: 2}
+  {description: "raft:subset=terms_of_service,model=text,max_eval_instances=10", priority: 2}
 
 
   ##### Toxicity Detection #####
   # Scenarios: CivilComments
 
-  {description: "civil_comments:model=text,demographic=all,data_augmentation=canonical,max_eval_instances=11", priority: 1}
-  {description: "civil_comments:model=text,demographic=male,data_augmentation=canonical,max_eval_instances=11", priority: 2}
-  {description: "civil_comments:model=text,demographic=female,data_augmentation=canonical,max_eval_instances=11", priority: 2}
-  {description: "civil_comments:model=text,demographic=LGBTQ,data_augmentation=canonical,max_eval_instances=11", priority: 2}
-  {description: "civil_comments:model=text,demographic=christian,data_augmentation=canonical,max_eval_instances=11", priority: 2}
-  {description: "civil_comments:model=text,demographic=muslim,data_augmentation=canonical,max_eval_instances=11", priority: 2}
-  {description: "civil_comments:model=text,demographic=other_religions,data_augmentation=canonical,max_eval_instances=11", priority: 2}
-  {description: "civil_comments:model=text,demographic=black,data_augmentation=canonical,max_eval_instances=11", priority: 2}
-  {description: "civil_comments:model=text,demographic=white,data_augmentation=canonical,max_eval_instances=12", priority: 2}
+  {description: "civil_comments:model=text,demographic=all,max_eval_instances=11", priority: 1}
+  {description: "civil_comments:model=text,demographic=male,max_eval_instances=11", priority: 2}
+  {description: "civil_comments:model=text,demographic=female,max_eval_instances=11", priority: 2}
+  {description: "civil_comments:model=text,demographic=LGBTQ,max_eval_instances=11", priority: 2}
+  {description: "civil_comments:model=text,demographic=christian,max_eval_instances=11", priority: 2}
+  {description: "civil_comments:model=text,demographic=muslim,max_eval_instances=11", priority: 2}
+  {description: "civil_comments:model=text,demographic=other_religions,max_eval_instances=11", priority: 2}
+  {description: "civil_comments:model=text,demographic=black,max_eval_instances=11", priority: 2}
+  {description: "civil_comments:model=text,demographic=white,max_eval_instances=12", priority: 2}
 
 ]

--- a/src/helm/benchmark/presentation/run_specs_core_scenarios_1000.conf
+++ b/src/helm/benchmark/presentation/run_specs_core_scenarios_1000.conf
@@ -4,33 +4,33 @@ entries: [
 
   ## Reading comprehension
 
-  {description: "boolq:model=text,data_augmentation=canonical,max_eval_instances=1000", priority: 1}
-  {description: "narrative_qa:model=text,data_augmentation=canonical,max_eval_instances=1000", priority: 2}
-  {description: "quac:model=text,data_augmentation=canonical,max_eval_instances=1000", priority: 1}
+  {description: "boolq:model=text,max_eval_instances=1000", priority: 1}
+  {description: "narrative_qa:model=text,max_eval_instances=1000", priority: 2}
+  {description: "quac:model=text,max_eval_instances=1000", priority: 1}
 
   ## Reading comprehension and closedbook QA variants
 
-  {description: "natural_qa:model=text,mode=openbook_longans,data_augmentation=canonical,max_eval_instances=1000", priority: 1}
-  {description: "natural_qa:model=text,mode=closedbook,data_augmentation=canonical,max_eval_instances=1000", priority: 1}
+  {description: "natural_qa:model=text,mode=openbook_longans,max_eval_instances=1000", priority: 1}
+  {description: "natural_qa:model=text,mode=closedbook,max_eval_instances=1000", priority: 1}
 
   ## Closed-book QA with multiple choice
 
   # Adaptation method is set to ADAPT_MULTIPLE_CHOICE_SEPARATE_CALIBRATED and echo=True
-  {description: "commonsense:model=full_functionality_text,dataset=hellaswag,method=multiple_choice_separate_original,data_augmentation=canonical,max_eval_instances=1000", priority: 1}
-  {description: "commonsense:model=full_functionality_text,dataset=openbookqa,method=multiple_choice_separate_calibrated,data_augmentation=canonical,max_eval_instances=1000", priority: 2}
-  {description: "truthful_qa:model=text,task=mc_single,data_augmentation=canonical,max_eval_instances=1000", priority: 1}
+  {description: "commonsense:model=full_functionality_text,dataset=hellaswag,method=multiple_choice_separate_original,max_eval_instances=1000", priority: 1}
+  {description: "commonsense:model=full_functionality_text,dataset=openbookqa,method=multiple_choice_separate_calibrated,max_eval_instances=1000", priority: 2}
+  {description: "truthful_qa:model=text,task=mc_single,max_eval_instances=1000", priority: 1}
 
-  {description: "mmlu:model=text,subject=abstract_algebra,data_augmentation=canonical,max_eval_instances=200", priority: 2}
-  {description: "mmlu:model=text,subject=college_chemistry,data_augmentation=canonical,max_eval_instances=200", priority: 2}
-  {description: "mmlu:model=text,subject=computer_security,data_augmentation=canonical,max_eval_instances=200", priority: 2}
-  {description: "mmlu:model=text,subject=econometrics,data_augmentation=canonical,max_eval_instances=200", priority: 2}
-  {description: "mmlu:model=text,subject=us_foreign_policy,data_augmentation=canonical,max_eval_instances=200", priority: 2}
+  {description: "mmlu:model=text,subject=abstract_algebra,max_eval_instances=200", priority: 2}
+  {description: "mmlu:model=text,subject=college_chemistry,max_eval_instances=200", priority: 2}
+  {description: "mmlu:model=text,subject=computer_security,max_eval_instances=200", priority: 2}
+  {description: "mmlu:model=text,subject=econometrics,max_eval_instances=200", priority: 2}
+  {description: "mmlu:model=text,subject=us_foreign_policy,max_eval_instances=200", priority: 2}
   
   ##### Information Retrieval #####
   # Scenarios: MS Marco (Regular), MS MARCO (TREC)
 
-  {description: "msmarco:model=full_functionality_text,data_augmentation=canonical,track=regular,valid_topk=30,max_eval_instances=1000", priority: 2}
-  {description: "msmarco:model=full_functionality_text,data_augmentation=canonical,track=trec,valid_topk=30,max_eval_instances=1000", priority: 1}
+  {description: "msmarco:model=full_functionality_text,track=regular,valid_topk=30,max_eval_instances=1000", priority: 2}
+  {description: "msmarco:model=full_functionality_text,track=trec,valid_topk=30,max_eval_instances=1000", priority: 1}
 
   ##### Summarization #####
   # Scenarios: XSUM, CNN/DM
@@ -42,36 +42,36 @@ entries: [
   ##### Sentiment Analysis #####
   # Scenarios: IMDB
 
-  {description: "imdb:model=text,data_augmentation=canonical,max_eval_instances=1000", priority: 1}
+  {description: "imdb:model=text,max_eval_instances=1000", priority: 1}
 
 
   ##### (Miscellaneous) Text Classification #####
   # Scenarios: RAFT
 
-  {description: "raft:subset=ade_corpus_v2,model=text,data_augmentation=canonical,max_eval_instances=90", priority: 2}
-  {description: "raft:subset=banking_77,model=text,data_augmentation=canonical,max_eval_instances=90", priority: 2}
-  {description: "raft:subset=neurips_impact_statement_risks,model=text,data_augmentation=canonical,max_eval_instances=90", priority: 2}
-  {description: "raft:subset=one_stop_english,model=text,data_augmentation=canonical,max_eval_instances=90", priority: 2}
-  {description: "raft:subset=overruling,model=text,data_augmentation=canonical,max_eval_instances=90", priority: 2}
-  {description: "raft:subset=semiconductor_org_types,model=text,data_augmentation=canonical,max_eval_instances=90", priority: 2}
-  {description: "raft:subset=tweet_eval_hate,model=text,data_augmentation=canonical,max_eval_instances=90", priority: 2}
-  {description: "raft:subset=twitter_complaints,model=text,data_augmentation=canonical,max_eval_instances=90", priority: 2}
-  {description: "raft:subset=systematic_review_inclusion,model=text,data_augmentation=canonical,max_eval_instances=90", priority: 2}
-  {description: "raft:subset=tai_safety_research,model=text,data_augmentation=canonical,max_eval_instances=90", priority: 2}
-  {description: "raft:subset=terms_of_service,model=text,data_augmentation=canonical,max_eval_instances=100", priority: 2}
+  {description: "raft:subset=ade_corpus_v2,model=text,max_eval_instances=90", priority: 2}
+  {description: "raft:subset=banking_77,model=text,max_eval_instances=90", priority: 2}
+  {description: "raft:subset=neurips_impact_statement_risks,model=text,max_eval_instances=90", priority: 2}
+  {description: "raft:subset=one_stop_english,model=text,max_eval_instances=90", priority: 2}
+  {description: "raft:subset=overruling,model=text,max_eval_instances=90", priority: 2}
+  {description: "raft:subset=semiconductor_org_types,model=text,max_eval_instances=90", priority: 2}
+  {description: "raft:subset=tweet_eval_hate,model=text,max_eval_instances=90", priority: 2}
+  {description: "raft:subset=twitter_complaints,model=text,max_eval_instances=90", priority: 2}
+  {description: "raft:subset=systematic_review_inclusion,model=text,max_eval_instances=90", priority: 2}
+  {description: "raft:subset=tai_safety_research,model=text,max_eval_instances=90", priority: 2}
+  {description: "raft:subset=terms_of_service,model=text,max_eval_instances=100", priority: 2}
 
 
   ##### Toxicity Detection #####
   # Scenarios: CivilComments
 
-  {description: "civil_comments:model=text,demographic=all,data_augmentation=canonical,max_eval_instances=110", priority: 1}
-  {description: "civil_comments:model=text,demographic=male,data_augmentation=canonical,max_eval_instances=110", priority: 2}
-  {description: "civil_comments:model=text,demographic=female,data_augmentation=canonical,max_eval_instances=110", priority: 2}
-  {description: "civil_comments:model=text,demographic=LGBTQ,data_augmentation=canonical,max_eval_instances=110", priority: 2}
-  {description: "civil_comments:model=text,demographic=christian,data_augmentation=canonical,max_eval_instances=110", priority: 2}
-  {description: "civil_comments:model=text,demographic=muslim,data_augmentation=canonical,max_eval_instances=110", priority: 2}
-  {description: "civil_comments:model=text,demographic=other_religions,data_augmentation=canonical,max_eval_instances=110", priority: 2}
-  {description: "civil_comments:model=text,demographic=black,data_augmentation=canonical,max_eval_instances=110", priority: 2}
-  {description: "civil_comments:model=text,demographic=white,data_augmentation=canonical,max_eval_instances=120", priority: 2}
+  {description: "civil_comments:model=text,demographic=all,max_eval_instances=110", priority: 1}
+  {description: "civil_comments:model=text,demographic=male,max_eval_instances=110", priority: 2}
+  {description: "civil_comments:model=text,demographic=female,max_eval_instances=110", priority: 2}
+  {description: "civil_comments:model=text,demographic=LGBTQ,max_eval_instances=110", priority: 2}
+  {description: "civil_comments:model=text,demographic=christian,max_eval_instances=110", priority: 2}
+  {description: "civil_comments:model=text,demographic=muslim,max_eval_instances=110", priority: 2}
+  {description: "civil_comments:model=text,demographic=other_religions,max_eval_instances=110", priority: 2}
+  {description: "civil_comments:model=text,demographic=black,max_eval_instances=110", priority: 2}
+  {description: "civil_comments:model=text,demographic=white,max_eval_instances=120", priority: 2}
 
 ]

--- a/src/helm/benchmark/presentation/run_specs_core_scenarios_20.conf
+++ b/src/helm/benchmark/presentation/run_specs_core_scenarios_20.conf
@@ -4,33 +4,33 @@ entries: [
 
   ## Reading comprehension
 
-  {description: "boolq:model=text,data_augmentation=canonical,max_eval_instances=20", priority: 1}
-  {description: "narrative_qa:model=text,data_augmentation=canonical,max_eval_instances=20", priority: 2}
-  {description: "quac:model=text,data_augmentation=canonical,max_eval_instances=20", priority: 1}
+  {description: "boolq:model=text,max_eval_instances=20", priority: 1}
+  {description: "narrative_qa:model=text,max_eval_instances=20", priority: 2}
+  {description: "quac:model=text,max_eval_instances=20", priority: 1}
 
   ## Reading comprehension and closedbook QA variants
 
-  {description: "natural_qa:model=text,mode=openbook_longans,data_augmentation=canonical,max_eval_instances=20", priority: 1}
-  {description: "natural_qa:model=text,mode=closedbook,data_augmentation=canonical,max_eval_instances=20", priority: 1}
+  {description: "natural_qa:model=text,mode=openbook_longans,max_eval_instances=20", priority: 1}
+  {description: "natural_qa:model=text,mode=closedbook,max_eval_instances=20", priority: 1}
 
   ## Closed-book QA with multiple choice
 
   # Adaptation method is set to ADAPT_MULTIPLE_CHOICE_SEPARATE_CALIBRATED and echo=True
-  {description: "commonsense:model=full_functionality_text,dataset=hellaswag,method=multiple_choice_separate_original,data_augmentation=canonical,max_eval_instances=20", priority: 1}
-  {description: "commonsense:model=full_functionality_text,dataset=openbookqa,method=multiple_choice_separate_calibrated,data_augmentation=canonical,max_eval_instances=20", priority: 2}
-  {description: "truthful_qa:model=text,task=mc_single,data_augmentation=canonical,max_eval_instances=20", priority: 1}
+  {description: "commonsense:model=full_functionality_text,dataset=hellaswag,method=multiple_choice_separate_original,max_eval_instances=20", priority: 1}
+  {description: "commonsense:model=full_functionality_text,dataset=openbookqa,method=multiple_choice_separate_calibrated,max_eval_instances=20", priority: 2}
+  {description: "truthful_qa:model=text,task=mc_single,max_eval_instances=20", priority: 1}
 
-  {description: "mmlu:model=text,subject=abstract_algebra,data_augmentation=canonical,max_eval_instances=4", priority: 2}
-  {description: "mmlu:model=text,subject=college_chemistry,data_augmentation=canonical,max_eval_instances=4", priority: 2}
-  {description: "mmlu:model=text,subject=computer_security,data_augmentation=canonical,max_eval_instances=4", priority: 2}
-  {description: "mmlu:model=text,subject=econometrics,data_augmentation=canonical,max_eval_instances=4", priority: 2}
-  {description: "mmlu:model=text,subject=us_foreign_policy,data_augmentation=canonical,max_eval_instances=4", priority: 2}
+  {description: "mmlu:model=text,subject=abstract_algebra,max_eval_instances=4", priority: 2}
+  {description: "mmlu:model=text,subject=college_chemistry,max_eval_instances=4", priority: 2}
+  {description: "mmlu:model=text,subject=computer_security,max_eval_instances=4", priority: 2}
+  {description: "mmlu:model=text,subject=econometrics,max_eval_instances=4", priority: 2}
+  {description: "mmlu:model=text,subject=us_foreign_policy,max_eval_instances=4", priority: 2}
   
   ##### Information Retrieval #####
   # Scenarios: MS Marco (Regular), MS MARCO (TREC)
 
-  {description: "msmarco:model=full_functionality_text,data_augmentation=canonical,track=regular,valid_topk=30,max_eval_instances=20", priority: 2}
-  {description: "msmarco:model=full_functionality_text,data_augmentation=canonical,track=trec,valid_topk=30,max_eval_instances=20", priority: 1}
+  {description: "msmarco:model=full_functionality_text,track=regular,valid_topk=30,max_eval_instances=20", priority: 2}
+  {description: "msmarco:model=full_functionality_text,track=trec,valid_topk=30,max_eval_instances=20", priority: 1}
 
   ##### Summarization #####
   # Scenarios: XSUM, CNN/DM
@@ -42,36 +42,36 @@ entries: [
   ##### Sentiment Analysis #####
   # Scenarios: IMDB
 
-  {description: "imdb:model=text,data_augmentation=canonical,max_eval_instances=20", priority: 1}
+  {description: "imdb:model=text,max_eval_instances=20", priority: 1}
 
 
   ##### (Miscellaneous) Text Classification #####
   # Scenarios: RAFT
 
-  {description: "raft:subset=ade_corpus_v2,model=text,data_augmentation=canonical,max_eval_instances=2", priority: 2}
-  {description: "raft:subset=banking_77,model=text,data_augmentation=canonical,max_eval_instances=2", priority: 2}
-  {description: "raft:subset=neurips_impact_statement_risks,model=text,data_augmentation=canonical,max_eval_instances=2", priority: 2}
-  {description: "raft:subset=one_stop_english,model=text,data_augmentation=canonical,max_eval_instances=2", priority: 2}
-  {description: "raft:subset=overruling,model=text,data_augmentation=canonical,max_eval_instances=2", priority: 2}
-  {description: "raft:subset=semiconductor_org_types,model=text,data_augmentation=canonical,max_eval_instances=2", priority: 2}
-  {description: "raft:subset=tweet_eval_hate,model=text,data_augmentation=canonical,max_eval_instances=2", priority: 2}
-  {description: "raft:subset=twitter_complaints,model=text,data_augmentation=canonical,max_eval_instances=2", priority: 2}
-  {description: "raft:subset=systematic_review_inclusion,model=text,data_augmentation=canonical,max_eval_instances=2", priority: 2}
-  {description: "raft:subset=tai_safety_research,model=text,data_augmentation=canonical,max_eval_instances=1", priority: 2}
-  {description: "raft:subset=terms_of_service,model=text,data_augmentation=canonical,max_eval_instances=1", priority: 2}
+  {description: "raft:subset=ade_corpus_v2,model=text,max_eval_instances=2", priority: 2}
+  {description: "raft:subset=banking_77,model=text,max_eval_instances=2", priority: 2}
+  {description: "raft:subset=neurips_impact_statement_risks,model=text,max_eval_instances=2", priority: 2}
+  {description: "raft:subset=one_stop_english,model=text,max_eval_instances=2", priority: 2}
+  {description: "raft:subset=overruling,model=text,max_eval_instances=2", priority: 2}
+  {description: "raft:subset=semiconductor_org_types,model=text,max_eval_instances=2", priority: 2}
+  {description: "raft:subset=tweet_eval_hate,model=text,max_eval_instances=2", priority: 2}
+  {description: "raft:subset=twitter_complaints,model=text,max_eval_instances=2", priority: 2}
+  {description: "raft:subset=systematic_review_inclusion,model=text,max_eval_instances=2", priority: 2}
+  {description: "raft:subset=tai_safety_research,model=text,max_eval_instances=1", priority: 2}
+  {description: "raft:subset=terms_of_service,model=text,max_eval_instances=1", priority: 2}
 
 
   ##### Toxicity Detection #####
   # Scenarios: CivilComments
 
-  {description: "civil_comments:model=text,demographic=all,data_augmentation=canonical,max_eval_instances=2", priority: 1}
-  {description: "civil_comments:model=text,demographic=male,data_augmentation=canonical,max_eval_instances=2", priority: 2}
-  {description: "civil_comments:model=text,demographic=female,data_augmentation=canonical,max_eval_instances=2", priority: 2}
-  {description: "civil_comments:model=text,demographic=LGBTQ,data_augmentation=canonical,max_eval_instances=2", priority: 2}
-  {description: "civil_comments:model=text,demographic=christian,data_augmentation=canonical,max_eval_instances=2", priority: 2}
-  {description: "civil_comments:model=text,demographic=muslim,data_augmentation=canonical,max_eval_instances=2", priority: 2}
-  {description: "civil_comments:model=text,demographic=other_religions,data_augmentation=canonical,max_eval_instances=2", priority: 2}
-  {description: "civil_comments:model=text,demographic=black,data_augmentation=canonical,max_eval_instances=3", priority: 2}
-  {description: "civil_comments:model=text,demographic=white,data_augmentation=canonical,max_eval_instances=3", priority: 2}
+  {description: "civil_comments:model=text,demographic=all,max_eval_instances=2", priority: 1}
+  {description: "civil_comments:model=text,demographic=male,max_eval_instances=2", priority: 2}
+  {description: "civil_comments:model=text,demographic=female,max_eval_instances=2", priority: 2}
+  {description: "civil_comments:model=text,demographic=LGBTQ,max_eval_instances=2", priority: 2}
+  {description: "civil_comments:model=text,demographic=christian,max_eval_instances=2", priority: 2}
+  {description: "civil_comments:model=text,demographic=muslim,max_eval_instances=2", priority: 2}
+  {description: "civil_comments:model=text,demographic=other_religions,max_eval_instances=2", priority: 2}
+  {description: "civil_comments:model=text,demographic=black,max_eval_instances=3", priority: 2}
+  {description: "civil_comments:model=text,demographic=white,max_eval_instances=3", priority: 2}
 
 ]

--- a/src/helm/benchmark/presentation/run_specs_core_scenarios_50.conf
+++ b/src/helm/benchmark/presentation/run_specs_core_scenarios_50.conf
@@ -4,33 +4,33 @@ entries: [
 
   ## Reading comprehension
 
-  {description: "boolq:model=text,data_augmentation=canonical,max_eval_instances=50", priority: 1}
-  {description: "narrative_qa:model=text,data_augmentation=canonical,max_eval_instances=50", priority: 2}
-  {description: "quac:model=text,data_augmentation=canonical,max_eval_instances=50", priority: 1}
+  {description: "boolq:model=text,max_eval_instances=50", priority: 1}
+  {description: "narrative_qa:model=text,max_eval_instances=50", priority: 2}
+  {description: "quac:model=text,max_eval_instances=50", priority: 1}
 
   ## Reading comprehension and closedbook QA variants
 
-  {description: "natural_qa:model=text,mode=openbook_longans,data_augmentation=canonical,max_eval_instances=50", priority: 1}
-  {description: "natural_qa:model=text,mode=closedbook,data_augmentation=canonical,max_eval_instances=50", priority: 1}
+  {description: "natural_qa:model=text,mode=openbook_longans,max_eval_instances=50", priority: 1}
+  {description: "natural_qa:model=text,mode=closedbook,max_eval_instances=50", priority: 1}
 
   ## Closed-book QA with multiple choice
 
   # Adaptation method is set to ADAPT_MULTIPLE_CHOICE_SEPARATE_CALIBRATED and echo=True
-  {description: "commonsense:model=full_functionality_text,dataset=hellaswag,method=multiple_choice_separate_original,data_augmentation=canonical,max_eval_instances=50", priority: 1}
-  {description: "commonsense:model=full_functionality_text,dataset=openbookqa,method=multiple_choice_separate_calibrated,data_augmentation=canonical,max_eval_instances=50", priority: 2}
-  {description: "truthful_qa:model=text,task=mc_single,data_augmentation=canonical,max_eval_instances=50", priority: 1}
+  {description: "commonsense:model=full_functionality_text,dataset=hellaswag,method=multiple_choice_separate_original,max_eval_instances=50", priority: 1}
+  {description: "commonsense:model=full_functionality_text,dataset=openbookqa,method=multiple_choice_separate_calibrated,max_eval_instances=50", priority: 2}
+  {description: "truthful_qa:model=text,task=mc_single,max_eval_instances=50", priority: 1}
 
-  {description: "mmlu:model=text,subject=abstract_algebra,data_augmentation=canonical,max_eval_instances=10", priority: 2}
-  {description: "mmlu:model=text,subject=college_chemistry,data_augmentation=canonical,max_eval_instances=10", priority: 2}
-  {description: "mmlu:model=text,subject=computer_security,data_augmentation=canonical,max_eval_instances=10", priority: 2}
-  {description: "mmlu:model=text,subject=econometrics,data_augmentation=canonical,max_eval_instances=10", priority: 2}
-  {description: "mmlu:model=text,subject=us_foreign_policy,data_augmentation=canonical,max_eval_instances=10", priority: 2}
+  {description: "mmlu:model=text,subject=abstract_algebra,max_eval_instances=10", priority: 2}
+  {description: "mmlu:model=text,subject=college_chemistry,max_eval_instances=10", priority: 2}
+  {description: "mmlu:model=text,subject=computer_security,max_eval_instances=10", priority: 2}
+  {description: "mmlu:model=text,subject=econometrics,max_eval_instances=10", priority: 2}
+  {description: "mmlu:model=text,subject=us_foreign_policy,max_eval_instances=10", priority: 2}
   
   ##### Information Retrieval #####
   # Scenarios: MS Marco (Regular), MS MARCO (TREC)
 
-  {description: "msmarco:model=full_functionality_text,data_augmentation=canonical,track=regular,valid_topk=30,max_eval_instances=50", priority: 2}
-  {description: "msmarco:model=full_functionality_text,data_augmentation=canonical,track=trec,valid_topk=30,max_eval_instances=50", priority: 1}
+  {description: "msmarco:model=full_functionality_text,track=regular,valid_topk=30,max_eval_instances=50", priority: 2}
+  {description: "msmarco:model=full_functionality_text,track=trec,valid_topk=30,max_eval_instances=50", priority: 1}
 
   ##### Summarization #####
   # Scenarios: XSUM, CNN/DM
@@ -42,36 +42,36 @@ entries: [
   ##### Sentiment Analysis #####
   # Scenarios: IMDB
 
-  {description: "imdb:model=text,data_augmentation=canonical,max_eval_instances=50", priority: 1}
+  {description: "imdb:model=text,max_eval_instances=50", priority: 1}
 
 
   ##### (Miscellaneous) Text Classification #####
   # Scenarios: RAFT
 
-  {description: "raft:subset=ade_corpus_v2,model=text,data_augmentation=canonical,max_eval_instances=4", priority: 2}
-  {description: "raft:subset=banking_77,model=text,data_augmentation=canonical,max_eval_instances=4", priority: 2}
-  {description: "raft:subset=neurips_impact_statement_risks,model=text,data_augmentation=canonical,max_eval_instances=4", priority: 2}
-  {description: "raft:subset=one_stop_english,model=text,data_augmentation=canonical,max_eval_instances=4", priority: 2}
-  {description: "raft:subset=overruling,model=text,data_augmentation=canonical,max_eval_instances=4", priority: 2}
-  {description: "raft:subset=semiconductor_org_types,model=text,data_augmentation=canonical,max_eval_instances=4", priority: 2}
-  {description: "raft:subset=tweet_eval_hate,model=text,data_augmentation=canonical,max_eval_instances=4", priority: 2}
-  {description: "raft:subset=twitter_complaints,model=text,data_augmentation=canonical,max_eval_instances=4", priority: 2}
-  {description: "raft:subset=systematic_review_inclusion,model=text,data_augmentation=canonical,max_eval_instances=4", priority: 2}
-  {description: "raft:subset=tai_safety_research,model=text,data_augmentation=canonical,max_eval_instances=5", priority: 2}
-  {description: "raft:subset=terms_of_service,model=text,data_augmentation=canonical,max_eval_instances=5", priority: 2}
+  {description: "raft:subset=ade_corpus_v2,model=text,max_eval_instances=4", priority: 2}
+  {description: "raft:subset=banking_77,model=text,max_eval_instances=4", priority: 2}
+  {description: "raft:subset=neurips_impact_statement_risks,model=text,max_eval_instances=4", priority: 2}
+  {description: "raft:subset=one_stop_english,model=text,max_eval_instances=4", priority: 2}
+  {description: "raft:subset=overruling,model=text,max_eval_instances=4", priority: 2}
+  {description: "raft:subset=semiconductor_org_types,model=text,max_eval_instances=4", priority: 2}
+  {description: "raft:subset=tweet_eval_hate,model=text,max_eval_instances=4", priority: 2}
+  {description: "raft:subset=twitter_complaints,model=text,max_eval_instances=4", priority: 2}
+  {description: "raft:subset=systematic_review_inclusion,model=text,max_eval_instances=4", priority: 2}
+  {description: "raft:subset=tai_safety_research,model=text,max_eval_instances=5", priority: 2}
+  {description: "raft:subset=terms_of_service,model=text,max_eval_instances=5", priority: 2}
 
 
   ##### Toxicity Detection #####
   # Scenarios: CivilComments
 
-  {description: "civil_comments:model=text,demographic=all,data_augmentation=canonical,max_eval_instances=4", priority: 1}
-  {description: "civil_comments:model=text,demographic=male,data_augmentation=canonical,max_eval_instances=4", priority: 2}
-  {description: "civil_comments:model=text,demographic=female,data_augmentation=canonical,max_eval_instances=4", priority: 2}
-  {description: "civil_comments:model=text,demographic=LGBTQ,data_augmentation=canonical,max_eval_instances=4", priority: 2}
-  {description: "civil_comments:model=text,demographic=christian,data_augmentation=canonical,max_eval_instances=4", priority: 2}
-  {description: "civil_comments:model=text,demographic=muslim,data_augmentation=canonical,max_eval_instances=5", priority: 2}
-  {description: "civil_comments:model=text,demographic=other_religions,data_augmentation=canonical,max_eval_instances=5", priority: 2}
-  {description: "civil_comments:model=text,demographic=black,data_augmentation=canonical,max_eval_instances=5", priority: 2}
-  {description: "civil_comments:model=text,demographic=white,data_augmentation=canonical,max_eval_instances=5", priority: 2}
+  {description: "civil_comments:model=text,demographic=all,max_eval_instances=4", priority: 1}
+  {description: "civil_comments:model=text,demographic=male,max_eval_instances=4", priority: 2}
+  {description: "civil_comments:model=text,demographic=female,max_eval_instances=4", priority: 2}
+  {description: "civil_comments:model=text,demographic=LGBTQ,max_eval_instances=4", priority: 2}
+  {description: "civil_comments:model=text,demographic=christian,max_eval_instances=4", priority: 2}
+  {description: "civil_comments:model=text,demographic=muslim,max_eval_instances=5", priority: 2}
+  {description: "civil_comments:model=text,demographic=other_religions,max_eval_instances=5", priority: 2}
+  {description: "civil_comments:model=text,demographic=black,max_eval_instances=5", priority: 2}
+  {description: "civil_comments:model=text,demographic=white,max_eval_instances=5", priority: 2}
 
 ]


### PR DESCRIPTION
This pull request adds:
- A fix to make the benchmark running tutorial work by allowing summarize to run without an instance.json file
- Updated and improved section for running the tutorial
- Removal of perturbation from the bear bones configuration file (to save an extra X3 compute)
