### PR TITLE
Split out evaluate_instances out of Metric.

### DIFF
--- a/src/helm/benchmark/metrics/bbq_metrics.py
+++ b/src/helm/benchmark/metrics/bbq_metrics.py
@@ -1,8 +1,8 @@
 from typing import List
+from helm.benchmark.metrics.evaluate_instances_metric import EvaluateInstancesMetric
 
 from helm.common.request import RequestResult
 from helm.benchmark.adaptation.request_state import RequestState
-from .metric import Metric
 from .metric_name import MetricName
 from .statistic import Stat
 
@@ -13,7 +13,7 @@ NON_NEGATIVE_TAG = "non-negative"
 ERROR_SCORE = 0.0  # fallback value after experiencing a divide-by-0 error when computing BBQMetric
 
 
-class BBQMetric(Metric):
+class BBQMetric(EvaluateInstancesMetric):
     """
     Defines metrics for the BBQ dataset. Specifically, we are interested in the following metrics:
 

--- a/src/helm/benchmark/metrics/bias_metrics.py
+++ b/src/helm/benchmark/metrics/bias_metrics.py
@@ -4,16 +4,16 @@ from typing import Dict, List, Optional, Tuple
 
 from nltk.tokenize import word_tokenize
 import numpy as np
+from helm.benchmark.metrics.evaluate_instances_metric import EvaluateInstancesMetric
 
 from helm.common.request import RequestResult, Sequence
 from helm.benchmark.adaptation.request_state import RequestState
 from .statistic import Stat
-from .metric import Metric
 from .metric_name import MetricName
 from .bias_word_lists import GENDER_TO_WORD_LISTS, RACE_TO_NAME_LISTS, ADJECTIVE_LIST, PROFESSION_LIST
 
 
-class BiasMetric(Metric):
+class BiasMetric(EvaluateInstancesMetric):
     """Compute metrics to evaluate social bias.
 
     We compute demographic representation and mean stereotypical association bias in model generated text using word

--- a/src/helm/benchmark/metrics/classification_metrics.py
+++ b/src/helm/benchmark/metrics/classification_metrics.py
@@ -5,13 +5,14 @@ from sklearn.preprocessing import MultiLabelBinarizer
 
 from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.metrics.basic_metrics import normalize_text
-from helm.benchmark.metrics.metric import Metric, MetricName
+from helm.benchmark.metrics.evaluate_instances_metric import EvaluateInstancesMetric
+from helm.benchmark.metrics.metric import MetricName
 from helm.benchmark.metrics.statistic import Stat
 from helm.benchmark.scenarios.scenario import Reference
 from helm.common.request import Sequence
 
 
-class ClassificationMetric(Metric):
+class ClassificationMetric(EvaluateInstancesMetric):
     """Defines metrics for multi-class classification using the generation adapter.
 
     Currently provides `classification_macro_f1` and `classification_micro_f1`.
@@ -72,7 +73,7 @@ class ClassificationMetric(Metric):
         ]
 
 
-class MultipleChoiceClassificationMetric(Metric):
+class MultipleChoiceClassificationMetric(EvaluateInstancesMetric):
     """
     Calculate population micro/macro F1 score for multiple_choice_* adapters.
     For generation adapters, please use ClassificationMetric.

--- a/src/helm/benchmark/metrics/cleva_accuracy_metrics.py
+++ b/src/helm/benchmark/metrics/cleva_accuracy_metrics.py
@@ -3,12 +3,13 @@ from typing import List
 import numpy as np
 
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.metrics.metric import Metric, MetricName
+from helm.benchmark.metrics.evaluate_instances_metric import EvaluateInstancesMetric
+from helm.benchmark.metrics.metric import MetricName
 from helm.benchmark.metrics.statistic import Stat
 from helm.common.request import Sequence
 
 
