### PR TITLE
Make ModelDeployments work when installing from package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,5 @@ jobs:
           TEST: ${{ matrix.test }}
           VERSION: ${{ github.head_ref || 'main' }}
       - name: Run entire pipeline quickly without any data
-        # Checking RunSpecs with openai/davinci
+        # Checking RunSpecs with openai/davinci should be comprehensive enough
         run: source venv/bin/activate && helm-run --suite test -m 100 --skip-instances --models-to-run openai/davinci --exit-on-error
-      - name: Run entire pipeline quickly with test data
-        run: helm-run --run-specs simple1:model=simple/model1 --max-eval-instances 10 --suite test && helm-summarize --suite test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,10 +29,12 @@ jobs:
           key: pip-${{ hashFiles('requirements.txt') }}-${{ matrix.python-version }}
           restore-keys: |
             pip-
-      - run: pip install -e .
-      - run: helm-run -h
-      - run: helm-summarize -h
-      - run: echo "Finished installation."
+      - run: python3 -m pip install --upgrade build
+      - run: python3 -m build
+      - run: python3 -m pip install dist/crfm_helm-*.whl
+      - run: helm-run --run-specs simple1:model=simple/model1 --max-eval-instances 10 --suite test
+      - run: helm-summarize --suite test
+      - run: helm-server --help
 
   test:
     name: Tests
@@ -65,5 +67,7 @@ jobs:
           TEST: ${{ matrix.test }}
           VERSION: ${{ github.head_ref || 'main' }}
       - name: Run entire pipeline quickly without any data
-        # Checking RunSpecs with openai/davinci should be comprehensive enough
+        # Checking RunSpecs with openai/davinci
         run: source venv/bin/activate && helm-run --suite test -m 100 --skip-instances --models-to-run openai/davinci --exit-on-error
+      - name: Run entire pipeline quickly with test data
+        run: helm-run --run-specs simple1:model=simple/model1 --max-eval-instances 10 --suite test && helm-summarize --suite test

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include src/helm/proxy/clients/ *.sp
 recursive-include src/helm/benchmark/ *.json
 recursive-include src/helm/benchmark/static/ *.css *.html *.js *.png *.yaml
+recursive-include src/helm/config/ *.yaml


### PR DESCRIPTION
- Change the "Install" GitHub Action job to install from a Wheel package, rather than using local editable mode
- Change the "Install" GitHub Action job to quickly run the entire pipeline with test data
- Added the `*.yaml` files in `src/helm/config` to the package manifest
- Added `__init__.py` to `src/helm/config` so that the package is importable