### PR TITLE
Auto filtering functionality for leaderboards

### DIFF
--- a/src/helm-frontend/src/components/LeaderboardTables.tsx
+++ b/src/helm-frontend/src/components/LeaderboardTables.tsx
@@ -12,7 +12,7 @@ interface Props {
   sortFirstMetric?: boolean;
   filtered?: boolean;
   modelsToFilter?: string[];
-  nModelsToAutoFilter?: number;
+  numModelsToAutoFilter?: number;
   filteredCols?: any[];
 }
 
@@ -25,7 +25,7 @@ export default function LeaderboardTables({
   filtered = false,
   filteredCols = [],
   modelsToFilter = [],
-  nModelsToAutoFilter = 0, // if non-zero, sets how many models to filter down to (ranked by first column)
+  numModelsToAutoFilter = 0, // if non-zero, sets how many models to filter down to (ranked by first column)
 }: Props) {
   const [activeSortColumn, setActiveSortColumn] = useState<number | undefined>(
     sortFirstMetric ? 1 : undefined,
@@ -40,17 +40,20 @@ export default function LeaderboardTables({
   useEffect(() => {
     setActiveGroupsTable({ ...groupsTables[activeGroup] });
     // upon receiving and setting data for current table, use sort to figure out n top models
-    if (nModelsToAutoFilter) {
+    if (numModelsToAutoFilter) {
       const activeRows = groupsTables[0].rows;
       const sortedRows = activeRows.sort((a, b) => {
+        // assumes we sort by column 1, which represents Mean Win Rate in the Core Scenarios table
+        // this assumption works as numModelsToAutoFilter is only used in mini leaderboards
+        // which always have one main scenario we sort by
         return Number(b[1].value) - Number(a[1].value);
       });
-      // Get the top N rows
-      const topNRows = sortedRows.slice(0, nModelsToAutoFilter);
-      const topNRowNames = topNRows.map((row) => String(row[0].value));
-      setFilteredModels(topNRowNames);
+      // Get the top ModelsToAutoFilter
+      const topNumRows = sortedRows.slice(0, numModelsToAutoFilter);
+      const topNumRowNames = topNumRows.map((row) => String(row[0].value));
+      setFilteredModels(topNumRowNames);
     }
-  }, [activeGroup, groupsTables, nModelsToAutoFilter]);
+  }, [activeGroup, groupsTables, numModelsToAutoFilter]);
 
   const handleSort = (columnIndex: number) => {
     let sort = sortDirection;

--- a/src/helm-frontend/src/components/MiniLeaderboard.tsx
+++ b/src/helm-frontend/src/components/MiniLeaderboard.tsx
@@ -83,14 +83,7 @@ export default function MiniLeaderboard() {
           activeGroup={activeGroup}
           ignoreHref={true}
           filtered
-          filteredModels={[
-            "Llama 2 (70B)",
-            "LLaMA (65B)",
-            "text-davinci-002",
-            "Mistral v0.1 (7B)",
-            "Cohere Command beta (52.4B)",
-            "text-davinci-003",
-          ]}
+          nModelsToAutoFilter={6}
           filteredCols={[0, 1]}
         />
       </>

--- a/src/helm-frontend/src/components/MiniLeaderboard.tsx
+++ b/src/helm-frontend/src/components/MiniLeaderboard.tsx
@@ -83,7 +83,7 @@ export default function MiniLeaderboard() {
           activeGroup={activeGroup}
           ignoreHref={true}
           filtered
-          nModelsToAutoFilter={6}
+          numModelsToAutoFilter={6}
           filteredCols={[0, 1]}
         />
       </>


### PR DESCRIPTION
A hacky way to automatically filter down models for leaderboards.

Tested & working on my fork at https://farzaank.github.io/helm/

I'll follow up with a PR for the style changes.

At some point, we will want to do this and some other leaderboard related functionality differently in the future, but that will require a larger leaderboard refactor (probably next quarter). 