### PR TITLE
Stop inheriting from Metric in classes that don't use its implementation

### DIFF
--- a/src/helm/benchmark/metrics/dry_run_metrics.py
+++ b/src/helm/benchmark/metrics/dry_run_metrics.py
@@ -8,7 +8,7 @@ from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.metrics.statistic import Stat, merge_stat
 from helm.benchmark.window_services.window_service import WindowService
 from helm.benchmark.window_services.window_service_factory import WindowServiceFactory
-from .metric import Metric, MetricResult, PerInstanceStats
+from .metric import MetricInterface, MetricResult, PerInstanceStats
 from .metric_name import MetricName
 from .metric_service import MetricService
 from .tokens.auto_token_cost_estimator import AutoTokenCostEstimator
@@ -47,7 +47,7 @@ class Processor:
         return stats
 
 
-class DryRunMetric(Metric):
+class DryRunMetric(MetricInterface):
     """Metrics for dry run."""
 
     def __init__(self):

--- a/src/helm/benchmark/metrics/image_generation/denoised_runtime_metric.py
+++ b/src/helm/benchmark/metrics/image_generation/denoised_runtime_metric.py
@@ -8,12 +8,12 @@ from helm.common.request import RequestResult
 from helm.benchmark.scenarios.scenario import Instance
 from helm.benchmark.adaptation.scenario_state import ScenarioState
 from helm.benchmark.metrics.statistic import Stat
-from helm.benchmark.metrics.metric import Metric, MetricResult
+from helm.benchmark.metrics.metric import MetricInterface, MetricResult
 from helm.benchmark.metrics.metric_name import MetricName
 from helm.benchmark.metrics.metric_service import MetricService
 
 
-class DenoisedRuntimeMetric(Metric):
+class DenoisedRuntimeMetric(MetricInterface):
     def __repr__(self):
         return "DenoisedRuntimeMetric()"
 

--- a/src/helm/benchmark/metrics/image_generation/fidelity_metrics.py
+++ b/src/helm/benchmark/metrics/image_generation/fidelity_metrics.py
@@ -11,14 +11,14 @@ from helm.benchmark.augmentations.perturbation_description import PerturbationDe
 from helm.benchmark.scenarios.scenario import Instance
 from helm.benchmark.adaptation.scenario_state import ScenarioState
 from helm.benchmark.metrics.statistic import Stat
-from helm.benchmark.metrics.metric import Metric, MetricResult
+from helm.benchmark.metrics.metric import MetricInterface, MetricResult
 from helm.benchmark.metrics.metric_name import MetricName
 from helm.benchmark.metrics.metric_service import MetricService
 from helm.common.images_utils import is_blacked_out_image, copy_image
 from helm.common.optional_dependencies import handle_module_not_found_error
 
 
-class FidelityMetric(Metric):
+class FidelityMetric(MetricInterface):
     """
     Frechet Inception Distance (FID) is a measure of similarity between two sets of images.
     Inception Score (IS) measures quality and diversity of images.

--- a/src/helm/benchmark/metrics/image_generation/image_critique_metrics.py
+++ b/src/helm/benchmark/metrics/image_generation/image_critique_metrics.py
@@ -5,7 +5,7 @@ import numpy as np
 from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.adaptation.scenario_state import ScenarioState
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
-from helm.benchmark.metrics.metric import Metric, MetricResult, PerInstanceStats, add_context
+from helm.benchmark.metrics.metric import MetricInterface, MetricResult, PerInstanceStats, add_context
 from helm.benchmark.metrics.metric_name import MetricContext, MetricName
 from helm.benchmark.metrics.metric_service import MetricService
 from helm.benchmark.metrics.statistic import Stat, merge_stat
@@ -18,7 +18,7 @@ from helm.common.request import RequestResult
 from helm.common.multimodal_request_utils import gather_generated_image_locations
 
 
-class ImageCritiqueMetric(Metric):
+class ImageCritiqueMetric(MetricInterface):
     """
     Critique evaluation for image generation. Possesses the ability to ask human
     annotators the following questions about the generated images:

--- a/src/helm/benchmark/metrics/image_generation/photorealism_critique_metrics.py
+++ b/src/helm/benchmark/metrics/image_generation/photorealism_critique_metrics.py
@@ -5,7 +5,7 @@ import numpy as np
 from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.adaptation.scenario_state import ScenarioState
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
-from helm.benchmark.metrics.metric import Metric, MetricResult, PerInstanceStats, add_context
+from helm.benchmark.metrics.metric import MetricInterface, MetricResult, PerInstanceStats, add_context
 from helm.benchmark.metrics.metric_name import MetricContext, MetricName
 from helm.benchmark.metrics.metric_service import MetricService
 from helm.benchmark.metrics.statistic import Stat, merge_stat
@@ -18,7 +18,7 @@ from helm.common.request import RequestResult
 from helm.common.multimodal_request_utils import gather_generated_image_locations
 
 
-class PhotorealismCritiqueMetric(Metric):
+class PhotorealismCritiqueMetric(MetricInterface):
     """
     Critique evaluation for evaluating how photorealistic the generated images are by humans.
     """


### PR DESCRIPTION
All of these classes define their own evaluation method and don't call any other methods defined in Metric from that.