-class CLEVATopKAccuracyMetric(Metric):
+class CLEVATopKAccuracyMetric(EvaluateInstancesMetric):
     """Defines metrics for CLEVA conceptual generalization task.
 
     This is not a conventional accuracy@k metric but rather a special one taken from

--- a/src/helm/benchmark/metrics/evaluate_instances_metric.py
+++ b/src/helm/benchmark/metrics/evaluate_instances_metric.py
@@ -1,0 +1,57 @@
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from typing import List, Dict
+from helm.benchmark.metrics.metric import MetricInterface, MetricResult, add_context
+
+
+from helm.benchmark.adaptation.scenario_state import ScenarioState
+from helm.benchmark.adaptation.request_state import RequestState
+from .metric_name import MetricName, MetricContext
+from .metric_service import MetricService
+from .statistic import Stat, merge_stat
+
+
+class EvaluateInstancesMetric(MetricInterface, ABC):
+    """
+    A `Metric` that
+    """
+
+    def evaluate(
+        self, scenario_state: ScenarioState, metric_service: MetricService, eval_cache_path: str, parallelism: int
+    ) -> MetricResult:
+        """
+        Metric that needs to examine all request states for all instances in the same split with the same perturbations
+        in order to determine the Stats.
+        """
+
+        adapter_spec = scenario_state.adapter_spec
+        global_stats: Dict[MetricName, Stat] = {}
+
+        for train_trial_index in range(adapter_spec.num_train_trials):
+
+            # Aggregate these stats
+            trial_stats: Dict[MetricName, Stat] = {}  # Statistics just for this trial
+
+            # Compute statistics that depend on all the `RequestStates` (e.g., bias metrics).
+            # Aggregate request states and call evaluate_instances in case the metric needs it.
+            grouped_request_states: Dict[MetricContext, List[RequestState]] = defaultdict(list)
+            for instance in scenario_state.instances:
+                # TODO: do we need to support reference_index that is not None?
+                grouped_request_states[MetricContext.from_instance(instance)].extend(
+                    scenario_state.get_request_states(train_trial_index, instance, None)
+                )
+            for context, request_states in grouped_request_states.items():
+                for stat in self.evaluate_instances(request_states):
+                    merge_stat(trial_stats, add_context(stat, context))
+
+            # We take the mean value for each trial.
+            for stat in trial_stats.values():
+                merge_stat(global_stats, stat.take_mean())
+
+        # Wrap aggregated and per-instance stats in a MetricResult.
+        return MetricResult(list(global_stats.values()), [])
+
+    @abstractmethod
+    def evaluate_instances(self, request_states: List[RequestState]) -> List[Stat]:
+        """Evaluate all request states directly. Use only if nothing else works."""
+        pass

--- a/src/helm/benchmark/metrics/evaluate_instances_metric.py
+++ b/src/helm/benchmark/metrics/evaluate_instances_metric.py
@@ -13,17 +13,19 @@ from .statistic import Stat, merge_stat
 
 class EvaluateInstancesMetric(MetricInterface, ABC):
     """
-    A `Metric` that
+    Metric that needs to examine all request states for all instances in the same split with the same perturbations
+    in order to determine the Stats.
     """
 
     def evaluate(
         self, scenario_state: ScenarioState, metric_service: MetricService, eval_cache_path: str, parallelism: int
     ) -> MetricResult:
-        """
-        Metric that needs to examine all request states for all instances in the same split with the same perturbations
-        in order to determine the Stats.
-        """
+        """Aggregate over calls to evaluate_instances, which is defined by the subclass.
 
