### PR TITLE
Hold a lock when using thread-hostile Hugging Face tokenizers

### DIFF
--- a/src/helm/benchmark/window_services/huggingface_window_service.py
+++ b/src/helm/benchmark/window_services/huggingface_window_service.py
@@ -18,21 +18,21 @@ class HuggingFaceWindowService(LocalWindowService):
     ):
         super().__init__(service)
         self._tokenizer_name = tokenizer_name
-        tokenizer = HuggingFaceTokenizer.get_tokenizer(
-            helm_tokenizer_name=tokenizer_name,
-            pretrained_model_name_or_path=pretrained_model_name_or_path or tokenizer_name,
-            revision=revision,
-        )
         # Override max_sequence_length, max_request_length, end_of_text_token
         # and prefix_token if provided as an argument.
         # Otherwise, auto-infer them from the Hugging Face tokenizer.
         #
         # Note that many Hugging Face tokenizers have incorrect sequence lengths,
         # so it is recommended to set this manually.
-        self._max_sequence_length = max_sequence_length or tokenizer.model_max_length
-        self._max_request_length = max_request_length or self._max_sequence_length
-        self._end_of_text_token = end_of_text_token or tokenizer.eos_token or ""
-        self._prefix_token = prefix_token or tokenizer.bos_token or ""
+        with HuggingFaceTokenizer.get_tokenizer(
+            helm_tokenizer_name=tokenizer_name,
+            pretrained_model_name_or_path=pretrained_model_name_or_path or tokenizer_name,
+            revision=revision,
+        ) as tokenizer:
+            self._max_sequence_length = max_sequence_length or tokenizer._model_max_length
+            self._max_request_length = max_request_length or self._max_sequence_length
+            self._end_of_text_token = end_of_text_token or tokenizer.eos_token or ""
+            self._prefix_token = prefix_token or tokenizer.bos_token or ""
 
     @property
     def tokenizer_name(self) -> str:

--- a/src/helm/benchmark/window_services/huggingface_window_service.py
+++ b/src/helm/benchmark/window_services/huggingface_window_service.py
@@ -29,7 +29,7 @@ class HuggingFaceWindowService(LocalWindowService):
             pretrained_model_name_or_path=pretrained_model_name_or_path or tokenizer_name,
             revision=revision,
         ) as tokenizer:
-            self._max_sequence_length = max_sequence_length or tokenizer._model_max_length
+            self._max_sequence_length = max_sequence_length or tokenizer.model_max_length
             self._max_request_length = max_request_length or self._max_sequence_length
             self._end_of_text_token = end_of_text_token or tokenizer.eos_token or ""
             self._prefix_token = prefix_token or tokenizer.bos_token or ""

--- a/src/helm/common/concurrency.py
+++ b/src/helm/common/concurrency.py
@@ -1,0 +1,32 @@
+from contextlib import AbstractContextManager
+from threading import Lock
+from typing import TypeVar, Generic
+
+
+T = TypeVar("T")
+
+
+class ThreadSafeWrapper(AbstractContextManager, Generic[T]):
+    """A wrapper that makes thread-hostile objects thread-safe.
+
+    This provides a context manager that holds a lock for accessing the inner object.
+
+    Example usage:
+
+        wrapped_obj = wrapper(thread_hostile_obj)
+        with wrapped_obj as obj:
+            # Lock is automatically held in here
+            obj.do_stuff()
+    """
+
+    def __init__(self, wrapped: T):
+        self._wrapped = wrapped
+        self._lock = Lock()
+
+    def __enter__(self) -> T:
+        self._lock.__enter__()
+        return self._wrapped
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self._lock.__exit__(exc_type, exc_value, traceback)
+        pass

--- a/src/helm/proxy/tokenizers/huggingface_tokenizer.py
+++ b/src/helm/proxy/tokenizers/huggingface_tokenizer.py
@@ -2,6 +2,7 @@ import os
 from typing import Any, Dict, Optional
 from threading import Lock
 from helm.common.cache import CacheConfig
+from helm.common.concurrency import ThreadSafeWrapper
 
 from transformers import AutoTokenizer, PreTrainedTokenizerBase
 
@@ -26,8 +27,22 @@ def resolve_alias(model_name: str) -> str:
     return _MODEL_NAME_ALIASES.get(model_name, model_name)
 
 
