### PR TITLE
Remove hardcoded constants from window services

### DIFF
--- a/src/helm/benchmark/adaptation/adapters/test_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/test_adapter.py
@@ -1,6 +1,7 @@
 import shutil
 import tempfile
 
+from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from helm.common.authentication import Authentication
 from helm.proxy.services.server_service import ServerService
 from helm.benchmark.window_services.tokenizer_service import TokenizerService
@@ -12,6 +13,7 @@ class TestAdapter:
     """
 
     def setup_method(self):
+        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service = ServerService(base_path=self.path, root_mode=True)
         self.tokenizer_service = TokenizerService(service, Authentication("test"))

--- a/src/helm/benchmark/adaptation/adapters/test_language_modeling_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/test_language_modeling_adapter.py
@@ -1,6 +1,5 @@
 # mypy: check_untyped_defs = False
 from typing import List
-from helm.benchmark.window_services.gpt2_window_service import GPT2WindowService
 
 from helm.common.tokenization_request import TokenizationToken
 from helm.benchmark.adaptation.request_state import RequestState
@@ -9,18 +8,6 @@ from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from .adapter_factory import AdapterFactory, ADAPT_LANGUAGE_MODELING
 from .test_adapter import TestAdapter
 from helm.benchmark.scenarios.scenario import TEST_SPLIT, Instance, Input, Reference
-
-
-class MockGPT2Window(GPT2WindowService):
-    """Utility for overriding properties of a GPT2WindowService for test purposes."""
-
-    def __init__(self, service, *, max_sequence_length):
-        super().__init__(service)
-        self._max_sequence_length = max_sequence_length
-
-    @property
-    def max_sequence_length(self) -> int:
-        return self._max_sequence_length
 
 
 class TestLanguageModelingAdapter(TestAdapter):
@@ -159,7 +146,8 @@ class TestLanguageModelingAdapter(TestAdapter):
         )
         adapter = AdapterFactory.get_adapter(adapter_spec, self.tokenizer_service)
         # Monkey patch the window service to have really short max sequences.
-        adapter.window_service = MockGPT2Window(self.tokenizer_service, max_sequence_length=max_sequence_length)
+        adapter.window_service._max_sequence_length = max_sequence_length
+        adapter.window_service._max_request_length = max_sequence_length + 1
         input_text = Input(text=" ".join(str(i) for i in range(input_tokens)))
         instance = Instance(input=input_text, references=[], split=TEST_SPLIT)
 

--- a/src/helm/benchmark/window_services/ai21_window_service.py
+++ b/src/helm/benchmark/window_services/ai21_window_service.py
@@ -9,12 +9,12 @@ from helm.common.tokenization_request import (
     TokenizationToken,
     TextRange,
 )
-from .window_service import WindowService, EncodeResult
+from .window_service import ConfigurableWindowService, EncodeResult
 from .tokenizer_service import TokenizerService
 from .gpt2_window_service import GPT2WindowService
 
 
-class AI21WindowService(WindowService):
+class AI21WindowService(ConfigurableWindowService):
     """Tokenizes by making a request to the proxy server with REST endpoint: `/api/tokenize`."""
 
     # AI21's tokenizer API rejects a tokenization request if the input sequence is too long, so
@@ -32,39 +32,29 @@ class AI21WindowService(WindowService):
         "AI21 only gave API access to their tokenizer, so this method is not supported."
     )
 
-    def __init__(self, service: TokenizerService, gpt2_window_service: GPT2WindowService):
+    def __init__(
+        self,
+        gpt2_window_service: GPT2WindowService,
+        service: TokenizerService,
+        tokenizer_name: str,
+        max_sequence_length: int,
+        max_request_length: Optional[int] = None,
+        max_sequence_and_generated_tokens_length: Optional[int] = None,
+        end_of_text_token: Optional[str] = None,
+        prefix_token: Optional[str] = None,
+    ):
+        super().__init__(
+            tokenizer_name=tokenizer_name,
+            max_sequence_length=max_sequence_length,
+            max_request_length=max_request_length,
+            max_sequence_and_generated_tokens_length=max_sequence_and_generated_tokens_length,
+            end_of_text_token=end_of_text_token,
+            prefix_token=prefix_token,
+        )
         # We need the `TokenizerService` to make requests to the server.
         self.service: TokenizerService = service
         # As explained above, we need a `GPT2WindowService` to help tokenize long text sequences.
         self.gpt2_window_service: GPT2WindowService = gpt2_window_service
-
-    @property
-    def tokenizer_name(self) -> str:
-        """Name of the tokenizer to use when sending a request."""
-        return "ai21/j1"
-
-    @property
-    def max_sequence_length(self) -> int:
-        """
-        The max token length of the model in. The AI21 server automatically prepends a token to every prompt,
-        so the actual max sequence length is 2048-1 = 2047.
-        """
-        return 2047
-
-    @property
-    def max_request_length(self) -> int:
-        """The max sequence length is the same as the max request length for AI21."""
-        return self.max_sequence_length
-
-    @property
-    def end_of_text_token(self) -> str:
-        # TODO: I'm not sure what their end of text token is. I don't think it's documented.
-        return " "
-
-    @property
-    def prefix_token(self) -> str:
-        """AI21 tokenizers do no have a prefix token"""
-        return ""
 
     def encode(self, text: str, truncation: bool = False, max_length: Optional[int] = None) -> EncodeResult:
         """

--- a/src/helm/benchmark/window_services/cohere_window_service.py
+++ b/src/helm/benchmark/window_services/cohere_window_service.py
@@ -2,7 +2,6 @@ from typing import List, Optional
 
 from helm.proxy.tokenizers.cohere_tokenizer import CohereTokenizer
 from .local_window_service import LocalWindowService
