### PR TITLE
Default helm-server to using schema_classic.yaml

### DIFF
--- a/src/helm/benchmark/server.py
+++ b/src/helm/benchmark/server.py
@@ -44,9 +44,9 @@ def serve_config():
 # We will remove this in a few months after most users have moved to the new version of helm-summarize.
 #
 # TODO(2023-03-01): Remove this.
-@app.get("/benchmark_output/runs/<version>/schema.json")
-def server_schema(version):
-    relative_schema_path = path.join("runs", version, "schema.json")
+@app.get("/benchmark_output/<runs_or_releases:re:runs|releases>/<version>/schema.json")
+def server_schema(runs_or_releases, version):
+    relative_schema_path = path.join(runs_or_releases, version, "schema.json")
     absolute_schema_path = path.join(app.config["helm.outputpath"], relative_schema_path)
     if path.isfile(absolute_schema_path):
         response = static_file(relative_schema_path, root=app.config["helm.outputpath"])

--- a/src/helm/benchmark/server.py
+++ b/src/helm/benchmark/server.py
@@ -44,7 +44,7 @@ def server_schema(version):
         response = static_file(relative_schema_path, root=app.config["helm.outputpath"])
     else:
         # Suite does not contain schema.json
-        # Fall back to schema_classic.json from the static directory
+        # Fall back to schema_classic.yaml from the static directory
         classic_schema_path = path.join(app.config["helm.staticpath"], SCHEMA_CLASSIC_YAML_FILENAME)
         with open(classic_schema_path, "r") as f:
             response = HTTPResponse(json.dumps(yaml.safe_load(f), indent=2, default=serialize_dates))

--- a/src/helm/benchmark/server.py
+++ b/src/helm/benchmark/server.py
@@ -43,7 +43,7 @@ def serve_config():
 #
 # We will remove this in a few months after most users have moved to the new version of helm-summarize.
 #
-# TODO(2023-03-01): Remove this.
+# TODO(2024-03-01): Remove this.
 @app.get("/benchmark_output/<runs_or_releases:re:runs|releases>/<version>/schema.json")
 def server_schema(runs_or_releases, version):
     relative_schema_path = path.join(runs_or_releases, version, "schema.json")

--- a/src/helm/benchmark/server.py
+++ b/src/helm/benchmark/server.py
@@ -34,8 +34,16 @@ def serve_config():
 
 
 # Shim for running helm-server for old suites from old version of helm-summarize
-# that do not contain schema.json
-# TODO(2023-05-01): Remove this.
+# that do not contain schema.json.
+#
+# The HELM web frontend expects to find a schema.json at /benchmark_output/runs/<version>/schema.json
+# which is produced by the new version of helm-summarize but not the old version.
+# When serving a suite produced by the old version of helm-summarize, the schena.json will be missing.
+# This shim supports those suites by serving a schena.json that is dynamically computed from schema_classic.yaml
+#
+# We will remove this in a few months after most users have moved to the new version of helm-summarize.
+#
+# TODO(2023-03-01): Remove this.
 @app.get("/benchmark_output/runs/<version>/schema.json")
 def server_schema(version):
     relative_schema_path = path.join("runs", version, "schema.json")


### PR DESCRIPTION
Adds a shim for running helm-server for old suites from old version of helm-summarize that do not contain schema.json.

Backwards compatibility change for #2075.