### PR TITLE
Register configs in SlurmRunner

### DIFF
--- a/src/helm/benchmark/config_registry.py
+++ b/src/helm/benchmark/config_registry.py
@@ -13,7 +13,7 @@ MODEL_DEPLOYMENTS_FILE: str = "model_deployments.yaml"
 CONFIG_PACKAGE = "helm.config"
 
 
-def register_configs_from_directory(dir_path) -> None:
+def register_configs_from_directory(dir_path: str) -> None:
     model_metadata_path = os.path.join(dir_path, MODEL_METADATA_FILE)
     if os.path.isfile(model_metadata_path):
         register_model_metadata_from_path(model_metadata_path)


### PR DESCRIPTION
#2142 requires all entry points to call the configuration registration, but `SlurmRunner` had another entry point that did not call the config registration. This PR adds config registration to that entry point.