-from .tokenizer_service import TokenizerService
 from .window_service import EncodeResult
 from helm.common.tokenization_request import (
     TokenizationRequest,
@@ -12,47 +11,6 @@ from helm.common.tokenization_request import (
 
 
 class CohereWindowService(LocalWindowService):
-    def __init__(self, service: TokenizerService):
-        super().__init__(service)
-
-    @property
-    def tokenizer_name(self) -> str:
-        return "cohere/cohere"
-
-    @property
-    def max_sequence_length(self) -> int:
-        """
-        The max length of the model input. Similar to MT-NLG, Cohere does not predict the logprob of
-        the first input token so `max_sequence_length` is one token shorter than `max_request_length`.
-        """
-        return self.max_request_length - 1
-
-    @property
-    def max_request_length(self) -> int:
-        """
-        The max request length of the model. For Cohere, this is the same as the `max_sequence_length`.
-        If we exceed the `max_sequence_length`, we get the following error:
-
-        Request failed with too many tokens: total number of tokens (prompt and prediction) cannot
-        exceed 2048 - received 2049. Try using a shorter prompt or a smaller max_tokens value.
-        """
-        return 2048
-
-    @property
-    def end_of_text_token(self) -> str:
-        """
-        The end of text token. Cohere does not have one.
-        """
-        return ""
-
-    @property
-    def prefix_token(self) -> str:
-        """
-        The prefix token. Cohere does not return the log prob for the first token when `echo_prompt` is True.
-        """
-        # Cohere recommended ":", but we can try out different values
-        return ":"
-
     def encode(self, text: str, truncation: bool = False, max_length: Optional[int] = None) -> EncodeResult:
         """
         Encodes the input text to tokens.
@@ -144,20 +102,5 @@ class CohereWindowService(LocalWindowService):
 
 
 class CohereCommandWindowService(CohereWindowService):
-    def __init__(self, service: TokenizerService):
-        super().__init__(service)
-
-    @property
-    def max_request_length(self) -> int:
-        """
-        The max request length of the model. For Cohere, this is the same as the `max_sequence_length`.
-        If we exceed the `max_sequence_length`, we get the following error:
-
-        Request failed with too many tokens: total number of tokens (prompt and prediction) cannot
-        exceed 2048 - received 2049. Try using a shorter prompt or a smaller max_tokens value.
-
-        For the Command model, in rare situations, the co.tokenize returns a shorter list of tokens
-        than the co.generate. This causes sequence length errors for rare inputs. Cohere's advice is
-        to reduce the sequence length to 2020 to avoid these issues.
-        """
-        return 2020
+    # TODO: Delete this WindowService.
+    pass

--- a/src/helm/benchmark/window_services/default_window_service.py
+++ b/src/helm/benchmark/window_services/default_window_service.py
@@ -1,48 +1,6 @@
-from typing import Optional
-from .window_service import INT_MAX
 from .local_window_service import LocalWindowService
-from .tokenizer_service import TokenizerService
 
 
 class DefaultWindowService(LocalWindowService):
-    def __init__(
-        self,
-        service: TokenizerService,
-        tokenizer_name: str,
-        max_sequence_length: int,
-        max_request_length: Optional[int] = None,
-        max_sequence_and_generated_tokens_length: Optional[int] = None,
-        end_of_text_token: Optional[str] = None,
-        prefix_token: Optional[str] = None,
-    ):
-        super().__init__(service)
-        self._tokenizer_name = tokenizer_name
-        self._max_sequence_length = max_sequence_length
-        self._max_request_length = max_request_length or max_sequence_length
-        self._max_sequence_and_generated_tokens_length = max_sequence_and_generated_tokens_length or INT_MAX
-        self._end_of_text_token = end_of_text_token or ""
-        self._prefix_token = prefix_token or ""
-
-    @property
-    def tokenizer_name(self) -> str:
-        return self._tokenizer_name
-
-    @property
-    def max_sequence_length(self) -> int:
-        return self._max_sequence_length
-
-    @property
-    def max_request_length(self) -> int:
-        return self._max_request_length
-
-    @property
-    def max_sequence_and_generated_tokens_length(self) -> int:
-        return self._max_sequence_and_generated_tokens_length
-
-    @property
-    def end_of_text_token(self) -> str:
-        return self._end_of_text_token
-
-    @property
-    def prefix_token(self) -> str:
-        return self._prefix_token
+    # TODO: Delete this WindowService.
+    pass

--- a/src/helm/benchmark/window_services/encoder_decoder_window_service.py
+++ b/src/helm/benchmark/window_services/encoder_decoder_window_service.py
@@ -2,20 +2,9 @@ from abc import ABC
 
 from helm.common.hierarchical_logger import hlog
 from .local_window_service import LocalWindowService
-from .tokenizer_service import TokenizerService
 
 
 class EncoderDecoderWindowService(LocalWindowService, ABC):
-    def __init__(self, service: TokenizerService):
-        super().__init__(service)
-
-    @property
-    def max_request_length(self) -> int:
-        """
-        Return the max request length. We set the max requests length to be `max_sequence_length`.
-        """
-        return self.max_sequence_length
-
     @property
     def max_output_length(self) -> int:
         """

--- a/src/helm/benchmark/window_services/flan_t5_window_service.py
+++ b/src/helm/benchmark/window_services/flan_t5_window_service.py
@@ -1,29 +1,6 @@
 from .encoder_decoder_window_service import EncoderDecoderWindowService
-from .tokenizer_service import TokenizerService
 
 
 class FlanT5WindowService(EncoderDecoderWindowService):
-    def __init__(self, service: TokenizerService):
-        super().__init__(service)
-
-    @property
-    def max_sequence_length(self) -> int:
-        """Return the max sequence length."""
-        # We subtract 1 to account for <extra_id_0> that gets appended to prompts.
-        return 512 - 1
-
-    @property
-    def end_of_text_token(self) -> str:
-        """The end of text token."""
-        return "</s>"
-
-    @property
-    def tokenizer_name(self) -> str:
-        """Name of the tokenizer to use when sending a request."""
-        return "google/flan-t5-xxl"
-
-    @property
-    def prefix_token(self) -> str:
-        """The prefix token is the same as the end of text token."""
-        # echo=True is not supported
-        return ""
+    pass
+    # TODO: Delete this

--- a/src/helm/benchmark/window_services/gpt2_window_service.py
+++ b/src/helm/benchmark/window_services/gpt2_window_service.py
@@ -1,32 +1,6 @@
 from .local_window_service import LocalWindowService
-from .tokenizer_service import TokenizerService
 
 
 class GPT2WindowService(LocalWindowService):
-    def __init__(self, service: TokenizerService):
-        super().__init__(service)
-
-    @property
-    def max_sequence_length(self) -> int:
-        """Return the max sequence length of this tokenizer."""
-        return 1024
-
-    @property
-    def max_request_length(self) -> int:
-        """Return the max request length of GPT-2."""
-        return self.max_sequence_length + 1
-
-    @property
-    def end_of_text_token(self) -> str:
-        """The end of text token."""
-        return "<|endoftext|>"
-
-    @property
-    def tokenizer_name(self) -> str:
-        """Name of the tokenizer to use when sending a request."""
-        return "huggingface/gpt2"
-
-    @property
-    def prefix_token(self) -> str:
-        """The prefix token for models that uses the GPT-2 tokenizer is the end of text token."""
-        return self.end_of_text_token
+    # TODO: Delete this WindowService.
+    pass

--- a/src/helm/benchmark/window_services/ice_window_service.py
+++ b/src/helm/benchmark/window_services/ice_window_service.py
@@ -1,41 +1,7 @@
 from .local_window_service import LocalWindowService
-from .tokenizer_service import TokenizerService
 
 
 class ICEWindowService(LocalWindowService):
-    def __init__(self, service: TokenizerService):
-        super().__init__(service)
-
-    @property
-    def tokenizer_name(self) -> str:
-        return "TsinghuaKEG/ice"
-
-    @property
-    def max_sequence_length(self) -> int:
-        """
-        The max length of the model input.
-        According to https://github.com/THUDM/GLM-130B, the max sequence length is 2048.
-        """
-        return 2048
-
-    @property
-    def max_request_length(self) -> int:
-        return self.max_sequence_length + 1
-
-    @property
-    def end_of_text_token(self) -> str:
-        """The end of text token."""
-        # Followed up in https://github.com/THUDM/icetk/issues/1
-        return "</s>"
-
-    @property
-    def prefix_token(self) -> str:
-        """
-        The prefix token.
-        Inference with echo=True is not feasible, so just set it to the empty string.
-        """
-        return ""
-
     def truncate_from_right(self, text: str, expected_completion_token_length: int = 0) -> str:
         """
         Truncates text from the right to fit within the context window given by `max_request_length`

--- a/src/helm/benchmark/window_services/image_generation/clip_window_service.py
+++ b/src/helm/benchmark/window_services/image_generation/clip_window_service.py
@@ -1,37 +1,9 @@
 from abc import ABC
 
 from helm.benchmark.window_services.local_window_service import LocalWindowService
-from helm.benchmark.window_services.tokenizer_service import TokenizerService
 
 
 class CLIPWindowService(LocalWindowService, ABC):
-    def __init__(self, service: TokenizerService):
-        super().__init__(service)
-
-    @property
-    def max_sequence_length(self) -> int:
-        """
-        The max length is 77, but we also need to account for <|startoftext|> and <|endoftext|>."
-        """
-        return 77 - 2
-
-    @property
-    def max_request_length(self) -> int:
-        """Return the max request length (same as `max_sequence_length`)."""
-        return self.max_sequence_length
-
-    @property
-    def end_of_text_token(self) -> str:
-        return ""
-
-    @property
-    def prefix_token(self) -> str:
-        return self.end_of_text_token
-
-    @property
-    def tokenizer_name(self) -> str:
-        return "openai/clip-vit-large-patch14"
-
     def truncate_from_right(self, text: str, expected_completion_token_length: int = 0) -> str:
         result: str = self.decode(self.encode(text, truncation=True, max_length=self.max_request_length).tokens)
 

--- a/src/helm/benchmark/window_services/image_generation/lexica_search_window_service.py
+++ b/src/helm/benchmark/window_services/image_generation/lexica_search_window_service.py
@@ -1,18 +1,7 @@
 from .clip_window_service import CLIPWindowService
-from helm.benchmark.window_services.tokenizer_service import TokenizerService
 
 
 class LexicaSearchWindowService(CLIPWindowService):
-    def __init__(self, service: TokenizerService):
-        super().__init__(service)
-
-    @property
-    def max_sequence_length(self) -> int:
-        """
-        The max sequence length in terms of the number of characters.
-        """
-        return 200
-
     def fits_within_context_window(self, text: str, expected_completion_token_length: int = 0) -> bool:
         return len(text) <= self.max_sequence_length
 

--- a/src/helm/benchmark/window_services/image_generation/openai_dalle_window_service.py
+++ b/src/helm/benchmark/window_services/image_generation/openai_dalle_window_service.py
@@ -1,20 +1,7 @@
-from helm.proxy.clients.image_generation.dalle2_client import DALLE2Client
 from .clip_window_service import CLIPWindowService
-from helm.benchmark.window_services.tokenizer_service import TokenizerService
 
 
 class OpenAIDALLEWindowService(CLIPWindowService):
-    def __init__(self, service: TokenizerService):
-        super().__init__(service)
-
-    @property
-    def max_sequence_length(self) -> int:
-        """
-        The max sequence length in terms of the number of characters.
-        https://beta.openai.com/docs/api-reference/images/create#images/create-prompt
-        """
-        return DALLE2Client.MAX_PROMPT_LENGTH
-
     def fits_within_context_window(self, text: str, expected_completion_token_length: int = 0) -> bool:
         return len(text) <= self.max_sequence_length
 

--- a/src/helm/benchmark/window_services/image_generation/test_clip_window_service.py
+++ b/src/helm/benchmark/window_services/image_generation/test_clip_window_service.py
@@ -1,6 +1,7 @@
 import shutil
 import tempfile
 
+from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from helm.benchmark.window_services.tokenizer_service import TokenizerService
 from helm.benchmark.window_services.test_utils import get_tokenizer_service
 from helm.benchmark.window_services.window_service_factory import WindowServiceFactory
@@ -8,6 +9,7 @@ from helm.benchmark.window_services.window_service_factory import WindowServiceF
 
 class TestCLIPWindowService:
     def setup_method(self):
+        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("huggingface/dreamlike-photoreal-v2-0", service)

--- a/src/helm/benchmark/window_services/image_generation/test_openai_dalle_window_service.py
+++ b/src/helm/benchmark/window_services/image_generation/test_openai_dalle_window_service.py
@@ -1,6 +1,7 @@
 import shutil
 import tempfile
 
+from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from helm.benchmark.window_services.tokenizer_service import TokenizerService
 from helm.proxy.clients.image_generation.dalle2_client import DALLE2Client
 from helm.benchmark.window_services.test_utils import get_tokenizer_service, TEST_PROMPT
@@ -9,6 +10,7 @@ from helm.benchmark.window_services.window_service_factory import WindowServiceF
 
 class TestOpenAIDALLEWindowService:
     def setup_method(self):
+        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("openai/dall-e-2", service)

--- a/src/helm/benchmark/window_services/local_window_service.py
+++ b/src/helm/benchmark/window_services/local_window_service.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from typing import List, Optional, cast
 
-from .window_service import WindowService, EncodeResult
+from .window_service import ConfigurableWindowService, EncodeResult
 from .tokenizer_service import TokenizerService
 from helm.common.tokenization_request import (
     DecodeRequest,
@@ -13,8 +13,25 @@ from helm.common.tokenization_request import (
 from helm.proxy.clients.client import cleanup_tokens
 
 
-class LocalWindowService(WindowService, ABC):
-    def __init__(self, service: TokenizerService):
+class LocalWindowService(ConfigurableWindowService, ABC):
+    def __init__(
+        self,
+        service: TokenizerService,
+        tokenizer_name: str,
+        max_sequence_length: int,
+        max_request_length: Optional[int] = None,
+        max_sequence_and_generated_tokens_length: Optional[int] = None,
+        end_of_text_token: Optional[str] = None,
+        prefix_token: Optional[str] = None,
+    ):
+        super().__init__(
+            tokenizer_name=tokenizer_name,
+            max_sequence_length=max_sequence_length,
+            max_request_length=max_request_length,
+            max_sequence_and_generated_tokens_length=max_sequence_and_generated_tokens_length,
+            end_of_text_token=end_of_text_token,
+            prefix_token=prefix_token,
+        )
         self.service: TokenizerService = service
 
     def encode(self, text: str, truncation: bool = False, max_length: Optional[int] = None) -> EncodeResult:

--- a/src/helm/benchmark/window_services/t0pp_window_service.py
+++ b/src/helm/benchmark/window_services/t0pp_window_service.py
@@ -1,35 +1,6 @@
 from .encoder_decoder_window_service import EncoderDecoderWindowService
-from .tokenizer_service import TokenizerService
 
 
 class T0ppWindowService(EncoderDecoderWindowService):
-    def __init__(self, service: TokenizerService):
-        super().__init__(service)
-
-    @property
-    def max_sequence_length(self) -> int:
-        """Return the max sequence length."""
-        # From https://arxiv.org/pdf/2110.08207.pdf, "we truncate input and target sequences to 1024 and 256 tokens,
-        # respectively. Following Raffel et al. (2020), we use packing to combine multiple training examples into
-        # a single sequence to reach the maximum sequence length."
-        return 1024
-
-    @property
-    def max_output_length(self) -> int:
-        return 256
-
-    @property
-    def end_of_text_token(self) -> str:
-        """The end of text token."""
-        return "</s>"
-
-    @property
-    def tokenizer_name(self) -> str:
-        """Name of the tokenizer to use when sending a request."""
-        return "bigscience/T0pp"
-
-    @property
-    def prefix_token(self) -> str:
-        """The prefix token is the same as the end of text token."""
-        # echo=True is not supported
-        return ""
+    pass
+    # TODO: Delete this

--- a/src/helm/benchmark/window_services/t511b_window_service.py
+++ b/src/helm/benchmark/window_services/t511b_window_service.py
@@ -1,30 +1,6 @@
 from .encoder_decoder_window_service import EncoderDecoderWindowService
-from .tokenizer_service import TokenizerService
 
 
 class T511bWindowService(EncoderDecoderWindowService):
-    def __init__(self, service: TokenizerService):
-        super().__init__(service)
-
-    @property
-    def max_sequence_length(self) -> int:
-        """Return the max sequence length."""
-        # From https://arxiv.org/pdf/1910.10683.pdf, "we use a maximum sequence length of 512".
-        # We subtract 1 to account for <extra_id_0> that gets appended to prompts.
-        return 512 - 1
-
-    @property
-    def end_of_text_token(self) -> str:
-        """The end of text token."""
-        return "</s>"
-
-    @property
-    def tokenizer_name(self) -> str:
-        """Name of the tokenizer to use when sending a request."""
-        return "google/t5-11b"
-
-    @property
-    def prefix_token(self) -> str:
-        """The prefix token is the same as the end of text token."""
-        # echo=True is not supported
-        return ""
+    pass
+    # TODO: Delete this

--- a/src/helm/benchmark/window_services/test_anthropic_window_service.py
+++ b/src/helm/benchmark/window_services/test_anthropic_window_service.py
@@ -2,6 +2,7 @@ import shutil
 import tempfile
 from typing import List
 
+from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
 from .test_utils import get_tokenizer_service, TEST_PROMPT
@@ -119,6 +120,7 @@ class TestAnthropicWindowService:
     ]
 
     def setup_method(self):
+        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("anthropic/claude-v1.3", service)

--- a/src/helm/benchmark/window_services/test_bloom_window_service.py
+++ b/src/helm/benchmark/window_services/test_bloom_window_service.py
@@ -2,6 +2,7 @@ import shutil
 import tempfile
 from typing import List
 
+from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
 from .test_utils import get_tokenizer_service, TEST_PROMPT
@@ -63,6 +64,7 @@ class TestBloomWindowService:
     ]
 
     def setup_method(self):
+        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("together/bloom", service)

--- a/src/helm/benchmark/window_services/test_cohere_window_service.py
+++ b/src/helm/benchmark/window_services/test_cohere_window_service.py
@@ -6,6 +6,7 @@ from typing import List
 
 from sqlitedict import SqliteDict
 
+from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from helm.common.general import ensure_directory_exists
 from .test_cohere_window_service_utils import REQUESTS_TO_RESPONSES, TEST_PROMPT, TOKENIZED_PROMPT
 from .tokenizer_service import TokenizerService
@@ -16,6 +17,7 @@ from .test_utils import get_tokenizer_service
 class TestCohereWindowService:
     @classmethod
     def setup_class(cls):
+        register_builtin_configs_from_helm_package()
         cls.path: str = tempfile.mkdtemp()
         cache_path: str = os.path.join(cls.path, "cache")
         ensure_directory_exists(cache_path)

--- a/src/helm/benchmark/window_services/test_flan_t5_window_service.py
+++ b/src/helm/benchmark/window_services/test_flan_t5_window_service.py
@@ -1,5 +1,6 @@
 import tempfile
 
+from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from helm.benchmark.window_services.test_t511b_window_service import TestT511bWindowService
 from helm.benchmark.window_services.window_service_factory import TokenizerService, WindowServiceFactory
 from helm.benchmark.window_services.test_utils import get_tokenizer_service
@@ -7,6 +8,7 @@ from helm.benchmark.window_services.test_utils import get_tokenizer_service
 
 class TestFlanT5WindowService(TestT511bWindowService):
     def setup_method(self):
+        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("together/flan-t5-xxl", service)

--- a/src/helm/benchmark/window_services/test_gpt2_window_service.py
+++ b/src/helm/benchmark/window_services/test_gpt2_window_service.py
@@ -1,6 +1,7 @@
 import shutil
 import tempfile
 
+from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from helm.benchmark.window_services.tokenizer_service import TokenizerService
 
 from .test_utils import get_tokenizer_service, TEST_PROMPT, GPT2_TEST_TOKENS, GPT2_TEST_TOKEN_IDS
@@ -9,6 +10,7 @@ from .window_service_factory import WindowServiceFactory
 
 class TestGPT2WindowService:
     def setup_method(self):
+        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("huggingface/gpt2", service)

--- a/src/helm/benchmark/window_services/test_gpt4_window_service.py
+++ b/src/helm/benchmark/window_services/test_gpt4_window_service.py
@@ -1,6 +1,7 @@
 import shutil
 import tempfile
 
+from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .test_utils import get_tokenizer_service, TEST_PROMPT, GPT4_TEST_TOKEN_IDS, GPT4_TEST_TOKENS
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
@@ -8,6 +9,7 @@ from .window_service_factory import WindowServiceFactory
 
 class TestOpenAIWindowService:
     def setup_method(self):
+        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("openai/gpt-3.5-turbo-0301", service)

--- a/src/helm/benchmark/window_services/test_gptj_window_service.py
+++ b/src/helm/benchmark/window_services/test_gptj_window_service.py
@@ -1,6 +1,7 @@
 import shutil
 import tempfile
 
+from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
 from .test_utils import get_tokenizer_service, GPT2_TEST_TOKENS, GPT2_TEST_TOKEN_IDS, TEST_PROMPT
@@ -8,6 +9,7 @@ from .test_utils import get_tokenizer_service, GPT2_TEST_TOKENS, GPT2_TEST_TOKEN
 
 class TestGPTJWindowService:
     def setup_method(self):
+        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("together/gpt-j-6b", service)

--- a/src/helm/benchmark/window_services/test_gptneox_window_service.py
+++ b/src/helm/benchmark/window_services/test_gptneox_window_service.py
@@ -2,6 +2,7 @@ import shutil
 import tempfile
 from typing import List
 
+from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
 from .test_utils import get_tokenizer_service, TEST_PROMPT
@@ -64,6 +65,7 @@ class TestGPTNeoXWindowService:
     ]
 
     def setup_method(self):
+        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("together/gpt-neox-20b", service)

--- a/src/helm/benchmark/window_services/test_ice_window_service.py
+++ b/src/helm/benchmark/window_services/test_ice_window_service.py
@@ -2,6 +2,7 @@ import shutil
 import tempfile
 from typing import List
 
+from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
 from .test_utils import get_tokenizer_service, TEST_PROMPT
@@ -63,6 +64,7 @@ class TestICEWindowService:
     ]
 
     def setup_method(self):
+        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("together/glm", service)

--- a/src/helm/benchmark/window_services/test_mt_nlg_window_service.py
+++ b/src/helm/benchmark/window_services/test_mt_nlg_window_service.py
@@ -1,6 +1,7 @@
 import shutil
 import tempfile
 
+from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .test_utils import get_tokenizer_service, TEST_PROMPT, GPT2_TEST_TOKENS, GPT2_TEST_TOKEN_IDS
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
@@ -8,6 +9,7 @@ from .window_service_factory import WindowServiceFactory
 
 class TestMTNLGWindowService:
     def setup_method(self):
+        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("microsoft/TNLGv2_7B", service)

--- a/src/helm/benchmark/window_services/test_openai_window_service.py
+++ b/src/helm/benchmark/window_services/test_openai_window_service.py
@@ -1,6 +1,7 @@
 import shutil
 import tempfile
 
+from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .test_utils import get_tokenizer_service, TEST_PROMPT, GPT2_TEST_TOKENS, GPT2_TEST_TOKEN_IDS
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
@@ -8,6 +9,7 @@ from .window_service_factory import WindowServiceFactory
 
 class TestOpenAIWindowService:
     def setup_method(self):
+        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("openai/davinci", service)

--- a/src/helm/benchmark/window_services/test_opt_window_service.py
+++ b/src/helm/benchmark/window_services/test_opt_window_service.py
@@ -1,6 +1,7 @@
 import shutil
 import tempfile
 
+from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .test_utils import get_tokenizer_service, TEST_PROMPT
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
@@ -8,6 +9,7 @@ from .window_service_factory import WindowServiceFactory
 
 class TestOPTWindowService:
     def setup_method(self):
+        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("together/opt-175b", service)

--- a/src/helm/benchmark/window_services/test_palmyra_window_service.py
+++ b/src/helm/benchmark/window_services/test_palmyra_window_service.py
@@ -1,6 +1,7 @@
 from tempfile import TemporaryDirectory
 from typing import List
 
+from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
 from .test_utils import get_tokenizer_service, TEST_PROMPT
@@ -116,6 +117,7 @@ class TestPalmyraWindowService:
     ]
 
     def setup_method(self):
+        register_builtin_configs_from_helm_package()
         self.temporary_directory = TemporaryDirectory()
         service: TokenizerService = get_tokenizer_service(self.temporary_directory.name)
         self.window_service = WindowServiceFactory.get_window_service("writer/palmyra-large", service)

--- a/src/helm/benchmark/window_services/test_t0pp_window_service.py
+++ b/src/helm/benchmark/window_services/test_t0pp_window_service.py
@@ -2,6 +2,7 @@ import shutil
 import tempfile
 from typing import List
 
+from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
 from .test_utils import get_tokenizer_service, TEST_PROMPT
@@ -69,6 +70,7 @@ class TestT0ppWindowService:
     ]
 
     def setup_method(self):
+        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("together/t0pp", service)

--- a/src/helm/benchmark/window_services/test_t511b_window_service.py
+++ b/src/helm/benchmark/window_services/test_t511b_window_service.py
@@ -2,6 +2,7 @@ import shutil
 import tempfile
 from typing import List
 
+from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
 from .test_utils import get_tokenizer_service, TEST_PROMPT
@@ -69,6 +70,7 @@ class TestT511bWindowService:
     ]
 
     def setup_method(self):
+        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("together/t5-11b", service)

--- a/src/helm/benchmark/window_services/test_ul2_window_service.py
+++ b/src/helm/benchmark/window_services/test_ul2_window_service.py
@@ -2,6 +2,7 @@ import shutil
 import tempfile
 from typing import List
 
+from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
 from .test_utils import get_tokenizer_service, TEST_PROMPT
@@ -69,6 +70,7 @@ class TestUL2WindowService:
     ]
 
     def setup_method(self):
+        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("together/ul2", service)

--- a/src/helm/benchmark/window_services/ul2_window_service.py
+++ b/src/helm/benchmark/window_services/ul2_window_service.py
@@ -1,30 +1,6 @@
 from .encoder_decoder_window_service import EncoderDecoderWindowService
-from .tokenizer_service import TokenizerService
 
 
 class UL2WindowService(EncoderDecoderWindowService):
-    def __init__(self, service: TokenizerService):
-        super().__init__(service)
-
-    @property
-    def max_sequence_length(self) -> int:
-        """Return the max sequence length."""
-        # From https://arxiv.org/pdf/2205.05131.pdf, "the sequence length is set to 512/512 for inputs and targets".
-        # We subtract 1 to account for <extra_id_0> that gets appended to prompts.
-        return 512 - 1
-
-    @property
-    def end_of_text_token(self) -> str:
-        """The end of text token."""
-        return "</s>"
-
-    @property
-    def tokenizer_name(self) -> str:
-        """Name of the tokenizer to use when sending a request."""
-        return "google/ul2"
-
-    @property
-    def prefix_token(self) -> str:
-        """The prefix token is the same as the end of text token."""
-        # echo=True is not supported
-        return ""
+    # TODO: Delete this WindowService.
+    pass

--- a/src/helm/benchmark/window_services/wider_ai21_window_service.py
+++ b/src/helm/benchmark/window_services/wider_ai21_window_service.py
@@ -2,23 +2,10 @@ from .ai21_window_service import AI21WindowService
 
 
 class WiderAI21WindowService(AI21WindowService):
-    @property
-    def max_sequence_length(self) -> int:
-        """
-        Return the max sequence length of the larger AI21 Jurassic-2 models.
-
-        The AI21 server automatically prepends a token to every prompt,
-        so the actual max sequence length is 8192 - 1 = 8191.
-        """
-        return 8191
+    # TODO: Delete this WindowService.
+    pass
 
 
 class AI21Jurassic2JumboWindowService(AI21WindowService):
-    @property
-    def max_sequence_length(self) -> int:
-        """
-        Return the max sequence length of the AI21 Jurassic-2 Jumbo.
-
-        AI21 has recommended using a sequence length of 6000 tokens to avoid OOMs.
-        """
-        return 6000
+    # TODO: Delete this WindowService.
+    pass

--- a/src/helm/benchmark/window_services/window_service.py
+++ b/src/helm/benchmark/window_services/window_service.py
@@ -110,3 +110,45 @@ class WindowService(ABC):
         minus the expected completion length (defaults to 0).
         """
         pass
+
+
+class ConfigurableWindowService(WindowService, ABC):
+    def __init__(
+        self,
+        tokenizer_name: str,
+        max_sequence_length: int,
+        max_request_length: Optional[int] = None,
+        max_sequence_and_generated_tokens_length: Optional[int] = None,
+        end_of_text_token: Optional[str] = None,
+        prefix_token: Optional[str] = None,
+    ):
+        self._tokenizer_name = tokenizer_name
+        self._max_sequence_length = max_sequence_length
+        self._max_request_length = max_request_length or max_sequence_length
+        self._max_sequence_and_generated_tokens_length = max_sequence_and_generated_tokens_length or INT_MAX
+        self._end_of_text_token = end_of_text_token or ""
+        self._prefix_token = prefix_token or ""
+
+    @property
+    def tokenizer_name(self) -> str:
+        return self._tokenizer_name
+
+    @property
+    def max_sequence_length(self) -> int:
+        return self._max_sequence_length
+
+    @property
+    def max_request_length(self) -> int:
+        return self._max_request_length
+
+    @property
+    def max_sequence_and_generated_tokens_length(self) -> int:
+        return self._max_sequence_and_generated_tokens_length
+
+    @property
+    def end_of_text_token(self) -> str:
+        return self._end_of_text_token
+
+    @property
+    def prefix_token(self) -> str:
+        return self._prefix_token

--- a/src/helm/benchmark/window_services/window_service_factory.py
+++ b/src/helm/benchmark/window_services/window_service_factory.py
@@ -53,7 +53,7 @@ class WindowServiceFactory:
                     "prefix_token": prefix_token,
                 },
                 provider_bindings={
-                    "gpt2_window_service": lambda: WindowServiceFactory.get_window_service("openai/gpt2", service)
+                    "gpt2_window_service": lambda: WindowServiceFactory.get_window_service("huggingface/gpt2", service)
                 },
             )
             return create_object(window_service_spec)

