### PR TITLE
update datasets dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ cycler==0.11.0
 cymem==2.0.6
 Cython==0.29.32
 dacite==1.6.0
-datasets==2.5.2
+datasets==2.14.6
 dill==0.3.5.1
 distlib==0.3.6
 emoji==2.1.0


### PR DESCRIPTION
Math scenarios fail without this

Running math:subject=precalculus,level=1,use_official_examples=False,use_chain_of_thought=True,model=neurips_local,max_eval_instances=22 {
    scenario.get_instances {
WARNING:datasets.builder:Using custom data configuration default WARNING:datasets.builder:Found cached dataset competition_math (file:///home/helm/.cache/huggingface/datasets/competition_math/default/1.0.0/52c6a268ae72ef772498d27551a3f682dac50cd8befddd0326d 758cb6908b5f0)
    } [0.863s]
  } [0.863s]
  Error when running math:subject=precalculus,level=1,use_official_examples=False,use_chain_of_thought=True,model=neurips_local,max_eval_instances=22:
Traceback (most recent call last):
  File "/helm/src/helm/benchmark/runner.py", line 173, in run_all
    self.run_one(run_spec)
  File "/helm/src/helm/benchmark/runner.py", line 221, in run_one
    instances = scenario.get_instances(scenario_output_path)
  File "/helm/src/helm/benchmark/scenarios/math_scenario.py", line 357, in get_instances
    data = typing.cast(DatasetDict, load_dataset("competition_math", ignore_verifications=True))
  File "/helm/private_helm_env/lib/python3.10/site-packages/datasets/load.py", line 1705, in load_dataset
    ds = builder_instance.as_dataset(split=split, ignore_verifications=ignore_verifications, in_memory=keep_in_memory)
  File "/helm/private_helm_env/lib/python3.10/site-packages/datasets/builder.py", line 992, in as_dataset
    raise NotImplementedError(f"Loading a dataset cached in a {type(self._fs).__name__} is not supported.")
NotImplementedError: Loading a dataset cached in a LocalFileSystem is not supported.