### PR TITLE
Fix incorrect cache directory used by run specs

### DIFF
--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -7,6 +7,7 @@ from helm.benchmark.huggingface_registration import (
 )
 
 from helm.benchmark.presentation.run_entry import RunEntry, read_run_entries
+from helm.common.general import ensure_directory_exists
 from helm.common.hierarchical_logger import hlog, htrack, htrack_block
 from helm.common.authentication import Authentication
 from helm.common.object_spec import parse_object_spec, get_class_by_name
@@ -18,7 +19,7 @@ from helm.benchmark.config_registry import register_helm_configurations
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark import vlm_run_specs  # noqa
 from .executor import ExecutionSpec
-from .runner import Runner, RunSpec, LATEST_SYMLINK
+from .runner import Runner, RunSpec, LATEST_SYMLINK, set_benchmark_output_path
 from .run_specs import construct_run_specs
 
 
@@ -277,6 +278,11 @@ def main():
         run_entries.extend(
             [RunEntry(description=description, priority=1, groups=None) for description in args.run_specs]
         )
+
+    # Must set benchmark output path before getting RunSpecs,
+    # because run spec functions can use the benchmark output directory for caching.
+    ensure_directory_exists(args.output_path)
+    set_benchmark_output_path(args.output_path)
 
     register_helm_configurations()
 

--- a/src/helm/benchmark/run_specs.py
+++ b/src/helm/benchmark/run_specs.py
@@ -1871,7 +1871,7 @@ def get_entity_data_imputation_spec(dataset: str) -> RunSpec:
 @htrack("Extracting adaptation parameters from the BIG-bench task definition and building the RunSpec")
 @run_spec_function("big_bench")
 def get_big_bench_spec(task: str, subtask: str) -> RunSpec:
-    from .scenarios.big_bench_scenario import BIGBenchScenario
+    from helm.scenarios.big_bench_scenario import BIGBenchScenario
 
     def get_adaptation_method(big_bench_metrics: List[str]) -> str:
         """
@@ -2455,7 +2455,7 @@ def get_anthropic_hh_rlhf_spec(num_respondents: int, subset: str) -> RunSpec:
 
 @run_spec_function("cleva")
 def get_cleva_spec(task: str, version: str, subtask: Optional[str] = None, prompt_id: int = 0) -> RunSpec:
-    from .scenarios.cleva_scenario import CLEVAScenario  # noqa
+    from helm.benchmark.scenarios.cleva_scenario import CLEVAScenario  # noqa
 
     scenario_cache_path = get_scenario_cache_path(get_benchmark_output_path(), CLEVAScenario.name)
     CLEVAScenario.download_dataset(task, version, scenario_cache_path)

--- a/src/helm/benchmark/run_specs.py
+++ b/src/helm/benchmark/run_specs.py
@@ -1871,7 +1871,7 @@ def get_entity_data_imputation_spec(dataset: str) -> RunSpec:
 @htrack("Extracting adaptation parameters from the BIG-bench task definition and building the RunSpec")
 @run_spec_function("big_bench")
 def get_big_bench_spec(task: str, subtask: str) -> RunSpec:
-    from helm.scenarios.big_bench_scenario import BIGBenchScenario
+    from helm.benchmark.scenarios.big_bench_scenario import BIGBenchScenario
 
     def get_adaptation_method(big_bench_metrics: List[str]) -> str:
         """

--- a/src/helm/benchmark/runner.py
+++ b/src/helm/benchmark/runner.py
@@ -191,6 +191,11 @@ class Runner:
         ensure_directory_exists(output_path)
         self.output_path = output_path
 
+        # Decide where to save input instances
+        self.instances_path: str = os.path.join(output_path, "scenario_instances")
+        ensure_directory_exists(self.instances_path)
+        self.output_path = output_path
+
         # Output the results under a folder with the name of the suite
         self.runs_path: str = os.path.join(output_path, "runs", suite)
 