--- a/src/helm/benchmark/window_services/window_service_factory.py
+++ b/src/helm/benchmark/window_services/window_service_factory.py
@@ -43,7 +43,7 @@ class WindowServiceFactory:
             #    in the users configuration file. Instead, they have to be constructed dynamically at runtime.
             window_service_spec = inject_object_spec_args(
                 window_service_spec,
-                {
+                constant_bindings={
                     "service": service,
                     "tokenizer_name": model_deployment.tokenizer_name,
                     "max_sequence_length": model_deployment.max_sequence_length,
@@ -51,6 +51,9 @@ class WindowServiceFactory:
                     "max_sequence_and_generated_tokens_length": model_deployment.max_sequence_and_generated_tokens_length,  # noqa
                     "end_of_text_token": end_of_text_token,
                     "prefix_token": prefix_token,
+                },
+                provider_bindings={
+                    "gpt2_window_service": lambda: WindowServiceFactory.get_window_service("openai/gpt2", service)
                 },
             )
             return create_object(window_service_spec)

--- a/src/helm/benchmark/window_services/yalm_window_service.py
+++ b/src/helm/benchmark/window_services/yalm_window_service.py
@@ -1,34 +1,7 @@
-from helm.proxy.tokenizers.yalm_tokenizer_data.yalm_tokenizer import YaLMTokenizer
 from .local_window_service import LocalWindowService
-from .tokenizer_service import TokenizerService
 
 
 class YaLMWindowService(LocalWindowService):
-    def __init__(self, service: TokenizerService):
-        super().__init__(service)
-
-    @property
-    def tokenizer_name(self) -> str:
-        return "Yandex/yalm"
-
-    @property
-    def max_sequence_length(self) -> int:
-        return YaLMTokenizer.MAX_SEQUENCE_LENGTH
-
-    @property
-    def max_request_length(self) -> int:
-        return self.max_sequence_length + 1
-
-    @property
-    def end_of_text_token(self) -> str:
-        """The end of text token."""
-        return YaLMTokenizer.EOS_TOKEN
-
-    @property
-    def prefix_token(self) -> str:
-        """The prefix token"""
-        return self.end_of_text_token
-
     def truncate_from_right(self, text: str, expected_completion_token_length: int = 0) -> str:
         """
         Truncates text from the right to fit within the context window given by `max_request_length`

--- a/src/helm/common/clip_score_request.py
+++ b/src/helm/common/clip_score_request.py
@@ -2,6 +2,9 @@ from dataclasses import dataclass
 from typing import Optional
 
 
+DEFAULT_CLIP_SCORE_MODEL = "openai/clip-vit-large-patch14"
+
+
 @dataclass(frozen=True)
 class CLIPScoreRequest:
     """
@@ -15,7 +18,7 @@ class CLIPScoreRequest:
     image_location: str
 
     # Which CLIP model to use
-    model: str = "openai/clip-vit-large-patch14"
+    model: str = DEFAULT_CLIP_SCORE_MODEL
 
     # Compute multilingual CLIPScore
     multilingual: bool = False

--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -42,10 +42,6 @@ model_deployments:
       class_name: "helm.proxy.clients.ai21_client.AI21Client"
     window_service_spec:
       class_name: "helm.benchmark.window_services.ai21_window_service.AI21WindowService"
-      args:
-        gpt2_window_service:
-          class_name: "helm.benchmark.window_services.gpt2_window_service.GPT2WindowService"
-          args: {}
 
   - name: ai21/j1-large
     deprecated: true
@@ -56,10 +52,6 @@ model_deployments:
       class_name: "helm.proxy.clients.ai21_client.AI21Client"
     window_service_spec:
       class_name: "helm.benchmark.window_services.ai21_window_service.AI21WindowService"
-      args:
-        gpt2_window_service:
-          class_name: "helm.benchmark.window_services.gpt2_window_service.GPT2WindowService"
-          args: {}
 
   - name: ai21/j1-grande
     deprecated: true
@@ -70,10 +62,6 @@ model_deployments:
       class_name: "helm.proxy.clients.ai21_client.AI21Client"
     window_service_spec:
       class_name: "helm.benchmark.window_services.ai21_window_service.AI21WindowService"
-      args:
-        gpt2_window_service:
-          class_name: "helm.benchmark.window_services.gpt2_window_service.GPT2WindowService"
-          args: {}
 
   - name: ai21/j1-grande-v2-beta
     deprecated: true
@@ -84,10 +72,6 @@ model_deployments:
       class_name: "helm.proxy.clients.ai21_client.AI21Client"
     window_service_spec:
       class_name: "helm.benchmark.window_services.ai21_window_service.AI21WindowService"
-      args:
-        gpt2_window_service:
-          class_name: "helm.benchmark.window_services.gpt2_window_service.GPT2WindowService"
-          args: {}
 
   - name: ai21/j2-jumbo
     model_name: ai21/j2-jumbo
@@ -97,10 +81,6 @@ model_deployments:
       class_name: "helm.proxy.clients.ai21_client.AI21Client"
     window_service_spec:
       class_name: "helm.benchmark.window_services.wider_ai21_window_service.AI21Jurassic2JumboWindowService"
-      args:
-        gpt2_window_service:
-          class_name: "helm.benchmark.window_services.gpt2_window_service.GPT2WindowService"
-          args: {}
 
   - name: ai21/j2-large
     model_name: ai21/j2-large
@@ -110,10 +90,6 @@ model_deployments:
       class_name: "helm.proxy.clients.ai21_client.AI21Client"
     window_service_spec:
       class_name: "helm.benchmark.window_services.ai21_window_service.AI21WindowService"
-      args:
-        gpt2_window_service:
-          class_name: "helm.benchmark.window_services.gpt2_window_service.GPT2WindowService"
-          args: {}
 
   - name: ai21/j2-grande
     model_name: ai21/j2-grande
@@ -123,10 +99,6 @@ model_deployments:
       class_name: "helm.proxy.clients.ai21_client.AI21Client"
     window_service_spec:
       class_name: "helm.benchmark.window_services.ai21_window_service.AI21WindowService"
-      args:
-        gpt2_window_service:
-          class_name: "helm.benchmark.window_services.gpt2_window_service.GPT2WindowService"
-          args: {}
 
 
 

--- a/src/helm/proxy/clients/clip_score_client.py
+++ b/src/helm/proxy/clients/clip_score_client.py
@@ -2,7 +2,7 @@ from typing import Dict, Optional
 from dataclasses import asdict
 
 from helm.common.cache import Cache, CacheConfig
-from helm.common.clip_score_request import CLIPScoreRequest, CLIPScoreResult
+from helm.common.clip_score_request import DEFAULT_CLIP_SCORE_MODEL, CLIPScoreRequest, CLIPScoreResult
 from .clip_scorers.clip_scorer import CLIPScorer
 
 
@@ -20,7 +20,7 @@ class CLIPScoreClient:
         Compute a CLIPScore for a given caption and image.
         """
         # TODO: support multilingual CLIPScore and other CLIP models.
-        assert request.model == "openai/clip-vit-large-patch14", f"Unsupported model: {request.model}"
+        assert request.model == DEFAULT_CLIP_SCORE_MODEL, f"Unsupported model: {request.model}"
         assert not request.multilingual
 
         try:


### PR DESCRIPTION
Instead of using hardcoded constants, load window service properties from `tokenizer_configs.yaml` and `model_deployments.yaml`.