+WrappedPreTrainedTokenizer = ThreadSafeWrapper[PreTrainedTokenizerBase]
+"""Thread safe wrapper around Hugging Face PreTrainedTokenizerBase.
+
+Hugging Face PreTrainedTokenizerBase is thread-hostile and using it from multiple threads
+simulataneously can result in an "Already borrowed" error (#1421). This wrapper ensures
+that a lock is held when using the PreTrainedTokenizerBase.
+
+Example usage:
+
+    with wrapped_tokenizer as tokenizer:
+        tokenizer.encode("...")
+"""
+
+
 class HuggingFaceTokenizer(CachingTokenizer):
-    _tokenizers: Dict[str, PreTrainedTokenizerBase] = {}
+    _tokenizers: Dict[str, WrappedPreTrainedTokenizer] = {}
     _tokenizers_lock: Lock = Lock()
 
     def __init__(
@@ -41,7 +56,9 @@ class HuggingFaceTokenizer(CachingTokenizer):
         self._revision = revision
 
     @staticmethod
-    def create_tokenizer(pretrained_model_name_or_path: str, revision: Optional[str] = None) -> PreTrainedTokenizerBase:
+    def create_tokenizer(
+        pretrained_model_name_or_path: str, revision: Optional[str] = None
+    ) -> WrappedPreTrainedTokenizer:
         """Loads tokenizer using files from disk if they exist. Otherwise, downloads from HuggingFace."""
         # To avoid deadlocks when using HuggingFace tokenizers with multiple processes
         # TODO: Figure out if we actually need this.
@@ -60,19 +77,23 @@ class HuggingFaceTokenizer(CachingTokenizer):
             # From https://huggingface.co/course/chapter6/3, "slow tokenizers are those written in Python inside
             # the Hugging Face Transformers library, while the fast versions are the ones provided by Hugging Face
             # Tokenizers, which are written in Rust." So, use the "fast" version of the tokenizers if available.
-            return AutoTokenizer.from_pretrained(
-                pretrained_model_name_or_path, local_files_only=True, use_fast=True, **tokenizer_kwargs
+            return WrappedPreTrainedTokenizer(
+                AutoTokenizer.from_pretrained(
+                    pretrained_model_name_or_path, local_files_only=True, use_fast=True, **tokenizer_kwargs
+                )
             )
         except OSError:
             hlog(f"Local files do not exist for HuggingFace tokenizer: {pretrained_model_name_or_path}. Downloading...")
-            return AutoTokenizer.from_pretrained(
-                pretrained_model_name_or_path, local_files_only=False, use_fast=True, **tokenizer_kwargs
+            return WrappedPreTrainedTokenizer(
+                AutoTokenizer.from_pretrained(
+                    pretrained_model_name_or_path, local_files_only=False, use_fast=True, **tokenizer_kwargs
+                )
             )
 
     @staticmethod
     def get_tokenizer(
         helm_tokenizer_name: str, pretrained_model_name_or_path: str, revision: Optional[str] = None
-    ) -> PreTrainedTokenizerBase:
+    ) -> WrappedPreTrainedTokenizer:
         """
         Checks if the desired tokenizer is cached. Creates the tokenizer if it's not cached.
         Returns the tokenizer.
@@ -89,33 +110,32 @@ class HuggingFaceTokenizer(CachingTokenizer):
                     )
         return HuggingFaceTokenizer._tokenizers[helm_tokenizer_name]
 
-    def _get_tokenizer_for_request(self, request: Dict[str, Any]) -> PreTrainedTokenizerBase:
+    def _get_tokenizer_for_request(self, request: Dict[str, Any]) -> WrappedPreTrainedTokenizer:
         """Method used in both _tokenize_do_it and _decode_do_it to get the tokenizer."""
         pretrained_model_name_or_path: str
         if self._pretrained_model_name_or_path:
             pretrained_model_name_or_path = self._pretrained_model_name_or_path
         else:
             pretrained_model_name_or_path = resolve_alias(request["tokenizer"])
-        _tokenizer = HuggingFaceTokenizer.get_tokenizer(
+        return HuggingFaceTokenizer.get_tokenizer(
             helm_tokenizer_name=request["tokenizer"],
             pretrained_model_name_or_path=pretrained_model_name_or_path,
             revision=self._revision,
         )
-        return _tokenizer
 
     def _tokenize_do_it(self, request: Dict[str, Any]) -> Dict[str, Any]:
-        _tokenizer = self._get_tokenizer_for_request(request)
-
         if request["encode"]:
             if request["truncation"]:
-                tokens = _tokenizer.encode(
-                    request["text"],
-                    truncation=request["truncation"],
-                    max_length=request["max_length"],
-                    add_special_tokens=False,
-                )
+                with self._get_tokenizer_for_request(request) as tokenizer:
+                    tokens = tokenizer.encode(
+                        request["text"],
+                        truncation=request["truncation"],
+                        max_length=request["max_length"],
+                        add_special_tokens=False,
+                    )
             else:
-                tokens = _tokenizer.encode(request["text"], add_special_tokens=False)
+                with self._get_tokenizer_for_request(request) as tokenizer:
+                    tokens = tokenizer.encode(request["text"], add_special_tokens=False)
         else:
             if "gpt" in request["tokenizer"] or request["tokenizer"] in [
                 "bigscience/bloom",
@@ -126,9 +146,10 @@ class HuggingFaceTokenizer(CachingTokenizer):
                 # convert_tokens_to_string method. We prefer to use this method instead
                 # of the hacky cleanup_tokens method below as it might handle cases
                 # we haven't thought of in cleanup_tokens.
-                tokens = [
-                    _tokenizer.convert_tokens_to_string([token]) for token in _tokenizer.tokenize(request["text"])
-                ]
+                with self._get_tokenizer_for_request(request) as tokenizer:
+                    tokens = [
+                        tokenizer.convert_tokens_to_string([token]) for token in tokenizer.tokenize(request["text"])
+                    ]
             else:
                 # Tokenizes the text and returns the tokens as a list of strings,
                 # not a list of token objects (otherwise "Hello world" would be"
@@ -138,14 +159,14 @@ class HuggingFaceTokenizer(CachingTokenizer):
                 # But this replaces all the "▁" characters by "", which is not what we want.
                 # This would be problematic as tokenize(" Hello", encode=False) would return ["Hello"]
                 # Just like tokenize("Hello", encode=False) would return ["Hello"].
-                tokens = _tokenizer.tokenize(request["text"])
+                with self._get_tokenizer_for_request(request) as tokenizer:
+                    tokens = tokenizer.tokenize(request["text"])
                 tokens = cleanup_tokens(tokens, request["tokenizer"])
         return {"tokens": tokens}
 
     def _decode_do_it(self, request: Dict[str, Any]) -> Dict[str, Any]:
-        _tokenizer = self._get_tokenizer_for_request(request)
-
-        text = _tokenizer.decode(
-            request["tokens"], clean_up_tokenization_spaces=request["clean_up_tokenization_spaces"]
-        )
+        with self._get_tokenizer_for_request(request) as tokenizer:
+            text = tokenizer.decode(
+                request["tokens"], clean_up_tokenization_spaces=request["clean_up_tokenization_spaces"]
+            )
         return {"text": text}

--- a/src/helm/proxy/tokenizers/huggingface_tokenizer.py
+++ b/src/helm/proxy/tokenizers/huggingface_tokenizer.py
@@ -31,7 +31,7 @@ WrappedPreTrainedTokenizer = ThreadSafeWrapper[PreTrainedTokenizerBase]
 """Thread safe wrapper around Hugging Face PreTrainedTokenizerBase.
 
 Hugging Face PreTrainedTokenizerBase is thread-hostile and using it from multiple threads
-simulataneously can result in an "Already borrowed" error (#1421). This wrapper ensures
+simultaneously can result in an "Already borrowed" error (#1421). This wrapper ensures
 that a lock is held when using the PreTrainedTokenizerBase.
 
 Example usage:

--- a/src/helm/proxy/tokenizers/test_huggingface_tokenizer.py
+++ b/src/helm/proxy/tokenizers/test_huggingface_tokenizer.py
@@ -93,12 +93,13 @@ class TestHuggingFaceTokenizer:
     def verify_get_tokenizer(
         tokenizer_name: str, expected_num_tokens: int, pretrained_model_name_or_path: Optional[str] = None
     ):
-        tokenizer = HuggingFaceTokenizer.get_tokenizer(
+        wrapped_tokenizer = HuggingFaceTokenizer.get_tokenizer(
             helm_tokenizer_name=tokenizer_name,
             pretrained_model_name_or_path=pretrained_model_name_or_path or tokenizer_name,
         )
         assert tokenizer_name in HuggingFaceTokenizer._tokenizers, "Tokenizer should be cached"
-        assert len(tokenizer.encode(TestHuggingFaceTokenizer.TEST_PROMPT)) == expected_num_tokens
+        with wrapped_tokenizer as tokenizer:
+            assert len(tokenizer.encode(TestHuggingFaceTokenizer.TEST_PROMPT)) == expected_num_tokens
 
     def test_get_tokenizer_gpt2(self):
         TestHuggingFaceTokenizer.verify_get_tokenizer("huggingface/gpt2", 51, pretrained_model_name_or_path="gpt2")
@@ -126,7 +127,8 @@ class TestHuggingFaceTokenizer:
 
     def test_gpt2_tokenize_eos(self):
         eos_token: str = "<|endoftext|>"
-        tokenizer = HuggingFaceTokenizer.get_tokenizer("huggingface/gpt2", pretrained_model_name_or_path="gpt2")
-        token_ids = tokenizer.encode(eos_token)
-        assert singleton(token_ids) == 50256
-        assert tokenizer.decode(token_ids) == eos_token
+        wrapped_tokenizer = HuggingFaceTokenizer.get_tokenizer("huggingface/gpt2", pretrained_model_name_or_path="gpt2")
+        with wrapped_tokenizer as tokenizer:
+            token_ids = tokenizer.encode(eos_token)
+            assert singleton(token_ids) == 50256
+            assert tokenizer.decode(token_ids) == eos_token

--- a/src/helm/proxy/tokenizers/test_huggingface_tokenizer.py
+++ b/src/helm/proxy/tokenizers/test_huggingface_tokenizer.py
@@ -63,7 +63,7 @@ class TestHuggingFaceGPT2Tokenizer:
         """Test workaround of the "Already borrowed" bug (#1421) caused by the thread-hostile Hugging Face tokenizer"""
 
         def make_tokenize_request(seed: int) -> None:
-            request_length = 100
+            request_length = 10
             truncation = bool(seed % 2)
             self.tokenizer.tokenize(
                 # The truncation parameter requires setting a flag on the Rust FastTokenizer.
@@ -73,7 +73,7 @@ class TestHuggingFaceGPT2Tokenizer:
                 )
             )
 
-        num_requests = 1000
+        num_requests = 100
         # Should not raise "Already borrowed" error
         parallel_map(make_tokenize_request, list(range(num_requests)), parallelism=8)
 

--- a/src/helm/proxy/tokenizers/test_huggingface_tokenizer.py
+++ b/src/helm/proxy/tokenizers/test_huggingface_tokenizer.py
@@ -1,5 +1,4 @@
 import os
-import pytest
 import tempfile
 from typing import Optional
 
@@ -61,7 +60,7 @@ class TestHuggingFaceGPT2Tokenizer:
         assert result.text == "I am a computer scientist."
 
     def test_already_borrowed(self):
-        """Demonstrates the "Already borrowed" bug (#1421) caused by the thread-hostile Hugging Face tokenizer"""
+        """Test workaround of the "Already borrowed" bug (#1421) caused by the thread-hostile Hugging Face tokenizer"""
 
         def make_tokenize_request(seed: int) -> None:
             request_length = 100
@@ -74,9 +73,9 @@ class TestHuggingFaceGPT2Tokenizer:
                 )
             )
 
-        with pytest.raises(ValueError, match="Already borrowed"):
-            num_requests = 1000
-            parallel_map(make_tokenize_request, list(range(num_requests)), parallelism=8)
+        num_requests = 1000
+        # Should not raise "Already borrowed" error
+        parallel_map(make_tokenize_request, list(range(num_requests)), parallelism=8)
 
 
 class TestHuggingFaceTokenizer:


### PR DESCRIPTION
Hugging Face `PreTrainedTokenizerBase` is thread-hostile and using it from multiple threads simultaneously can result in an "Already borrowed" error (#1421). This adds `ThreadSafeWrapper`, which ensures that a lock is held when using the `PreTrainedTokenizerBase`.

Fixes #1421