@@ -249,8 +254,7 @@ class Runner:
         # This 'output_path' will be used when the model's input instances are saved.
         args_str = ",".join([f"{k}={v}" for k, v in sorted(run_spec.scenario_spec.args.items())])
         scenario_name_with_args = f"{scenario.name}:{args_str}" if args_str else f"{scenario.name}"
-        input_instances_output_path = os.path.join(self.output_path, "scenario_instances", scenario_name_with_args)
-        ensure_directory_exists(input_instances_output_path)
+        input_instances_output_path = os.path.join(self.instances_path, scenario_name_with_args)
         input_instances_file_path = os.path.join(input_instances_output_path, "input_instances.json")
 
         instances: List[Instance]

--- a/src/helm/benchmark/runner.py
+++ b/src/helm/benchmark/runner.py
@@ -194,7 +194,6 @@ class Runner:
         # Decide where to save input instances
         self.instances_path: str = os.path.join(output_path, "scenario_instances")
         ensure_directory_exists(self.instances_path)
-        self.output_path = output_path
 
         # Output the results under a folder with the name of the suite
         self.runs_path: str = os.path.join(output_path, "runs", suite)

--- a/src/helm/benchmark/runner.py
+++ b/src/helm/benchmark/runner.py
@@ -23,6 +23,7 @@ from .scenarios.scenario import (
     ScenarioSpec,
     create_scenario,
     Instance,
+    get_scenario_cache_path,
     with_instance_ids,
 )
 from .adaptation.adapters.adapter import Adapter
@@ -39,6 +40,22 @@ from .window_services.tokenizer_service import TokenizerService
 
 
 LATEST_SYMLINK: str = "latest"
+_BENCHMARK_OUTPUT_PATH: str = "benchmark_output"
+
+
+def get_benchmark_output_path() -> str:
+    """Get the genchmark output path.
+
+    Many run spec functions need to know the benchmark output path,
+    but there is no way to pass it via  the run spec function,
+    so instead the run spec function should read this global variable."""
+    return _BENCHMARK_OUTPUT_PATH
+
+
+def set_benchmark_output_path(benchmark_output_path: str) -> None:
+    """Set the genchmark output path."""
+    global _BENCHMARK_OUTPUT_PATH
+    _BENCHMARK_OUTPUT_PATH = benchmark_output_path
 
 
 class RunnerError(Exception):
@@ -172,12 +189,7 @@ class Runner:
         self.exit_on_error: bool = exit_on_error
 
         ensure_directory_exists(output_path)
-        # Decide where to save the raw data (e.g., "output/scenarios/mmlu").
-        self.scenarios_path: str = os.path.join(output_path, "scenarios")
-        ensure_directory_exists(self.scenarios_path)
-        # Decide where to save input instances
-        self.instances_path: str = os.path.join(output_path, "scenario_instances")
-        ensure_directory_exists(self.instances_path)
+        self.output_path = output_path
 
         # Output the results under a folder with the name of the suite
         self.runs_path: str = os.path.join(output_path, "runs", suite)
@@ -234,14 +246,11 @@ class Runner:
         # Load the scenario
         scenario: Scenario = create_scenario(run_spec.scenario_spec)
 
-        # This `output_path` will be used when `Adapter` calls `Scenario.get_instances`.
-        scenario_output_path = os.path.join(self.scenarios_path, scenario.name)
-        ensure_directory_exists(scenario_output_path)
-
         # This 'output_path' will be used when the model's input instances are saved.
         args_str = ",".join([f"{k}={v}" for k, v in sorted(run_spec.scenario_spec.args.items())])
         scenario_name_with_args = f"{scenario.name}:{args_str}" if args_str else f"{scenario.name}"
-        input_instances_output_path = os.path.join(self.instances_path, scenario_name_with_args)
+        input_instances_output_path = os.path.join(self.output_path, "scenario_instances", scenario_name_with_args)
+        ensure_directory_exists(input_instances_output_path)
         input_instances_file_path = os.path.join(input_instances_output_path, "input_instances.json")
 
         instances: List[Instance]
