### PR TITLE
Add py.typed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+recursive-include src/helm/ py.typed
 recursive-include src/helm/proxy/clients/ *.sp
 recursive-include src/helm/benchmark/ *.json
 recursive-include src/helm/benchmark/static/ *.css *.html *.js *.png *.yaml


### PR DESCRIPTION
Required for package users to use type-checking - see [PEP 561](https://peps.python.org/pep-0561/).