### PR TITLE
Compute number of metrics correctly

### DIFF
--- a/src/helm-frontend/src/components/MetricsList.tsx
+++ b/src/helm-frontend/src/components/MetricsList.tsx
@@ -10,7 +10,11 @@ export default function MetricList({ metrics, metricGroups }: Props) {
   const metricNameToMetric = new Map<string, Metric>();
   metrics.forEach((metric) => metricNameToMetric.set(metric.name, metric));
 
-  let numMetrics = 0;
+  // Only count metrics that have a group and are displayed
+  // i.e. don't count "orphaned" metrics
+  // Also, don't double-count metrics that appear in multiple groups
+  const groupedMetricNames = new Set<string>();
+
   const metricGroupsWithMetrics: [MetricGroup, Metric[]][] = [];
   metricGroups.forEach((metricGroup) => {
     const metricGroupMetrics: Metric[] = [];
@@ -18,17 +22,17 @@ export default function MetricList({ metrics, metricGroups }: Props) {
       const maybeMetric = metricNameToMetric.get(metricField.name);
       if (maybeMetric) {
         metricGroupMetrics.push(maybeMetric);
+        groupedMetricNames.add(maybeMetric.name);
       }
     });
     if (metricGroupMetrics.length > 0) {
       metricGroupsWithMetrics.push([metricGroup, metricGroupMetrics]);
-      numMetrics += metricGroupMetrics.length;
     }
   });
 
   return (
     <section>
-      <h3 className="text-3xl">{numMetrics} metrics</h3>
+      <h3 className="text-3xl">{groupedMetricNames.size} metrics</h3>
       <ul>
         {metricGroupsWithMetrics.map(([metricGroup, metrics]) => (
           <li className="my-3" key={metricGroup.name}>

--- a/src/helm-frontend/src/components/MetricsList.tsx
+++ b/src/helm-frontend/src/components/MetricsList.tsx
@@ -1,6 +1,5 @@
 import type Metric from "@/types/Metric";
 import type MetricGroup from "@/types/MetricGroup";
-import { Link as ReactRouterLink } from "react-router-dom";
 
 interface Props {
   metrics: Metric[];
@@ -8,34 +7,40 @@ interface Props {
 }
 
 export default function MetricList({ metrics, metricGroups }: Props) {
+  const metricNameToMetric = new Map<string, Metric>();
+  metrics.forEach((metric) => metricNameToMetric.set(metric.name, metric));
+
+  let numMetrics = 0;
+  const metricGroupsWithMetrics: [MetricGroup, Metric[]][] = [];
+  metricGroups.forEach((metricGroup) => {
+    const metricGroupMetrics: Metric[] = [];
+    metricGroup.metrics.forEach((metricField) => {
+      const maybeMetric = metricNameToMetric.get(metricField.name);
+      if (maybeMetric) {
+        metricGroupMetrics.push(maybeMetric);
+      }
+    });
+    if (metricGroupMetrics.length > 0) {
+      metricGroupsWithMetrics.push([metricGroup, metricGroupMetrics]);
+      numMetrics += metricGroupMetrics.length;
+    }
+  });
+
   return (
     <section>
-      <h3 className="text-3xl">{metrics.length} metrics</h3>
+      <h3 className="text-3xl">{numMetrics} metrics</h3>
       <ul>
-        {metricGroups.map((metricGroup, idx) => (
-          <li className="my-3" key={idx}>
-            {metrics.filter((metric) =>
-              metricGroup.metrics.some((m) => m.name === metric.name),
-            ).length > 0 ? (
-              <ReactRouterLink
-                className="text-black"
-                to={"groups/" + metricGroup.name}
-              >
-                <h4>{metricGroup.display_name}</h4>
-              </ReactRouterLink>
-            ) : null}
+        {metricGroupsWithMetrics.map(([metricGroup, metrics]) => (
+          <li className="my-3" key={metricGroup.name}>
+            <h4>{metricGroup.display_name}</h4>
             <ul className="list-disc list-inside">
-              {metrics
-                .filter((metric) =>
-                  metricGroup.metrics.some((m) => m.name === metric.name),
-                )
-                .map((metric, idx) => {
-                  return (
-                    <li key={idx} className="ml-4">
-                      {metric.display_name}
-                    </li>
-                  );
-                })}
+              {metrics.map((metric) => {
+                return (
+                  <li key={metric.name} className="ml-4">
+                    {metric.display_name}
+                  </li>
+                );
+              })}
             </ul>
           </li>
         ))}


### PR DESCRIPTION
Previously the frontend's metric count was the total number of metrics in the schema. This pull request changes it to the number of actually rendered metric names.

Also removes the dead link from the metric group header.