@@ -254,6 +263,7 @@ class Runner:
                 instances = [dacite.from_dict(Instance, instance) for instance in json_instances]
             else:
                 # Create the instances of the scenario
+                scenario_output_path = get_scenario_cache_path(self.output_path, scenario.name)
                 with htrack_block("scenario.get_instances"):
                     instances = scenario.get_instances(scenario_output_path)
         if self.cache_instances and not os.path.exists(input_instances_file_path):

--- a/src/helm/benchmark/scenarios/cleva_scenario.py
+++ b/src/helm/benchmark/scenarios/cleva_scenario.py
@@ -407,14 +407,14 @@ class CLEVAScenario(Scenario):
         pass
 
     @classmethod
-    def download_dataset(cls, task: str, version: str, output_path: str):
+    def download_dataset(cls, task: str, version: str, cache_dir: str):
         source_url: str = CLEVA_DATA_URL + f"/{version}/{task}.zip"
-        target_dir: str = os.path.join(output_path, "data", version)
+        target_dir: str = os.path.join(cache_dir, "data", version)
         ensure_directory_exists(target_dir)
         ensure_file_downloaded(source_url=source_url, target_path=os.path.join(target_dir, task), unpack=True)
 
-    def load_dataset(self, output_path) -> Dict[str, List[Dict[str, Any]]]:
-        data_dir: str = os.path.join(output_path, "data", self.version, self.task)
+    def load_dataset(self, cache_dir: str) -> Dict[str, List[Dict[str, Any]]]:
+        data_dir: str = os.path.join(cache_dir, "data", self.version, self.task)
         if self.subtask:
             data_dir = os.path.join(data_dir, self.subtask)
 
@@ -431,10 +431,8 @@ class CLEVAScenario(Scenario):
         return dataset
 
     @staticmethod
-    def load_prompt_templates(
-        task: str, subtask: Optional[str], version: str, output_path: str
-    ) -> List[Dict[str, Any]]:
-        prompt_dir: str = os.path.join(output_path, "data", version, task)
+    def load_prompt_templates(task: str, subtask: Optional[str], version: str, cache_dir: str) -> List[Dict[str, Any]]:
+        prompt_dir: str = os.path.join(cache_dir, "data", version, task)
         if subtask:
             prompt_dir = os.path.join(prompt_dir, subtask)
         file_path = os.path.join(prompt_dir, "prompts.json")
@@ -518,10 +516,10 @@ class CLEVAScenario(Scenario):
 
     @classmethod
     def load_inference_parameters(
-        cls, task: str, subtask: Optional[str], version: str, prompt_id: int, output_path: str
+        cls, task: str, subtask: Optional[str], version: str, prompt_id: int, cache_dir: str
     ) -> Dict[str, Any]:
         # We use a dict instead of dataclass to store hyperparameters such that we can set different default values
-        params_dir: str = os.path.join(output_path, "data", version, task)
+        params_dir: str = os.path.join(cache_dir, "data", version, task)
         if subtask:
             params_dir = os.path.join(params_dir, subtask)
         file_path = os.path.join(params_dir, "infer_params.json")

--- a/src/helm/benchmark/scenarios/cleva_scenario.py
+++ b/src/helm/benchmark/scenarios/cleva_scenario.py
@@ -10,6 +10,7 @@ from helm.benchmark.adaptation.adapters.adapter_factory import (
     ADAPT_MULTIPLE_CHOICE_SEPARATE_ORIGINAL,
     ADAPT_GENERATION,
 )
