### PR TITLE
Set name in tokenizer requests correctly

### DIFF
--- a/scripts/cache/fix_anthropic_cache.py
+++ b/scripts/cache/fix_anthropic_cache.py
@@ -8,7 +8,6 @@ from helm.common.general import parse_hocon
 from helm.common.hierarchical_logger import hlog, htrack
 from helm.proxy.clients.anthropic_client import AnthropicLegacyClient
 from helm.proxy.retry import get_retry_decorator
-from helm.proxy.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer
 
 
 """
@@ -48,9 +47,7 @@ def add_logprobs(mongo_uri: str, credentials_path: str, dry_run: bool):
         api_key: str = credentials["anthropicApiKey"]
 
     cache_config = MongoCacheConfig(mongo_uri, collection_name="anthropic")
-    client = AnthropicLegacyClient(
-        api_key=api_key, tokenizer=HuggingFaceTokenizer(cache_config), cache_config=cache_config
-    )
+    client = AnthropicLegacyClient(api_key=api_key, cache_config=cache_config)
 
     with create_key_value_store(cache_config) as cache:
         for i, (request, response) in enumerate(cache.get_all()):

--- a/src/helm/common/tokenization_request.py
+++ b/src/helm/common/tokenization_request.py
@@ -19,7 +19,7 @@ class TokenizationRequest:
     text: str
 
     # Which tokenizer we should use
-    tokenizer: str = "huggingface/gpt2"
+    tokenizer: str
 
     # Whether to encode
     encode: bool = False

--- a/src/helm/proxy/clients/anthropic_client.py
+++ b/src/helm/proxy/clients/anthropic_client.py
@@ -56,9 +56,12 @@ class AnthropicClient(CachingClient):
     ADDITIONAL_TOKENS: int = 5
     PROMPT_ANSWER_START: str = "The answer is "
 
-    def __init__(self, tokenizer: Tokenizer, cache_config: CacheConfig, api_key: Optional[str] = None):
+    def __init__(
+        self, tokenizer: Tokenizer, tokenizer_name: str, cache_config: CacheConfig, api_key: Optional[str] = None
+    ):
         super().__init__(cache_config=cache_config)
         self.tokenizer = tokenizer
+        self.tokenizer_name = tokenizer_name
         self.api_key: Optional[str] = api_key
         self._client = anthropic.Client(api_key) if api_key else None
 
@@ -165,7 +168,7 @@ class AnthropicClient(CachingClient):
             # The Anthropic API doesn't return us tokens or logprobs, so we tokenize ourselves.
             tokenization_result: TokenizationRequestResult = self.tokenizer.tokenize(
                 # Anthropic uses their own tokenizer
-                TokenizationRequest(text, tokenizer=request.model_engine)
+                TokenizationRequest(text, tokenizer=self.tokenizer_name)
             )
 
             # Log probs are not currently not supported by the Anthropic, so set to 0 for now.
@@ -240,7 +243,7 @@ class AnthropicLegacyClient(CachingClient):
             hlog(f"Invalid logprobs response: {raw_response}")
             return False
 
-    def __init__(self, api_key: str, tokenizer: Tokenizer, cache_config: CacheConfig):
+    def __init__(self, api_key: str, cache_config: CacheConfig):
         hlog("This client is deprecated. Please use AnthropicClient instead.")
         super().__init__(cache_config=cache_config)
         self.api_key = api_key

--- a/src/helm/proxy/clients/auto_client.py
+++ b/src/helm/proxy/clients/auto_client.py
@@ -68,7 +68,7 @@ class AutoClient(Client):
 
             client_spec = inject_object_spec_args(
                 model_deployment.client_spec,
-                constant_bindings={"cache_config": cache_config},
+                constant_bindings={"cache_config": cache_config, "tokenizer_name": model_deployment.tokenizer_name},
                 provider_bindings={
                     "api_key": lambda: provide_api_key(self.credentials, host_organization, model_deployment_name),
                     "tokenizer": lambda: self._auto_tokenizer._get_tokenizer(

--- a/src/helm/proxy/clients/lit_gpt_client.py
+++ b/src/helm/proxy/clients/lit_gpt_client.py
@@ -89,6 +89,7 @@ class LitGPTClient(CachingClient):
     def __init__(
         self,
         tokenizer: Tokenizer,
+        tokenizer_name: str,
         cache_config: CacheConfig,
         checkpoint_dir: Path = Path(""),
         precision: str = "bf16-true",

--- a/src/helm/proxy/clients/megatron_client.py
+++ b/src/helm/proxy/clients/megatron_client.py
@@ -26,9 +26,10 @@ class MegatronClient(CachingClient):
     https://github.com/NVIDIA/Megatron-LM#gpt-text-generation
     """
 
-    def __init__(self, tokenizer: Tokenizer, cache_config: CacheConfig):
+    def __init__(self, tokenizer: Tokenizer, tokenizer_name: str, cache_config: CacheConfig):
         super().__init__(cache_config=cache_config)
         self.tokenizer = tokenizer
