### PR TITLE
Adding legalbench tasks

### DIFF
--- a/src/helm/benchmark/run_specs.py
+++ b/src/helm/benchmark/run_specs.py
@@ -42,6 +42,11 @@ from .scenarios.big_bench_scenario import BIGBenchScenario
 from .scenarios.msmarco_scenario import MSMARCOScenario
 from .scenarios.copyright_scenario import datatag2hash_code
 from .scenarios.raft_scenario import get_raft_instructions
+from .scenarios.legalbench_scenario import (
+    get_legalbench_instructions,
+    get_legalbench_max_train_instances,
+    get_legalbench_output_nouns,
+)
 from .scenarios.lextreme_scenario import (
     get_lextreme_instructions,
     get_lextreme_max_train_instances,
@@ -1772,6 +1777,29 @@ def get_dyck_language_spec(num_parenthesis_pairs: int) -> RunSpec:
         adapter_spec=adapter_spec,
         metric_specs=get_basic_metric_specs(["exact_match_indicator"]) + get_generative_harms_metric_specs(),
         groups=["dyck_language"],
+    )
+
+
+@run_spec_function("legalbench")
+def get_legalbench_spec(subset: str) -> RunSpec:
+    scenario_spec = ScenarioSpec(
+        class_name="helm.benchmark.scenarios.legalbench_scenario.LegalBenchScenario", args={"subset": subset}
+    )
+
+    adapter_spec = get_generation_adapter_spec(
+        instructions=get_legalbench_instructions(subset),
+        input_noun=None,
+        output_noun=get_legalbench_output_nouns(subset),
+        max_tokens=30,  # at most ~50 characters per label,
+        max_train_instances=get_legalbench_max_train_instances(subset),
+    )
+
+    return RunSpec(
+        name=f"legalbench:subset={subset}",
+        scenario_spec=scenario_spec,
+        adapter_spec=adapter_spec,
+        metric_specs=get_exact_match_metric_specs() + get_bias_metric_specs() + get_classification_metric_specs(),
+        groups=["legalbench"],
     )
 
 