+from helm.benchmark.runner import get_benchmark_output_path
 from helm.common.general import (
     assert_is_str,
     assert_is_str_list,
@@ -17,12 +18,21 @@ from helm.common.general import (
     ensure_directory_exists,
 )
 from helm.common.hierarchical_logger import hlog
-from .scenario import Scenario, Instance, Reference, TRAIN_SPLIT, TEST_SPLIT, CORRECT_TAG, Input, Output
+from .scenario import (
+    Scenario,
+    Instance,
+    Reference,
+    TRAIN_SPLIT,
+    TEST_SPLIT,
+    CORRECT_TAG,
+    Input,
+    Output,
+    get_scenario_cache_path,
+)
 from .code_scenario import CodeReference, CodeInstance
 
 
 CLEVA_DATA_URL = "http://39.108.215.175/data"
-CLEVA_DATA_PATH = "benchmark_output/scenarios/cleva"
 
 
 @dataclass(frozen=True)
@@ -386,7 +396,10 @@ class CLEVAScenario(Scenario):
         self.subtask = subtask
         self.version = version
         self.converter = Converter()
-        self.prompt_template, _ = CLEVAScenario.get_prompt_setting(self.task, subtask, version, prompt_id)
+        scenario_cache_path = get_scenario_cache_path(get_benchmark_output_path(), CLEVAScenario.name)
+        self.prompt_template, _ = CLEVAScenario.get_prompt_setting(
+            self.task, subtask, version, prompt_id, scenario_cache_path
+        )
 
     @property
     @abstractmethod
@@ -394,14 +407,14 @@ class CLEVAScenario(Scenario):
         pass
 
     @classmethod
-    def download_dataset(cls, task: str, version: str):
+    def download_dataset(cls, task: str, version: str, output_path: str):
         source_url: str = CLEVA_DATA_URL + f"/{version}/{task}.zip"
-        target_dir: str = os.path.join(CLEVA_DATA_PATH, "data", version)
+        target_dir: str = os.path.join(output_path, "data", version)
         ensure_directory_exists(target_dir)
         ensure_file_downloaded(source_url=source_url, target_path=os.path.join(target_dir, task), unpack=True)
 
-    def load_dataset(self) -> Dict[str, List[Dict[str, Any]]]:
-        data_dir: str = os.path.join(CLEVA_DATA_PATH, "data", self.version, self.task)
+    def load_dataset(self, output_path) -> Dict[str, List[Dict[str, Any]]]:
+        data_dir: str = os.path.join(output_path, "data", self.version, self.task)
         if self.subtask:
             data_dir = os.path.join(data_dir, self.subtask)
 
@@ -418,8 +431,10 @@ class CLEVAScenario(Scenario):
         return dataset
 
     @staticmethod
-    def load_prompt_templates(task: str, subtask: Optional[str], version: str) -> List[Dict[str, Any]]:
-        prompt_dir: str = os.path.join(CLEVA_DATA_PATH, "data", version, task)
+    def load_prompt_templates(
+        task: str, subtask: Optional[str], version: str, output_path: str
+    ) -> List[Dict[str, Any]]:
+        prompt_dir: str = os.path.join(output_path, "data", version, task)
         if subtask:
             prompt_dir = os.path.join(prompt_dir, subtask)
         file_path = os.path.join(prompt_dir, "prompts.json")
@@ -432,7 +447,7 @@ class CLEVAScenario(Scenario):
 
     def get_instances(self, output_path: str) -> List[Instance]:
         # Download the raw data
-        dataset = self.load_dataset()
+        dataset = self.load_dataset(output_path)
 
         # Read all the instances
         instances: List[Instance] = []
@@ -449,9 +464,9 @@ class CLEVAScenario(Scenario):
 
     @classmethod
     def get_prompt_setting(
-        cls, task: str, subtask: Optional[str], version: str, prompt_id: int
+        cls, task: str, subtask: Optional[str], version: str, prompt_id: int, output_path: str
     ) -> Tuple[Dict[str, Any], PromptSetting]:
-        prompt_templates = cls.load_prompt_templates(task, subtask, version)
+        prompt_templates = cls.load_prompt_templates(task, subtask, version, output_path)
         if prompt_id >= len(prompt_templates):
             raise ValueError(
                 f"You want to use prompt template with prompt_id {prompt_id}, but there is only"
@@ -503,10 +518,10 @@ class CLEVAScenario(Scenario):
 
     @classmethod
     def load_inference_parameters(
-        cls, task: str, subtask: Optional[str], version: str, prompt_id: int
+        cls, task: str, subtask: Optional[str], version: str, prompt_id: int, output_path: str
     ) -> Dict[str, Any]:
         # We use a dict instead of dataclass to store hyperparameters such that we can set different default values
-        params_dir: str = os.path.join(CLEVA_DATA_PATH, "data", version, task)
+        params_dir: str = os.path.join(output_path, "data", version, task)
         if subtask:
             params_dir = os.path.join(params_dir, subtask)
         file_path = os.path.join(params_dir, "infer_params.json")
@@ -916,7 +931,7 @@ class CLEVADialogueGenerationScenario(CLEVAScenario):
 
     def get_instances(self, output_path: str) -> List[Instance]:
         # Download the raw data
-        dataset = self.load_dataset()
+        dataset = self.load_dataset(output_path)
 
         # Read all the instances
         instances: List[Instance] = []

--- a/src/helm/benchmark/scenarios/dialogue_scenarios.py
+++ b/src/helm/benchmark/scenarios/dialogue_scenarios.py
@@ -135,3 +135,9 @@ class EmpatheticDialoguesScenario(Scenario):
     def get_instances(self, output_path: str) -> List[Instance]:
         self.download_data(output_path)
         return self.filter_instances(self.read_instances())
+
+
+if __name__ == "__main__":
+    scenario = EmpatheticDialoguesScenario()
+    instances = scenario.get_instances("./benchmark_output/scenarios/empatheticdialogues")
+    print(instances[100])

--- a/src/helm/benchmark/scenarios/dialogue_scenarios.py
+++ b/src/helm/benchmark/scenarios/dialogue_scenarios.py
@@ -135,9 +135,3 @@ class EmpatheticDialoguesScenario(Scenario):
     def get_instances(self, output_path: str) -> List[Instance]:
         self.download_data(output_path)
         return self.filter_instances(self.read_instances())
-
-
-if __name__ == "__main__":
-    scenario = EmpatheticDialoguesScenario()
-    instances = scenario.get_instances("./benchmark_output/scenarios/empatheticdialogues")
-    print(instances[100])

--- a/src/helm/benchmark/scenarios/legalbench_scenario.py
+++ b/src/helm/benchmark/scenarios/legalbench_scenario.py
@@ -1,7 +1,6 @@
 import random
 import os
 import json
-import tempfile
 import datasets
 from pathlib import Path
 from typing import List, Dict
@@ -20,14 +19,11 @@ SUBSETS = [
 ]
 
 
-def get_legalbench_prompt_settings(subset: str, cache_dir=None):
+def get_legalbench_prompt_settings(subset: str, cache_dir: str):
     """
     Loads prompt construction settings for all subsets.
     """
     assert subset in SUBSETS, "Unknown subset: {}".format(subset)
-
-    if cache_dir is None:
-        cache_dir = tempfile.gettempdir()
 
     prompt_construction_settings_path = os.path.join(cache_dir, "legalbench_prompt_construction_settings.json")
     ensure_directory_exists(cache_dir)
@@ -48,15 +44,15 @@ def get_legalbench_prompt_settings(subset: str, cache_dir=None):
     )
 
 
-def get_legalbench_instructions(subset: str, cache_dir=None):
+def get_legalbench_instructions(subset: str, cache_dir: str):
     return get_legalbench_prompt_settings(subset, cache_dir)[1]
 
 
-def get_legalbench_output_nouns(subset: str, cache_dir=None):
+def get_legalbench_output_nouns(subset: str, cache_dir: str):
     return get_legalbench_prompt_settings(subset, cache_dir)[3]
 
 
-def get_legalbench_max_train_instances(subset: str, cache_dir=None):
+def get_legalbench_max_train_instances(subset: str, cache_dir: str):
     return get_legalbench_prompt_settings(subset, cache_dir)[4]
 
 

--- a/src/helm/benchmark/scenarios/legalbench_scenario.py
+++ b/src/helm/benchmark/scenarios/legalbench_scenario.py
@@ -25,7 +25,7 @@ def get_legalbench_prompt_settings(subset: str, cache_dir: str):
     """
     assert subset in SUBSETS, "Unknown subset: {}".format(subset)
 
-    prompt_construction_settings_path = os.path.join(cache_dir, "legalbench_prompt_construction_settings.json")
+    prompt_construction_settings_path = os.path.join(cache_dir, "prompt_construction_settings.json")
     ensure_directory_exists(cache_dir)
     ensure_file_downloaded(
         source_url=PROMPT_SETTINGS_URL,

--- a/src/helm/benchmark/scenarios/raft_scenario.py
+++ b/src/helm/benchmark/scenarios/raft_scenario.py
@@ -28,7 +28,7 @@ SUBSETS = [
 def get_raft_prompt_settings(subset: str, cache_dir: str):
     assert subset in SUBSETS, "Unknown subset: {}".format(subset)
 
-    prompt_construction_settings_path = os.path.join(cache_dir, "raft_prompt_construction_settings.json")
+    prompt_construction_settings_path = os.path.join(cache_dir, "prompt_construction_settings.json")
     ensure_directory_exists(cache_dir)
     ensure_file_downloaded(
         source_url=PROMPT_SETTINGS_URL,

--- a/src/helm/benchmark/scenarios/raft_scenario.py
+++ b/src/helm/benchmark/scenarios/raft_scenario.py
@@ -1,7 +1,6 @@
 import random
 import os
 import json
-import tempfile
 import datasets
 from pathlib import Path
 from typing import List, Dict
@@ -26,11 +25,8 @@ SUBSETS = [
 ]
 
 
-def get_raft_prompt_settings(subset: str, cache_dir=None):
+def get_raft_prompt_settings(subset: str, cache_dir: str):
     assert subset in SUBSETS, "Unknown subset: {}".format(subset)
-
-    if cache_dir is None:
-        cache_dir = tempfile.gettempdir()
 
     prompt_construction_settings_path = os.path.join(cache_dir, "raft_prompt_construction_settings.json")
     ensure_directory_exists(cache_dir)
@@ -44,7 +40,7 @@ def get_raft_prompt_settings(subset: str, cache_dir=None):
     return field_ordering[subset], instructions[subset]
 
 
-def get_raft_instructions(subset: str, cache_dir=None):
+def get_raft_instructions(subset: str, cache_dir: str):
     return get_raft_prompt_settings(subset, cache_dir)[1]
 
 

--- a/src/helm/benchmark/scenarios/scenario.py
+++ b/src/helm/benchmark/scenarios/scenario.py
@@ -1,12 +1,13 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, replace
 from typing import List, Optional, Tuple
+import os
 from pathlib import PurePath
 import inspect
 
 from helm.common.media_object import MultimediaObject
 from helm.common.object_spec import ObjectSpec, create_object
-from helm.common.general import format_text, format_split, format_tags, indent_lines
+from helm.common.general import ensure_directory_exists, format_text, format_split, format_tags, indent_lines
 from helm.benchmark.augmentations.perturbation_description import PerturbationDescription
 
 """ Data splits """
@@ -249,3 +250,10 @@ class ScenarioSpec(ObjectSpec):
 def create_scenario(scenario_spec: ScenarioSpec) -> Scenario:
     """Construct the scenario and set some fields."""
     return create_object(scenario_spec)
+
+
+def get_scenario_cache_path(benchmark_output_path: str, scenario_name: str):
+    """Return a directory under benchmark_output_path in which Scenario can cache temporary data."""
+    scenarios_path: str = os.path.join(benchmark_output_path, "scenarios", scenario_name)
+    ensure_directory_exists(scenarios_path)
+    return scenarios_path


### PR DESCRIPTION
This fixes two problems:

- RAFT and LegalBench sometimes both use the same cache folder, as noted in #2075
- RAFT, LegalBench, CLEVA and BIG-Bench run spec functions and scenarios don't respect the `--output-path` flag