+        self.tokenizer_name = tokenizer_name
 
     def _send_request(self, raw_request: Dict[str, Any]) -> Dict[str, Any]:
         response = requests.request(
@@ -48,7 +49,7 @@ class MegatronClient(CachingClient):
         return out
 
     def _tokenize_response(self, text: str) -> List[Token]:
-        tokenized_text = self.tokenizer.tokenize(TokenizationRequest(text, tokenizer="huggingface/gpt2"))
+        tokenized_text = self.tokenizer.tokenize(TokenizationRequest(text, tokenizer=self.tokenizer_name))
 
         # TODO(tgale): Support logprobs.
         tokens = [Token(text=str(token), logprob=0, top_logprobs={}) for token in tokenized_text.raw_tokens]

--- a/src/helm/proxy/clients/openai_client.py
+++ b/src/helm/proxy/clients/openai_client.py
@@ -15,7 +15,6 @@ from .client import CachingClient, truncate_sequence
 
 try:
     import openai
-    import tiktoken
 except ModuleNotFoundError as e:
     handle_module_not_found_error(e, ["openai"])
 
@@ -29,12 +28,14 @@ class OpenAIClient(CachingClient):
     def __init__(
         self,
         tokenizer: Tokenizer,
+        tokenizer_name: str,
         cache_config: CacheConfig,
         api_key: Optional[str] = None,
         org_id: Optional[str] = None,
     ):
         super().__init__(cache_config=cache_config)
         self.tokenizer = tokenizer
+        self.tokenizer_name = tokenizer_name
         self.org_id: Optional[str] = org_id
         self.api_key: Optional[str] = api_key
         self.api_base: str = "https://api.openai.com/v1"
@@ -156,9 +157,7 @@ class OpenAIClient(CachingClient):
                 text: str = request.prompt + raw_completion_content if request.echo_prompt else raw_completion_content
                 # The OpenAI chat completion API doesn't return us tokens or logprobs, so we tokenize ourselves.
                 tokenization_result: TokenizationRequestResult = self.tokenizer.tokenize(
-                    TokenizationRequest(
-                        text, tokenizer="openai/" + tiktoken.encoding_for_model(request.model_engine).name
-                    )
+                    TokenizationRequest(text, tokenizer=self.tokenizer_name)
                 )
                 # Log probs are not currently not supported by the OpenAI chat completion API, so set to 0 for now.
                 tokens = [

--- a/src/helm/proxy/clients/palmyra_client.py
+++ b/src/helm/proxy/clients/palmyra_client.py
@@ -28,10 +28,11 @@ def _is_content_moderation_failure(response: Dict) -> bool:
 
 
 class PalmyraClient(CachingClient):
-    def __init__(self, tokenizer: Tokenizer, cache_config: CacheConfig, api_key: str):
+    def __init__(self, tokenizer: Tokenizer, tokenizer_name: str, cache_config: CacheConfig, api_key: str):
         super().__init__(cache_config=cache_config)
         self.api_key: str = api_key
         self.tokenizer = tokenizer
+        self.tokenizer_name = tokenizer_name
 
     def _send_request(self, model_name: str, raw_request: Dict[str, Any]) -> Dict[str, Any]:
         response = requests.request(
@@ -123,7 +124,7 @@ class PalmyraClient(CachingClient):
             # The Writer API doesn't return us tokens or logprobs, so we tokenize ourselves.
             tokenization_result: TokenizationRequestResult = self.tokenizer.tokenize(
                 # Writer uses the GPT-2 tokenizer
-                TokenizationRequest(text, tokenizer="writer/gpt2")
+                TokenizationRequest(text, tokenizer=self.tokenizer_name)
             )
 
             # Log probs are not currently not supported by the Writer, so set to 0 for now.

--- a/src/helm/proxy/clients/vertexai_client.py
+++ b/src/helm/proxy/clients/vertexai_client.py
@@ -19,11 +19,14 @@ except ModuleNotFoundError as e:
 
 
 class VertexAIClient(CachingClient):
-    def __init__(self, tokenizer: Tokenizer, cache_config: CacheConfig, project_id: str, location: str) -> None:
+    def __init__(
+        self, tokenizer: Tokenizer, tokenizer_name: str, cache_config: CacheConfig, project_id: str, location: str
+    ) -> None:
         super().__init__(cache_config=cache_config)
         self.project_id = project_id
         self.location = location
         self.tokenizer = tokenizer
+        self.tokenizer_name = tokenizer_name
 
         vertexai.init(project=self.project_id, location=self.location)
 
@@ -85,7 +88,7 @@ class VertexAIClient(CachingClient):
             text: str = request.prompt + response_text if request.echo_prompt else response_text
 
             tokenization_result: TokenizationRequestResult = self.tokenizer.tokenize(
-                TokenizationRequest(text, tokenizer="google/mt5-base")
+                TokenizationRequest(text, tokenizer=self.tokenizer_name)
             )
 
             # TODO #2085: Add support for log probs.

--- a/src/helm/proxy/clients/vision_language/idefics_client.py
+++ b/src/helm/proxy/clients/vision_language/idefics_client.py
@@ -54,9 +54,10 @@ class IDEFICSClient(CachingClient):
     END_OF_UTTERANCE_TOKEN: str = "<end_of_utterance>"
     BAD_WORD_TOKENS: List[str] = ["<image>", "<fake_token_around_image>"]
 
-    def __init__(self, tokenizer: Tokenizer, cache_config: CacheConfig):
+    def __init__(self, tokenizer: Tokenizer, tokenizer_name: str, cache_config: CacheConfig):
         super().__init__(cache_config=cache_config)
         self.tokenizer = tokenizer
+        self.tokenizer_name = tokenizer_name
         self._device: str = get_torch_device_name()
 
     def _get_model(self, checkpoint: str) -> LoadedIDEFICSModelProcessor:
@@ -142,7 +143,7 @@ class IDEFICSClient(CachingClient):
         # TODO: Does it make sense to support echo? Include these params in the cache key.
         # TODO: Together might support this model so use the TogetherClient
         tokenization_result: TokenizationRequestResult = self.tokenizer.tokenize(
-            TokenizationRequest(result["output"], tokenizer=request.model)
+            TokenizationRequest(result["output"], tokenizer=self.tokenizer_name)
         )
         tokens: List[Token] = [
             Token(text=str(text), logprob=0, top_logprobs={}) for text in tokenization_result.raw_tokens

--- a/src/helm/proxy/token_counters/openai_token_counter.py
+++ b/src/helm/proxy/token_counters/openai_token_counter.py
@@ -16,7 +16,7 @@ class OpenAITokenCounter(TokenCounter):
         https://community.openai.com/t/how-do-i-calculate-the-pricing-for-generation-of-text/11662/5
         """
         tokenized_prompt: TokenizationRequestResult = self.huggingface_tokenizer.tokenize(
-            TokenizationRequest(request.prompt)
+            TokenizationRequest(request.prompt, tokenizer="huggingface/gpt2")
         )
         # Number of tokens in the prompt + number of tokens in all the completions
         return len(tokenized_prompt.tokens) + sum([len(sequence.tokens) for sequence in completions])

--- a/src/helm/proxy/tokenizers/test_anthropic_tokenizer.py
+++ b/src/helm/proxy/tokenizers/test_anthropic_tokenizer.py
@@ -26,7 +26,7 @@ class TestAnthropicTokenizer:
         os.remove(self.cache_path)
 
     def test_tokenize(self):
-        request = TokenizationRequest(text=self.TEST_PROMPT)
+        request = TokenizationRequest(text=self.TEST_PROMPT, tokenizer="anthropic/claude")
         result: TokenizationRequestResult = self.tokenizer.tokenize(request)
         assert not result.cached, "First time making the tokenize request. Result should not be cached"
         assert result.raw_tokens == self.TEST_TOKENS
@@ -35,7 +35,9 @@ class TestAnthropicTokenizer:
         assert result.raw_tokens == self.TEST_TOKENS
 
     def test_encode(self):
-        request = TokenizationRequest(text=self.TEST_PROMPT, encode=True, truncation=True, max_length=1)
+        request = TokenizationRequest(
+            text=self.TEST_PROMPT, tokenizer="anthropic/claude", encode=True, truncation=True, max_length=1
+        )
         result: TokenizationRequestResult = self.tokenizer.tokenize(request)
         assert not result.cached, "First time making the tokenize request. Result should not be cached"
         assert result.raw_tokens == [self.TEST_ENCODED[0]]
@@ -43,13 +45,15 @@ class TestAnthropicTokenizer:
         assert result.cached, "Result should be cached"
         assert result.raw_tokens == [self.TEST_ENCODED[0]]
 
-        request = TokenizationRequest(text=self.TEST_PROMPT, encode=True, truncation=True, max_length=1024)
+        request = TokenizationRequest(
+            text=self.TEST_PROMPT, tokenizer="anthropic/claude", encode=True, truncation=True, max_length=1024
+        )
         result = self.tokenizer.tokenize(request)
         assert not result.cached, "First time making this particular request. Result should not be cached"
         assert result.raw_tokens == self.TEST_ENCODED
 
     def test_decode(self):
-        request = DecodeRequest(tokens=self.TEST_ENCODED)
+        request = DecodeRequest(tokens=self.TEST_ENCODED, tokenizer="anthropic/claude")
         result: DecodeRequestResult = self.tokenizer.decode(request)
         assert not result.cached, "First time making the decode request. Result should not be cached"
         assert result.text == self.TEST_PROMPT


### PR DESCRIPTION
Previously, `tokenizer` was set incorrectly in some `TokenizationRequest` / `DecodingRequest` objects.