### PR TITLE
Update tutorial to reflect changes on model deployments

### DIFF
--- a/docs/adding_new_models.md
+++ b/docs/adding_new_models.md
@@ -1,12 +1,76 @@
 # Adding new models
 
-Currently, you must clone the HELM repostory and modify the HELM code locally to add a new model.
+## Overview of the process
+To add a new model you need to define 3 objects:
+* a `ModelMetadata` objects that defines properties of your model (name, metadata, capabilities, ...).
+* one or several `ModelDeployment` which defines how to query a model (mainly by providing a `Client`, a `WindowService` and a `Tokenizer`). You can define several deployments for a single model (`local/your-model`, `huggingface/your-model`, `together/your-model`, ...).
+* a `TokenizerConfig` which defines how to build the `Tokenizer` (mainly by providing a `TokenizerSpec`).
 
-1. Pick a new organization name that does not conflict with any of the organizations for the [existing models](models.md).
-2. Define a new [`Model`](https://github.com/stanford-crfm/helm/blob/v0.2.0/src/helm/proxy/models.py#L39) describing your model and add it to [`ALL_MODELS` in `helm.proxy.models`](https://github.com/stanford-crfm/helm/blob/main/src/helm/proxy/models.py#L88). Set `Model.group` and `Model.creator_organization` to your organization name. Set `Model.name` to  `"your_organization_name/your_model_name"`.
-3. Implement a new [`Client`](https://github.com/stanford-crfm/helm/blob/v0.2.0/src/helm/proxy/clients/client.py#L16). The `Client` is responsible for implementing the core logic of your model, and responding to requests. In particular, it needs to implement three methods, `Client.make_request()`, `Client.tokenize()` and `Client.decode()`. Note that despite the name `Client`, it is possible for `Client` to run model inference locally. Refer to [`SimpleClient`](https://github.com/stanford-crfm/helm/blob/v0.2.0/src/helm/proxy/clients/simple_client.py#L15) for an example implementation.
-4. Modify both [`AutoClient.get_client()`](https://github.com/stanford-crfm/helm/blob/v0.2.0/src/helm/proxy/clients/auto_client.py#L56) and [`AutoClient.get_tokenizer_client()`](https://github.com/stanford-crfm/helm/blob/v0.2.0/src/helm/proxy/clients/auto_client.py#L143) to return your implementation of `Client` for your organization name.
-5. Implement a [`WindowService`](https://github.com/stanford-crfm/helm/blob/v0.2.0/src/helm/benchmark/window_services/window_service.py#L24). You will usually want to make your implementation a subclass of [`LocalWindowService`](https://github.com/stanford-crfm/helm/blob/v0.2.0/src/helm/benchmark/window_services/local_window_service.py#L15), which will reuse the `Client.tokenize()` and `Client.decode()` methods that you implemented earlier. The subclass should implement the method `LocalWindowService.tokenizer_name()` to return `"your_organization_name/your_model_name"`. The subclass of `LocalWindowService` will also need to implement the methods `LocalWindowService.max_sequence_length()`, `LocalWindowService.max_sequence_length()`, `LocalWindowService.end_of_text_token()`, `LocalWindowService.prefix_token()` and `LocalWindowService.tokenizer_name()`. Refer to [`GPT2WindowService`](https://github.com/stanford-crfm/helm/blob/v0.2.0/src/helm/benchmark/window_services/gpt2_window_service.py#L5) for an example implementation.
-6. Modify [`WindowServiceFactory.get_window_service()`](https://github.com/stanford-crfm/helm/blob/v0.2.0/src/helm/benchmark/window_services/window_service_factory.py#L30) to construct and return your implementation of `WindowService` for your organization name.
-7. Add an entry to [`schema.yaml`](https://github.com/stanford-crfm/helm/blob/v0.2.0/src/helm/benchmark/static/schema.yaml) describing your model.
-8. Update [`contamination.yaml`](https://github.com/stanford-crfm/helm/blob/v0.2.0/src/helm/benchmark/static/contamination.yaml) to indicate if the training set of your model has been contaminated by data from any scenarios.
+In some cases you might have to define additionally:
+* a `Client` if your query method differ from any clients we have implemented. This will be then referenced in the `ModelDeployment`. We recommend checking `HTTPModelClient` and `HuggingFaceClient` which can be used in a lot of cases. If you identify the need for a new client, a good starting to point is to have a look at `SimpleClient`.
+* a `WindowService`. First have a look at `DefaultWindowService` to check if this is not enough for your use case. If you need you own `truncate_from_right` function, then you might need to create your own `WindowService`. In that case, a good starting point is to have a look at `AI21WindowService`.
+
+
+## Where to create the objects
+There are two cases: private models that should only be accessible to you and models not yet supported by HELM but that would benefit everyone if added.
+
+In the first case, you should create the files `model_deployments.yaml`, `model_metadata.yaml` and `tokenizer_configs.yaml` in `prod_env/` (A folder that you should create at the root of the repo if not already done). HELM will automatically registed any model defined in these files without any change in the code while ignoring them on Github which can be convenient for you. Then you can simply duplicate the corresponding files from `src/helm/config`, delete the models and add yours. Follow the next section for an example.
+
+In the second case, if you want to add a model to HELM, you can directly do it in `src/helm/config`. You can then open a Pull Request on Github to share the model. When you do, make sure to:
+* Include any link justifying the metadata used in `ModelMetadata` such as the release data, number of parameters, capabilities and so on (you should not infer anything).
+* Check that you are respecting the format used in those files (`ModelMetadata` should be named as `<CREATOR-ORGANIZATION>/<MODEL-NAME>` and the `ModelDeployment` should be named as `<HOST-ORGANIZATION>/<MODEL-NAME>`, for example `ModelMetadata`: `openai/gpt2` and `ModelDeployment`: `huggingface/gpt2`). Add the appropriate comments and so on.
+* Run `helm-run --run-specs "mmlu:subject=anatomy,model_deployment=<YOUR-DEPLOYMENT>" --suite v1 --max-eval-instances 10` and make sure that everything works. Include the logs from the terminal in your PR.
+* Not create unnecessary objects (`Client` `TokenizerCOnfig`, `WindowService`) and if you have to create one of these objects, document in your PR why you had to. Make them general enough so that they could be re-used by other models (especially the `Client`).
+
+
+## Example
+
+In `src/helm/config/model_metadata.yaml`:
+```yaml
+# [...]
+
+models:
+
+  - name: simple/model1
+    [...]
+
+  # NEW MODEL STARTS HERE
+  - name: simple/tutorial
+    display_name: Tutorial Model
+    description: This is a simple model used in the tutorial.
+    creator_organization_name: Helm
+    access: open
+    release_date: 2023-01-01
+    tags: [TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG]
+
+  [...]
+```
+
+In `src/helm/config/model_deployments.yaml`:
+```yaml
+# [...]
+
+model_deployments:
+
+  - name: simple/model1
+    [...]
+
+  - name: simple/tutorial
+    model_name: simple/tutorial
+    tokenizer_name: simple/model1
+    max_sequence_length: 2048
+    client_spec:
+      class_name: "helm.proxy.clients.simple_client.SimpleClient"
+      args: {}
+    window_service_spec:
+      class_name: "helm.benchmark.window_services.openai_window_service.OpenAIWindowService"
+      args: {}
+
+  [...]
+```
+
+We won't be adding any `TokenizerConfig` here as we are reusing `simple/model1`. This shows a good practice when adding a new model, always check if the correct tokenizer does not already exists.
+
+You should now be able to run `helm-run --run-specs "mmlu:subject=anatomy,model_deployment=simple/tutorial" --suite v1 --max-eval-instances 10` without any error.
+
+

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -4,7 +4,7 @@ Run the following:
 
 ```
 # Create a run specs configuration
-echo 'entries: [{description: "mmlu:subject=philosophy,model=huggingface/gpt2", priority: 1}]' > run_specs.conf
+echo 'entries: [{description: "mmlu:subject=philosophy,model=openai/gpt2", priority: 1}]' > run_specs.conf
 
 # Run benchmark
 helm-run --conf-paths run_specs.conf --suite v1 --max-eval-instances 10

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -10,7 +10,7 @@ We will run two runs using the `mmlu` scenario on the `openai/gpt2` model. The `
 
 To run this benchmark using the HELM command-line tools, we need to specify **run spec descriptions** that describes the desired runs. For this example, the run spec descriptions are `mmlu:subject=anatomy,model=openai/gpt2` (for anatomy) and `mmlu:subject=philosophy,model=openai/gpt2` (for philosophy).
 
-Next, we need to create a **run spec configuration file** contining these run spec descriptions. A run spec configuration file is a text file containing `RunEntries` serialized to JSON, where each entry in `RunEntries` contains a run spec description. The `description` field of each entry should be a **run spec description**. Create a text file named `run_specs.conf` with the following contents:
+Next, we need to create a **run spec configuration file** containing these run spec descriptions. A run spec configuration file is a text file containing `RunEntries` serialized to JSON, where each entry in `RunEntries` contains a run spec description. The `description` field of each entry should be a **run spec description**. Create a text file named `run_specs.conf` with the following contents:
 
 ```
 entries: [
@@ -46,6 +46,8 @@ Each output sub-directory will contain several JSON files that were generated du
 - `stats.json` contains a serialized list of `PerInstanceStats`, which contains the statistics produced for the metrics, aggregated across all instances (i.e. inputs).
 
 `helm-run` provides additional arguments that can be used to filter out `--models-to-run`, `--groups-to-run` and `--priority`. It can be convenient to create a large `run_specs.conf` file containing every run spec description of interest, and then use these flags to filter down the RunSpecs to actually run. As an example, the main `run_specs.conf` file used for the HELM benchmarking paper can be found [here](https://github.com/stanford-crfm/helm/blob/main/src/helm/benchmark/presentation/run_specs.conf).
+
+**Using model or model_deployment:** Some models have several deployments (for exmaple `eleutherai/gpt-j-6b` is deployed under `huggingface/gpt-j-6b`, `gooseai/gpt-j-6b` and `together/gpt-j-6b`). Since the results can differ depending on the deployment, we provide a way to specify the deployment instead of the model. Instead of using `model=eleutherai/gpt-g-6b`, use `model_deployment=huggingface/gpt-j-6b`. If you do not, a deployment will be arbitrarily chosen. This can still be used for models that have a single deployment and is a good practice to follow to avoid any ambiguity.
 
 ## Using `helm-summarize`
 


### PR DESCRIPTION
Fix #2022.
- Rewrote from scratch "Adding new models".
- Added a variant of `simple/model1` for the tutorial.
- Added a paragraph explaining the use of `model` and `model_deployment` keywords in `tutorial.md`.
- Ported a `model=huggingface/gpt2` to `model=openai/gpt2`.