### PR TITLE
Add tokenizer config path argument

### DIFF
--- a/src/helm/benchmark/model_deployment_registry.py
+++ b/src/helm/benchmark/model_deployment_registry.py
@@ -115,12 +115,14 @@ def register_model_deployment(model_deployment: ModelDeployment) -> None:
 
 
 def register_model_deployments_from_path(path: str) -> None:
+    global DEPLOYMENTS_REGISTERED
     hlog(f"Reading model deployments from {path}...")
     with open(path, "r") as f:
         raw = yaml.safe_load(f)
     model_deployments: ModelDeployments = cattrs.structure(raw, ModelDeployments)
     for model_deployment in model_deployments.model_deployments:
         register_model_deployment(model_deployment)
+    DEPLOYMENTS_REGISTERED = True
 
 
 def maybe_register_model_deployments_from_base_path(path: str) -> None:
@@ -178,8 +180,6 @@ def get_model_names_with_tokenizer(tokenizer_name: str) -> List[str]:
 
 
 def register_deployments_if_not_already_registered() -> None:
-    global DEPLOYMENTS_REGISTERED
     if not DEPLOYMENTS_REGISTERED:
         path: str = resources.files(CONFIG_PACKAGE).joinpath(MODEL_DEPLOYMENTS_FILE)
         maybe_register_model_deployments_from_base_path(path)
-        DEPLOYMENTS_REGISTERED = True

--- a/src/helm/benchmark/model_metadata_registry.py
+++ b/src/helm/benchmark/model_metadata_registry.py
@@ -126,6 +126,7 @@ MODEL_NAME_TO_MODEL_METADATA: Dict[str, ModelMetadata] = {model.name: model for 
 # ===================== REGISTRATION FUNCTIONS ==================== #
 def register_model_metadata_from_path(path: str) -> None:
     """Register model configurations from the given path."""
+    global METADATAS_REGISTERED
     with open(path, "r") as f:
         raw = yaml.safe_load(f)
     # Using dacite instead of cattrs because cattrs doesn't have a default
@@ -133,6 +134,7 @@ def register_model_metadata_from_path(path: str) -> None:
     model_metadata_list = dacite.from_dict(ModelMetadataList, raw)
     for model_metadata in model_metadata_list.models:
         register_model_metadata(model_metadata)
+    METADATAS_REGISTERED = True
 
 
 def register_model_metadata(model_metadata: ModelMetadata) -> None:
@@ -201,11 +203,9 @@ def get_all_instruction_following_models() -> List[str]:
 
 
 def register_metadatas_if_not_already_registered() -> None:
-    global METADATAS_REGISTERED
     if not METADATAS_REGISTERED:
         path: str = resources.files(CONFIG_PACKAGE).joinpath(MODEL_METADATA_FILE)
         maybe_register_model_metadata_from_base_path(path)
-        METADATAS_REGISTERED = True
 
 
 def get_default_model_metadata(helm_model_name: str) -> ModelMetadata:

--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -14,6 +14,7 @@ from helm.proxy.services.remote_service import create_authentication, add_servic
 
 from helm.benchmark.model_metadata_registry import register_model_metadata_from_path
 from helm.benchmark.model_deployment_registry import register_model_deployments_from_path
+from helm.benchmark.tokenizer_config_registry import register_tokenizer_configs_from_path
 from helm.benchmark.config_registry import register_helm_configurations
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark import vlm_run_specs  # noqa
@@ -257,6 +258,12 @@ def main():
         help="Experimental: Where to read model deployments from",
         default=[],
     )
+    parser.add_argument(
+        "--tokenizer-configs-paths",
+        nargs="+",
+        help="Experimental: Where to read tokenizer configurations from",
+        default=[],
+    )
     add_run_args(parser)
     args = parser.parse_args()
     validate_args(args)
@@ -269,6 +276,8 @@ def main():
         register_model_metadata_from_path(model_metadata_path)
     for model_deployment_paths in args.model_deployment_paths:
         register_model_deployments_from_path(model_deployment_paths)
+    for tokenizer_configs_paths in args.tokenizer_configs_paths:
+        register_tokenizer_configs_from_path(tokenizer_configs_paths)
 
     run_entries: List[RunEntry] = []
     if args.conf_paths:

--- a/src/helm/benchmark/tokenizer_config_registry.py
+++ b/src/helm/benchmark/tokenizer_config_registry.py
@@ -51,12 +51,14 @@ def register_tokenizer_config(tokenizer_config: TokenizerConfig) -> None:
 
 
 def register_tokenizer_configs_from_path(path: str) -> None:
+    global TOKENIZERS_REGISTERED
     hlog(f"Reading tokenizer configs from {path}...")
     with open(path, "r") as f:
         raw = yaml.safe_load(f)
     tokenizer_configs: TokenizerConfigs = cattrs.structure(raw, TokenizerConfigs)
     for tokenizer_config in tokenizer_configs.tokenizer_configs:
         register_tokenizer_config(tokenizer_config)
+    TOKENIZERS_REGISTERED = True
 
 
 def maybe_register_tokenizer_configs_from_base_path(path: str) -> None:
@@ -71,8 +73,6 @@ def get_tokenizer_config(name: str) -> Optional[TokenizerConfig]:
 
 
 def register_tokenizers_if_not_already_registered() -> None:
-    global TOKENIZERS_REGISTERED
     if not TOKENIZERS_REGISTERED:
         path: str = resources.files(CONFIG_PACKAGE).joinpath(TOKENIZER_CONFIGS_FILE)
         maybe_register_tokenizer_configs_from_base_path(path)
-        TOKENIZERS_REGISTERED = True


### PR DESCRIPTION
The possibility of modifying two out of the tree config files was added in [PR 1761](https://github.com/stanford-crfm/helm/pull/1761), however the tokenizer configuration was left out (not sure why). I believe that we should enable the user to select a custom `tokenizer_configs.yaml` file by means of a new parameter:

```bash
    --tokenizer-configs-paths tokenizer_configs.yaml
```

In my particular case this is required to enable the separation of the tokenizer endpoint from the model endpoint. By means of the PR, the user will be able to do the following:

1- Set a tokenizer and model deployment config:
```bash
    --tokenizer-configs-paths tokenizer_configs.yaml
    --model-deployment-paths model_deployments.yaml
```

2- Assign different urls to each endpoint:
(model_deployments.yaml)
```yaml
model_deployments:
  - name: neurips/local
    model_name: neurips/local
    tokenizer_name: neurips/local
    max_sequence_length: 2048
    client_spec:
      class_name: "helm.proxy.clients.http_model_client.HTTPModelClient"
      args: {
        base_url: "http://192.168.1.1:8080"
      }
    window_service_spec:
      class_name: "helm.benchmark.window_services.http_model_window_service.HTTPModelWindowService"
      args: {}
```

(tokenizer_configs.yaml)
```yaml
tokenizer_configs:
  - name: neurips/local
    tokenizer_spec:
      class_name: "helm.proxy.tokenizers.http_model_tokenizer.HTTPModelTokenizer"
      args: {
        base_url: "http://192.168.1.2:8080"
      }
    end_of_text_token: "<|endoftext|>"
    prefix_token: "<|endoftext|>"
```

Note: The other way of changing the URL is through the `HELM_HTTP_MODEL_BASE_URL` environment variable, but this changes both the model and the tokenizer URL which not what I required.
