### PR TITLE
Front-end updates for HELM lite

### DIFF
--- a/src/helm-frontend/src/components/Hero.tsx
+++ b/src/helm-frontend/src/components/Hero.tsx
@@ -15,10 +15,9 @@ export default function Hero() {
       </div>
 
       {/* Container for Image and Leaderboard */}
-      {/* Container for Image and Leaderboard */}
       <div
         className="flex flex-col md:flex-col lg:flex-row lg:justify-center"
-        style={{ height: "525px", transform: "scale(0.8)" }} // Reduced height by 10%
+        style={{ height: "525px", transform: "scale(0.9)" }} // Reduced height by 10%
       >
         {/* Image section */}
         <div className="w-full lg:w-1/2 flex justify-center mb-4 lg:mb-0 h-full py-10">

--- a/src/helm-frontend/src/components/LeaderboardTables.tsx
+++ b/src/helm-frontend/src/components/LeaderboardTables.tsx
@@ -116,7 +116,7 @@ export default function LeaderboardTables({
       {filtered ? (
         <div
           className="rounded-2xl overflow-hidden border-2 bg-white p-1 mx-2 my-0"
-          style={{ width: "505px", height: "380px", overflow: "auto" }}
+          style={{ overflow: "auto" }}
         >
           <div className="overflow-x-auto">
             <table className="table w-full">

--- a/src/helm-frontend/src/components/NavBar/NavBar.test.tsx
+++ b/src/helm-frontend/src/components/NavBar/NavBar.test.tsx
@@ -11,6 +11,6 @@ test("displays nav bar", () => {
   );
 
   expect(screen.getByRole("navigation")).toHaveTextContent(
-    "LeaderboardModelsScenariosPredictionsGitHub Classic LeaderboardModelsScenariosPredictionsGitHub Release: undefined",
+    "LeaderboardModelsScenariosPredictionsGitHub LeaderboardModelsScenariosPredictionsGitHub Release: undefined",
   );
 });

--- a/src/helm-frontend/src/components/NavDropdown.tsx
+++ b/src/helm-frontend/src/components/NavDropdown.tsx
@@ -14,8 +14,15 @@ function NavDropdown() {
               alt="Image 1"
               className="w-full h-10 object-cover"
             />
-
-            <div className="hidden lg:flex pl-3"> Classic </div>
+            {/* Manually set whether Classic or Not via config, otherwise don't show this */}
+            {window.HELM_TYPE ? (
+              <div className="hidden lg:flex pl-3">
+                {" "}
+                <strong>{window.HELM_TYPE}</strong>{" "}
+              </div>
+            ) : (
+              <> </>
+            )}
           </div>
         </Link>
 
@@ -56,8 +63,24 @@ function NavDropdown() {
               <Link to="https://crfm.stanford.edu/helm/latest/">
                 <div className="flex items-center">
                   <span>
-                    <strong>HELM Classic: </strong>Holistic evaluation of
-                    language models
+                    <strong>HELM Classic: </strong>Thorough language model
+                    evaluations based on the scenarios from the original HELM
+                    paper
+                  </span>
+                </div>
+              </Link>
+            </div>
+
+            <div
+              className="block px-4 py-2 text-md text-gray-700 hover:bg-gray-100 hover:text-gray-900"
+              role="menuitem"
+            >
+              <Link to="https://nlp.stanford.edu/helm/v2-lite-canary/">
+                <div className="flex items-center">
+                  <span>
+                    <strong>HELM Lite: </strong>Lightweight, broad evaluation of
+                    the capabilities of language models using in-context
+                    learning
                   </span>
                 </div>
               </Link>

--- a/src/helm-frontend/src/types/global.d.ts
+++ b/src/helm-frontend/src/types/global.d.ts
@@ -2,4 +2,5 @@ interface Window {
   RELEASE: string;
   SUITE: string;
   BENCHMARK_OUTPUT_BASE_URL: string;
+  HELM_TYPE: string;
 }


### PR DESCRIPTION
- Reads in whether to show classic/lite from config.js
- Style fixes
  - Bolding lite/classic
  - Fix mobile leaderboard on landing page 
  - Updated copy of nav dropdown from Percy's suggestion
  
Live at https://farzaank.github.io/helm/

Still finishing up raw runs linking, I'll follow this up with that PR tomorrow

@yifanmai could you share the code or schema for HELM lite so I can see why the scenario list isn't showing up properly?

And sorry for late PR adjusting to a different timezone (New Zealand)