### PR TITLE
Add lock to AnthropicTokenizer

### DIFF
--- a/src/helm/proxy/tokenizers/anthropic_tokenizer.py
+++ b/src/helm/proxy/tokenizers/anthropic_tokenizer.py
@@ -15,6 +15,9 @@ except ModuleNotFoundError as e:
 
 class AnthropicTokenizer(CachingTokenizer):
     LOCK: threading.Lock = threading.Lock()
+    """Global lock for the Anthropic tokenizer.
+
+    The Anthropic tokenizer is a wrapper around a single global Hugging Face tokenizer, which is thread-hostile."""
 
     def __init__(self, cache_config: CacheConfig) -> None:
         super().__init__(cache_config)

--- a/src/helm/proxy/tokenizers/anthropic_tokenizer.py
+++ b/src/helm/proxy/tokenizers/anthropic_tokenizer.py
@@ -26,21 +26,24 @@ class AnthropicTokenizer(CachingTokenizer):
     def _tokenize_do_it(self, request: Dict[str, Any]) -> Dict[str, Any]:
         if request["encode"]:
             if request["truncation"]:
-                tokens = self._tokenizer.encode(
-                    request["text"],
-                    truncation=request["truncation"],
-                    max_length=request["max_length"],
-                    add_special_tokens=False,
-                )
+                with AnthropicTokenizer.LOCK:
+                    tokens = self._tokenizer.encode(
+                        request["text"],
+                        truncation=request["truncation"],
+                        max_length=request["max_length"],
+                        add_special_tokens=False,
+                    )
             else:
-                tokens = self._tokenizer.encode(request["text"], add_special_tokens=False)
+                with AnthropicTokenizer.LOCK:
+                    tokens = self._tokenizer.encode(request["text"], add_special_tokens=False)
         else:
             # No encoding, just return the token strings
             tokens = [self._tokenizer.convert_tokens_to_string([i]) for i in self._tokenizer.tokenize(request["text"])]
         return {"tokens": tokens}
 
     def _decode_do_it(self, request: Dict[str, Any]) -> Dict[str, Any]:
-        text = self._tokenizer.decode(
-            request["tokens"], clean_up_tokenization_spaces=request["clean_up_tokenization_spaces"]
-        )
+        with AnthropicTokenizer.LOCK:
+            text = self._tokenizer.decode(
+                request["tokens"], clean_up_tokenization_spaces=request["clean_up_tokenization_spaces"]
+            )
         return {"text": text}

--- a/src/helm/proxy/tokenizers/test_anthropic_tokenizer.py
+++ b/src/helm/proxy/tokenizers/test_anthropic_tokenizer.py
@@ -3,6 +3,7 @@ import tempfile
 from typing import List
 
 from helm.common.cache import SqliteCacheConfig
+from helm.common.general import parallel_map
 from helm.common.tokenization_request import (
     DecodeRequest,
     DecodeRequestResult,
@@ -26,7 +27,7 @@ class TestAnthropicTokenizer:
         os.remove(self.cache_path)
 
     def test_tokenize(self):
-        request = TokenizationRequest(text=self.TEST_PROMPT)
+        request = TokenizationRequest(text=self.TEST_PROMPT, tokenizer="anthropic/claude")
         result: TokenizationRequestResult = self.tokenizer.tokenize(request)
         assert not result.cached, "First time making the tokenize request. Result should not be cached"
         assert result.raw_tokens == self.TEST_TOKENS
@@ -35,7 +36,9 @@ class TestAnthropicTokenizer:
         assert result.raw_tokens == self.TEST_TOKENS
 
     def test_encode(self):
-        request = TokenizationRequest(text=self.TEST_PROMPT, encode=True, truncation=True, max_length=1)
+        request = TokenizationRequest(
+            text=self.TEST_PROMPT, tokenizer="anthropic/claude", encode=True, truncation=True, max_length=1
+        )
         result: TokenizationRequestResult = self.tokenizer.tokenize(request)
         assert not result.cached, "First time making the tokenize request. Result should not be cached"
         assert result.raw_tokens == [self.TEST_ENCODED[0]]
@@ -43,16 +46,37 @@ class TestAnthropicTokenizer:
         assert result.cached, "Result should be cached"
         assert result.raw_tokens == [self.TEST_ENCODED[0]]
 
-        request = TokenizationRequest(text=self.TEST_PROMPT, encode=True, truncation=True, max_length=1024)
+        request = TokenizationRequest(
+            text=self.TEST_PROMPT, tokenizer="anthropic/claude", encode=True, truncation=True, max_length=1024
+        )
         result = self.tokenizer.tokenize(request)
         assert not result.cached, "First time making this particular request. Result should not be cached"
         assert result.raw_tokens == self.TEST_ENCODED
 
     def test_decode(self):
-        request = DecodeRequest(tokens=self.TEST_ENCODED)
+        request = DecodeRequest(tokens=self.TEST_ENCODED, tokenizer="anthropic/claude")
         result: DecodeRequestResult = self.tokenizer.decode(request)
         assert not result.cached, "First time making the decode request. Result should not be cached"
         assert result.text == self.TEST_PROMPT
         result = self.tokenizer.decode(request)
         assert result.cached, "Result should be cached"
         assert result.text == self.TEST_PROMPT
+
+    def test_already_borrowed(self):
+        """Test workaround of the "Already borrowed" bug (#1421) caused by the thread-hostile Anthropic tokenizer,
+        which is a thin wrapper around a Hugging Face FastTokenizer"""
+
+        def make_tokenize_request(seed: int) -> None:
+            request_length = 10
+            truncation = bool(seed % 2)
+            self.tokenizer.tokenize(
+                # The truncation parameter requires setting a flag on the Rust FastTokenizer.
+                # Concurrent requests cause concurrent mutations, which results an Rust concurrency error.
+                TokenizationRequest(
+                    text=str(seed) * request_length, tokenizer="anthropic/claude", encode=True, truncation=truncation
+                )
+            )
+
+        num_requests = 100
+        # Should not raise "Already borrowed" error
+        parallel_map(make_tokenize_request, list(range(num_requests)), parallelism=8)


### PR DESCRIPTION
Add a global lock for the Anthropic tokenizer.
    
The Anthropic tokenizer is a wrapper around a single global Hugging Face tokenizer, which is thread-hostile.

Fixes #1421