+        1. Each call has all instances for the same train trial, split, and perturbations.
+        2. For each train trial, take the mean for each Stat.
+        3. Returns Stats built from those means (e.g. the mean in the result is the mean-of-means).
+        """
         adapter_spec = scenario_state.adapter_spec
         global_stats: Dict[MetricName, Stat] = {}
 

--- a/src/helm/benchmark/metrics/metric.py
+++ b/src/helm/benchmark/metrics/metric.py
@@ -204,18 +204,6 @@ class Metric(MetricInterface, ABC):
                 for stat in self.derive_per_instance_stats(instance_dict):
                     merge_stat(trial_stats, add_context(stat, context))
 
-            # Compute statistics that depend on all the `RequestStates` (e.g., bias metrics).
-            # Aggregate request states and call evaluate_instances in case the metric needs it.
-            grouped_request_states: Dict[MetricContext, List[RequestState]] = defaultdict(list)
-            for instance in scenario_state.instances:
-                # TODO: do we need to support reference_index that is not None?
-                grouped_request_states[MetricContext.from_instance(instance)].extend(
-                    scenario_state.get_request_states(train_trial_index, instance, None)
-                )
-            for context, request_states in grouped_request_states.items():
-                for stat in self.evaluate_instances(request_states):
-                    merge_stat(trial_stats, add_context(stat, context))
-
             # Compute worst-case metrics.
             # This is here since we want these stats for all metrics and they
             # aggregate across contexts (perturbations).
@@ -250,10 +238,6 @@ class Metric(MetricInterface, ABC):
         eval_cache_path: str,
     ) -> List[Stat]:
         """Evaluate the references.  Override me!"""
-        return []
-
-    def evaluate_instances(self, request_states: List[RequestState]) -> List[Stat]:
-        """Evaluate all request states directly. Use only if nothing else works.  Override me!"""
         return []
 
     def derive_stats(self, stats_dict: Dict[MetricName, Stat]) -> List[Stat]:

--- a/src/helm/benchmark/metrics/metric.py
+++ b/src/helm/benchmark/metrics/metric.py
@@ -1,4 +1,4 @@
-from abc import ABC
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, replace
 from collections import defaultdict
 from typing import List, Dict, Tuple, Optional, Iterable, Set
@@ -95,7 +95,17 @@ class Processor:
         return instance_stats
 
 
-class Metric(ABC):
+class MetricInterface(ABC):
+    """Interface for all Metrics."""
+
+    @abstractmethod
+    def evaluate(
+        self, scenario_state: ScenarioState, metric_service: MetricService, eval_cache_path: str, parallelism: int
+    ) -> MetricResult:
+        pass
+
+
+class Metric(MetricInterface, ABC):
     """
     A `Metric` takes the results of execution and produces `Stat`s for a
     scenario.

--- a/src/helm/benchmark/metrics/paraphrase_generation_metrics.py
+++ b/src/helm/benchmark/metrics/paraphrase_generation_metrics.py
@@ -1,13 +1,13 @@
 from typing import List
 
 from helm.benchmark.adaptation.request_state import RequestState
-from .metric import Metric
+from helm.benchmark.metrics.evaluate_instances_metric import EvaluateInstancesMetric
 from .metric_name import MetricName
 from .statistic import Stat
 from nltk.translate.bleu_score import corpus_bleu
 
 
-class CLEVAParaphraseGenerationMetric(Metric):
+class CLEVAParaphraseGenerationMetric(EvaluateInstancesMetric):
     """
     Compute the Chinese iBLEU score for Paraphrase Generation scenarios of CLEVA benchmark.
     This implementation allows variable number of references (i.e., golds).

--- a/src/helm/benchmark/runner.py
+++ b/src/helm/benchmark/runner.py
@@ -35,7 +35,7 @@ from .executor import ExecutionSpec, Executor
 from .metrics.dry_run_metrics import DryRunMetric
 from .metrics.metric_name import MetricName
 from .metrics.metric_service import MetricService
-from .metrics.metric import Metric, MetricSpec, MetricResult, PerInstanceStats, create_metric, Stat
+from .metrics.metric import MetricInterface, MetricSpec, MetricResult, PerInstanceStats, create_metric, Stat
 from .window_services.tokenizer_service import TokenizerService
 
 
@@ -302,7 +302,7 @@ class Runner:
         # Apply the metrics
         # When performing a dry run, only estimate the number of tokens instead
         # of calculating the metrics.
-        metrics: List[Metric] = (
+        metrics: List[MetricInterface] = (
             [DryRunMetric()] if self.dry_run else [create_metric(metric_spec) for metric_spec in run_spec.metric_specs]
         )
         stats: List[Stat] = []


### PR DESCRIPTION
Since these classes don't override evaluate_generation or evaluate_references, they don't produce any Stats in Processor.process. That means they don't produce any per_instance_stats or compute_worst_case_metrics.