--- a/src/helm/benchmark/scenarios/legalbench_scenario.py
+++ b/src/helm/benchmark/scenarios/legalbench_scenario.py
@@ -1,0 +1,134 @@
+import random
+import os
+import json
+import tempfile
+import datasets
+from pathlib import Path
+from typing import List, Dict
+
+from helm.common.general import ensure_file_downloaded, ensure_directory_exists
+from .scenario import Scenario, Instance, Reference, CORRECT_TAG, TRAIN_SPLIT, TEST_SPLIT, Input, Output
+
+PROMPT_SETTINGS_URL = "https://raw.githubusercontent.com/HazyResearch/legalbench/main/helm_prompt_settings.jsonl"
+
+SUBSETS = [
+    "abercrombie",
+    "corporate_lobbying",
+    "international_citizenship_questions",
+    "function_of_decision_section",
+    "proa",
+]
+
+
+def get_legalbench_prompt_settings(subset: str, cache_dir=None):
+    """
+    Loads prompt construction settings for all subsets.
+    """
+    assert subset in SUBSETS, "Unknown subset: {}".format(subset)
+
+    if cache_dir is None:
+        cache_dir = tempfile.gettempdir()
+
+    prompt_construction_settings_path = os.path.join(cache_dir, "prompt_construction_settings.json")
+    ensure_directory_exists(cache_dir)
+    ensure_file_downloaded(
+        source_url=PROMPT_SETTINGS_URL,
+        target_path=prompt_construction_settings_path,
+    )
+    with open(prompt_construction_settings_path, "r") as f:
+        field_ordering, instructions, label_keys, output_nouns, max_train_instances = map(
+            json.loads, f.read().strip().split("\n")
+        )
+    return (
+        field_ordering[subset],
+        instructions[subset],
+        label_keys[subset],
+        output_nouns[subset],
+        max_train_instances[subset],
+    )
+
+
+def get_legalbench_instructions(subset: str, cache_dir=None):
+    return get_legalbench_prompt_settings(subset, cache_dir)[1]
+
+
+def get_legalbench_output_nouns(subset: str, cache_dir=None):
+    return get_legalbench_prompt_settings(subset, cache_dir)[3]
+
+
+def get_legalbench_max_train_instances(subset: str, cache_dir=None):
+    return get_legalbench_prompt_settings(subset, cache_dir)[4]
+
+
+class LegalBenchScenario(Scenario):
+    """
+    LegalBench is benchmark containing different legal reasoning tasks. We use a subset of the tasks, selected
+    to represent different legal reasoning patterns.
+
+    LegalBench: A Collaboratively Built Benchmark for Measuring Legal Reasoning in Large Language Models
+    https://arxiv.org/abs/2308.11462
+
+    Official website for LegalBench:
+    http://hazyresearch.stanford.edu/legalbench/
+
+    Dataset summary:
+    https://huggingface.co/datasets/nguha/legalbench
+
+    Prompts are adapted from:
+    https://github.com/HazyResearch/legalbench/
+
+    Subsets:
+
+    - abercrombie
+    - corporate_lobbying
+    - international_citizenship_questions
+    - function_of_decision_section
+    - proa
+    """
+
+    name = "legalbench"
+    description = "LegalBench"
+    tags = ["text_classification", "robustness"]
+
+    def __init__(self, subset: str, random_seed=42):
+        super().__init__()
+        assert subset in SUBSETS, "Unknown subset: {}".format(subset)
+        self.subset = subset
+        self.random_seed = random_seed
+
+    def load_prompt_construction_settings(self, output_path: str):
+        # Load from prompt construction settings
+        cache_dir = str(Path(output_path) / "data")
+        return get_legalbench_prompt_settings(self.subset, cache_dir)
+
+    def get_instances(self, output_path: str) -> List[Instance]:
+        fields, _, label_key, _, _ = self.load_prompt_construction_settings(output_path)
+        cache_dir = str(Path(output_path) / "data")
+
+        # Download data from Huggingface. LegalBench provides splits for samples to
+        # be used for prompt construction and for testing.
+        train_dataset = datasets.load_dataset("nguha/legalbench", self.subset, cache_dir=cache_dir, split="train")
+        test_dataset = datasets.load_dataset("nguha/legalbench", self.subset, cache_dir=cache_dir, split="test")
+        assert isinstance(train_dataset, datasets.Dataset)
+        assert isinstance(test_dataset, datasets.Dataset)
+
+        dataset_splits: Dict[str, datasets.Dataset] = {
+            TRAIN_SPLIT: train_dataset,
+            TEST_SPLIT: test_dataset,
+        }
+
+        # Read all instances
+        random.seed(self.random_seed)
+        instances: List[Instance] = []
+        for split, subset in dataset_splits.items():
+            for x in subset:
+                assert fields is not None, "Field ordering not loaded"
+                prompt: str = "\n".join([f"{field[0]}: {x[field[1]]}" for field in fields])
+                instance = Instance(
+                    input=Input(text=prompt),
+                    references=[Reference(Output(text=x[label_key]), tags=[CORRECT_TAG])],
+                    split=split,
+                )
+                instances.append(instance)
+
+        return instances

--- a/src/helm/benchmark/static/schema.yaml
+++ b/src/helm/benchmark/static/schema.yaml
@@ -2735,6 +2735,23 @@ run_groups:
       when: n/a
       language: synthetic
 
+  - name: legalbench
+    display_name: LegalBench
+    description: LegalBench is a large collaboratively constructed benchmark of legal reasoning. Five representative tasks are included here. See [(Guha et al, 2023)[https://arxiv.org/abs/2308.11462] for more details.
+    metric_groups:
+      - classification_metrics
+      - efficiency
+      - general_information
+    environment:
+      main_name: quasi_exact_match
+      main_split: test
+    taxonomy:
+      task: "text classification"
+      what: "fact patterns, questions, and legal documents"
+      who: "lawyers"
+      when: n/a
+      language: English
+
   - name: legal_support
     display_name: LegalSupport
     description: Scenario introduced in this work to measure fine-grained legal reasoning through reverse entailment.


### PR DESCRIPTION
Adding 5 LegalBench tasks, which capture representative aspects of the benchmark. The scenarios file was modeled after RAFT. 