### PR TITLE
Add retrying to AutoTokenizer

### DIFF
--- a/src/helm/proxy/retry.py
+++ b/src/helm/proxy/retry.py
@@ -85,3 +85,7 @@ def retry_if_request_failed(result: Union[RequestResult, TokenizationRequestResu
 retry_request: Callable = get_retry_decorator(
     "Request", max_attempts=5, wait_exponential_multiplier_seconds=5, retry_on_result=retry_if_request_failed
 )
+
+retry_tokenizer_request: Callable = get_retry_decorator(
+    "Request", max_attempts=5, wait_exponential_multiplier_seconds=1, retry_on_result=retry_if_request_failed
+)

--- a/src/helm/proxy/tokenizers/auto_tokenizer.py
+++ b/src/helm/proxy/tokenizers/auto_tokenizer.py
@@ -9,6 +9,7 @@ from helm.common.credentials_utils import provide_api_key
 from helm.common.cache import CacheConfig
 from helm.common.hierarchical_logger import hlog
 from helm.common.object_spec import create_object, inject_object_spec_args
+from helm.proxy.retry import retry_tokenizer_request
 from helm.common.tokenization_request import (
     DecodeRequest,
     DecodeRequestResult,
@@ -59,6 +60,7 @@ class AutoTokenizer(Tokenizer):
     def tokenize(self, request: TokenizationRequest) -> TokenizationRequestResult:
         """Tokenizes based on the name of the tokenizer (e.g., huggingface/gpt2)."""
 
+        @retry_tokenizer_request
         def tokenize_with_retry(tokenizer: Tokenizer, request: TokenizationRequest) -> TokenizationRequestResult:
             return tokenizer.tokenize(request)
 
@@ -75,6 +77,7 @@ class AutoTokenizer(Tokenizer):
     def decode(self, request: DecodeRequest) -> DecodeRequestResult:
         """Decodes based on the the name of the tokenizer (e.g., huggingface/gpt2)."""
 
+        @retry_tokenizer_request
         def decode_with_retry(tokenizer: Tokenizer, request: DecodeRequest) -> DecodeRequestResult:
             return tokenizer.decode(request)
 


### PR DESCRIPTION
For some reason, `tokenize_with_retry` and `retry_tokenizer_request` in `AutoTokenizer` do not actually retry. This change makes them actually retry.