### PR TITLE
Fix test_language_modeling_adapter

### DIFF
--- a/src/helm/benchmark/adaptation/adapters/test_language_modeling_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/test_language_modeling_adapter.py
@@ -156,7 +156,7 @@ class TestLanguageModelingAdapter(TestAdapter):
         # Monkey patch the window service to have really short max sequences.
         adapter.window_service = MockGPT2Window(self.tokenizer_service, max_sequence_length=max_sequence_length)
         input_text = Input(text=" ".join(str(i) for i in range(input_tokens)))
-        instance = Instance(input=input_text, references=[])
+        instance = Instance(input=input_text, references=[], split=TEST_SPLIT)
 
         # Generate the requests
         request_states: List[RequestState] = adapter.adapt([instance], parallelism=1).request_states


### PR DESCRIPTION
Fix a test breakage caused by a merge conflict in the logic of #1986 (made `LanguageModelingAdapter` only support eval instances) and #1970 (added a new test for `LanguageModelingAdapter` with non-eval instances)