### PR TITLE
Shorten cache retry time

### DIFF
--- a/src/helm/common/cache.py
+++ b/src/helm/common/cache.py
@@ -22,7 +22,7 @@ def retry_if_write_failed(success: bool) -> bool:
 
 
 retry: Callable = get_retry_decorator(
-    "Write", max_attempts=10, wait_exponential_multiplier_seconds=2, retry_on_result=retry_if_write_failed
+    "Write", max_attempts=5, wait_exponential_multiplier_seconds=2, retry_on_result=retry_if_write_failed
 )
 
 


### PR DESCRIPTION
Currently the cache keeps retrying for _half an hour_ if the cache is down.

Additionally, this is nested within a outer request retry loop, which also retries for five times, giving a total of _two and half hours_ of retrying time.

This makes `helm-run` run for hours uselessly if the cache is down.

This change shortens it to one minute.