### PR TITLE
Start to break CommonSenseScenario into smaller chunks.

### DIFF
--- a/src/helm/benchmark/run_specs.py
+++ b/src/helm/benchmark/run_specs.py
@@ -5,6 +5,7 @@ from functools import partial
 from typing import Any, Callable, List, Dict, Optional, Set, TypeVar
 
 from helm.benchmark.model_deployment_registry import ALL_MODEL_DEPLOYMENTS, DEPLOYMENT_NAME_TO_MODEL_DEPLOYMENT
+from helm.benchmark.scenarios.commonsense_scenario import HellaSwagScenario, OpenBookQA
 from helm.common.hierarchical_logger import hlog, htrack
 from helm.common.object_spec import ObjectSpec
 from helm.benchmark.adaptation.adapters.adapter_factory import (
@@ -990,10 +991,17 @@ def get_wikifact_spec(k: str, subject: str) -> RunSpec:
 
 @run_spec_function("commonsense")
 def get_commonsense_spec(dataset: str, method: str) -> RunSpec:
-    scenario_spec = ScenarioSpec(
-        class_name="helm.benchmark.scenarios.commonsense_scenario.CommonSenseScenario",
-        args={"dataset": dataset},
-    )
+    if dataset == HellaSwagScenario.name:
+        scenario_spec = ScenarioSpec(
+            class_name="helm.benchmark.scenarios.commonsense_scenario.HellaSwagScenario", args={}
+        )
+    elif dataset == OpenBookQA.name:
+        scenario_spec = ScenarioSpec(class_name="helm.benchmark.scenarios.commonsense_scenario.OpenBookQA", args={})
+    else:
+        scenario_spec = ScenarioSpec(
+            class_name="helm.benchmark.scenarios.commonsense_scenario.CommonSenseScenario",
+            args={"dataset": dataset},
+        )
 
     adapter_spec = get_multiple_choice_adapter_spec(
         method=method,

--- a/src/helm/benchmark/scenarios/commonsense_scenario.py
+++ b/src/helm/benchmark/scenarios/commonsense_scenario.py
@@ -17,6 +17,103 @@ from .scenario import (
 )
 
 
+_SPLIT_TRANSLATION = {
+    "train": TRAIN_SPLIT,
+    "val": VALID_SPLIT,
+    "test": TEST_SPLIT,
+}
+
+
+def _make_instance(question: str, answers: List[str], correct_answer: str, split: str):
+    references = []
+    for answer in answers:
+        references.append(Reference(Output(text=answer), tags=[CORRECT_TAG] if answer == correct_answer else []))
+    return Instance(
+        input=Input(text=question),
+        references=references,
+        split=_SPLIT_TRANSLATION[split],
+    )
+
+
+class HellaswagScenario(Scenario):
+    name = "hellaswag"
+    description = "Benchmark from https://arxiv.org/pdf/1905.07830.pdf."
+    tags = ["knowledge", "multiple_choice"]
+
+    def get_instances(self, output_path: str) -> List[Instance]:
+        # Download the raw data
+        data_path = os.path.join(output_path, "data", "hellaswag")
+        ensure_directory_exists(data_path)
+
+        instances = []
+        base_url = "https://raw.githubusercontent.com/rowanz/hellaswag/master/data/hellaswag_{}.jsonl"
+        # Ignore HellaSwag test set because no label information
+        for split in ["train", "val"]:
+            file_path = os.path.join(data_path, f"hellaswag_{split}.jsonl")
+            ensure_file_downloaded(
+                source_url=base_url.format(split),
+                target_path=file_path,
+            )
+            hlog(f"Reading {file_path}")
+            with open(file_path) as f:
+                for line in f:
+                    item = json.loads(line)
+                    instances.append(self.json_to_instance(item, split))
+        return instances
+
+    @staticmethod
+    def json_to_instance(item, split) -> Instance:
+        ctx_b_fixed = item["ctx_b"][0].upper() + item["ctx_b"][1:] if len(item["ctx_b"]) != 0 else ""
+
+        question = f"{item['activity_label']}: {item['ctx_a']} {ctx_b_fixed}"
+        answers = item["endings"]
+        correct_answer = answers[item["label"]]
+
+        assert len(answers) == 4
+        return _make_instance(question=question, answers=answers, correct_answer=correct_answer, split=split)
+
+
+class OpenBookQA(Scenario):
+    name = "openbookqa"
+    description = "Benchmark from https://aclanthology.org/D18-1260.pdf."
+    tags = ["knowledge", "multiple_choice"]
+
+    def get_instances(self, output_path: str):
+        # Download the raw data
+        data_path = os.path.join(output_path, "data", "openbookqa")
+        ensure_directory_exists(data_path)
+
+        ensure_file_downloaded(
+            source_url="https://ai2-public-datasets.s3.amazonaws.com/open-book-qa/OpenBookQA-V1-Sep2018.zip",
+            target_path=os.path.join(data_path, "OpenBookQA-V1-Sep2018"),
+            unpack=True,
+            unpack_type="unzip",
+        )
+
+        instances = []
+        for split in ["train", "test"]:
+            file_path = os.path.join(data_path, "OpenBookQA-V1-Sep2018", "Data", "Main", f"{split}.jsonl")
+            hlog(f"Reading {file_path}")
+            with open(file_path) as f:
+                for line in f:
+                    item = json.loads(line)
+                    instances.append(self.json_to_instance(item, split))
+        return instances
+
+    @staticmethod
+    def json_to_instance(item, split) -> Instance:
+        letter2idx = {"A": 0, "B": 1, "C": 2, "D": 3}
+
+        question = item["question"]["stem"]
+        answers = [answer["text"] for answer in item["question"]["choices"]]
+        correct_choice = letter2idx[item["answerKey"]]
+        correct_answer = answers[correct_choice]
+
+        assert len(answers) == 4
+        assert item["question"]["choices"][correct_choice]["label"] == item["answerKey"]
+        return _make_instance(question=question, answers=answers, correct_answer=correct_answer, split=split)
+
+
 class CommonSenseScenario(Scenario):
     """
     Unified interface for all CommonSense scenarios.
@@ -45,30 +142,6 @@ class CommonSenseScenario(Scenario):
         super().__init__()
         self.dataset = dataset
         assert self.dataset in ["hellaswag", "openbookqa", "commonsenseqa", "piqa", "siqa"]
-
-    @staticmethod
-    def process_hellaswag_item(item):
-        ctx_b_fixed = item["ctx_b"][0].upper() + item["ctx_b"][1:] if len(item["ctx_b"]) != 0 else ""
-
-        question = f"{item['activity_label']}: {item['ctx_a']} {ctx_b_fixed}"
-        answers = item["endings"]
-        correct_answer = answers[item["label"]]
-
-        assert len(answers) == 4
-        return question, answers, correct_answer
-
-    @staticmethod
-    def process_openbookqa_item(item):
-        letter2idx = {"A": 0, "B": 1, "C": 2, "D": 3}
-
-        question = item["question"]["stem"]
-        answers = [answer["text"] for answer in item["question"]["choices"]]
-        correct_choice = letter2idx[item["answerKey"]]
-        correct_answer = answers[correct_choice]
-
-        assert len(answers) == 4
-        assert item["question"]["choices"][correct_choice]["label"] == item["answerKey"]
-        return question, answers, correct_answer
 
     @staticmethod
     def process_commonsenseqa_item(item):
@@ -110,21 +183,7 @@ class CommonSenseScenario(Scenario):
         data_path = os.path.join(output_path, "data", self.dataset)
         ensure_directory_exists(data_path)
 
-        if self.dataset == "hellaswag":
-            url = "https://raw.githubusercontent.com/rowanz/hellaswag/master/data/hellaswag_{}.jsonl"
-            for split in ["train", "val", "test"]:
-                ensure_file_downloaded(
-                    source_url=url.format(split),
-                    target_path=os.path.join(data_path, f"hellaswag_{split}.jsonl"),
-                )
-        elif self.dataset == "openbookqa":
-            ensure_file_downloaded(
-                source_url="https://ai2-public-datasets.s3.amazonaws.com/open-book-qa/OpenBookQA-V1-Sep2018.zip",
-                target_path=os.path.join(data_path, "OpenBookQA-V1-Sep2018"),
-                unpack=True,
-                unpack_type="unzip",
-            )
-        elif self.dataset == "commonsenseqa":
+        if self.dataset == "commonsenseqa":
             url = "https://s3.amazonaws.com/commensenseqa/{}_rand_split.jsonl"
             split_mapping = {"train": "train", "val": "dev"}
             for split in ["train", "val"]:
@@ -192,18 +251,7 @@ class CommonSenseScenario(Scenario):
     def load_dataset(self, output_path: str) -> List[List[str]]:
         data_path = os.path.join(output_path, "data", self.dataset)
 
-        if self.dataset == "hellaswag":
-            split_to_file = {
-                split: os.path.join(data_path, f"hellaswag_{split}.jsonl") for split in ["train", "val"]
-            }  # Ignore HellaSwag test set because no label information
-            item_process_func = self.process_hellaswag_item
-        elif self.dataset == "openbookqa":
-            split_to_file = {
-                split: os.path.join(data_path, "OpenBookQA-V1-Sep2018", "Data", "Main", f"{split}.jsonl")
-                for split in ["train", "test"]
-            }
-            item_process_func = self.process_openbookqa_item
-        elif self.dataset == "commonsenseqa":
+        if self.dataset == "commonsenseqa":
             split_to_file = {
                 split: os.path.join(data_path, f"commonsenseqa_{split}.jsonl") for split in ["train", "val"]
             }  # Ignore CommonSenseQA test set because no label information
@@ -236,14 +284,12 @@ class CommonSenseScenario(Scenario):
         return data
 
     def get_instances(self, output_path: str) -> List[Instance]:
+        if self.dataset == "hellaswag":
+            return HellaswagScenario().get_instances(output_path)
+        if self.dataset == "openbookqa":
+            return OpenBookQA().get_instances(output_path)
         self.download_dataset(output_path)
         data = self.load_dataset(output_path)
-
-        splits = {
-            "train": TRAIN_SPLIT,
-            "val": VALID_SPLIT,
-            "test": TEST_SPLIT,
-        }
 
         instances: List[Instance] = []
 
@@ -254,7 +300,7 @@ class CommonSenseScenario(Scenario):
             instance = Instance(
                 input=Input(text=question),
                 references=list(map(answer_to_reference, answers)),
-                split=splits[split],
+                split=_SPLIT_TRANSLATION[split],
             )
             instances.append(instance)
         return instances

--- a/src/helm/benchmark/scenarios/commonsense_scenario.py
+++ b/src/helm/benchmark/scenarios/commonsense_scenario.py
@@ -35,14 +35,14 @@ def _make_instance(question: str, answers: List[str], correct_answer: str, split
     )
 
 
-class HellaswagScenario(Scenario):
+class HellaSwagScenario(Scenario):
     name = "hellaswag"
     description = "Benchmark from https://arxiv.org/pdf/1905.07830.pdf."
     tags = ["knowledge", "multiple_choice"]
 
     def get_instances(self, output_path: str) -> List[Instance]:
         # Download the raw data
-        data_path = os.path.join(output_path, "data", "hellaswag")
+        data_path = os.path.join(output_path, "data")
         ensure_directory_exists(data_path)
 
         instances = []
@@ -80,7 +80,7 @@ class OpenBookQA(Scenario):
 
     def get_instances(self, output_path: str):
         # Download the raw data
-        data_path = os.path.join(output_path, "data", "openbookqa")
+        data_path = os.path.join(output_path, "data")
         ensure_directory_exists(data_path)
 
         ensure_file_downloaded(
@@ -284,10 +284,6 @@ class CommonSenseScenario(Scenario):
         return data
 
     def get_instances(self, output_path: str) -> List[Instance]:
-        if self.dataset == "hellaswag":
-            return HellaswagScenario().get_instances(output_path)
-        if self.dataset == "openbookqa":
-            return OpenBookQA().get_instances(output_path)
         self.download_dataset(output_path)
         data = self.load_dataset(output_path)
 

--- a/src/helm/benchmark/scenarios/commonsense_scenario.py
+++ b/src/helm/benchmark/scenarios/commonsense_scenario.py
@@ -118,12 +118,6 @@ class CommonSenseScenario(Scenario):
     """
     Unified interface for all CommonSense scenarios.
 
-    - The "HellaSwag" benchmark from this paper:
-      https://arxiv.org/pdf/1905.07830.pdf
-
-    - The "OpenBookQA" benchmark from this paper:
-      https://aclanthology.org/D18-1260.pdf
-
     - The "CommonSenseQA" benchmark from this paper:
       https://arxiv.org/pdf/1811.00937.pdf
 
@@ -141,7 +135,7 @@ class CommonSenseScenario(Scenario):
     def __init__(self, dataset):
         super().__init__()
         self.dataset = dataset
-        assert self.dataset in ["hellaswag", "openbookqa", "commonsenseqa", "piqa", "siqa"]
+        assert self.dataset in ["commonsenseqa", "piqa", "siqa"]
 
     @staticmethod
     def process_commonsenseqa_item(item):


### PR DESCRIPTION
In most cases, each Scenario represents a single source of data. For example, in almost all cases each Scenario has just one line using `ensure_file_downloaded`, often in a loop tweaking minor parts of the URL. However, each of `CommonSenseScenario`'s 5 datasets get data from different hosts. Two are zipped, and two appear to store labels in separate files. All 5 have different json structures.

I think we can simplify the code and make Scenario more uniform by breaking up `CommonSenseScenario`. This PR demonstrates pulling out HellaSwag and OpenBookQA. If we generally like where this is going, I can do the rest. If there is a strong reason to keep them as a single Scenario, please let me know so I can better understand the usecase.

For now I'm maintaining the ability to access all the datasets through `CommonSenseScenario`. 