### PR TITLE
Improve Python pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,9 @@ repos:
       name: run-pre-commit
       entry: ./pre-commit.sh
       language: script
+      pass_filenames: false
+      require_serial: true
+      types_or: [python]
 - repo: https://github.com/pre-commit/mirrors-prettier
   rev: 'fc260393cc4ec09f8fc0a5ba4437f481c8b55dc1'
   hooks:


### PR DESCRIPTION
- Only run Python pre-commit when Python files are changed
- Fixed a bug where a commit with a large changed file list can cause concurrent instances of `pre-commit.sh` to be spawned, which can lead to errors due to concurrent runs of `mypy`.