### PR TITLE
Handle responses with no completion_tokens field in AlephAlphaClient

### DIFF
--- a/src/helm/proxy/clients/aleph_alpha_client.py
+++ b/src/helm/proxy/clients/aleph_alpha_client.py
@@ -67,7 +67,7 @@ class AlephAlphaClient(CachingClient):
             tokens: List[Token] = []
 
             # `completion_tokens` is the list of selected tokens.
-            for i, token in enumerate(completion["completion_tokens"]):
+            for i, token in enumerate(completion.get("completion_tokens", [])):
                 # Get the top K logprobs for the ith token
                 top_logprobs: Dict[str, float] = completion["log_probs"][i]
                 # Use the selected token value to get the logprob


### PR DESCRIPTION
The `completion_tokens` field may be omitted when the response is empty.