### PR TITLE
Add a flag to serve the React frontend on helm-server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ notes.otl
 .nfs*
 
 node_modules
+
+# frontend build
+static_build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,4 +9,5 @@ repos:
   rev: 'fc260393cc4ec09f8fc0a5ba4437f481c8b55dc1'
   hooks:
     - id: prettier
+      files: "helm-frontend"
       types_or: [tsx, javascript]

--- a/helm-frontend/index.html
+++ b/helm-frontend/index.html
@@ -2,14 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/helm.svg" />
+    <link rel="icon" type="image/svg+xml" href="./helm.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Holistic Evaluation of Language Models (HELM)</title>
     <meta name="description" content="The Holistic Evaluation of Language Models (HELM) serves as a living benchmark for transparency in language models. Providing broad coverage and recognizing incompleteness, multi-metric measurements, and standardization. All data and analysis are freely accessible on the website for exploration and study." />
-    <script type="text/javascript" src="/config.js"></script>
+    <script type="text/javascript" src="./config.js"></script>
   </head>
   <body class="block">
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/helm-frontend/public/config.js
+++ b/helm-frontend/public/config.js
@@ -1,3 +1,4 @@
-window.BENCHMARK_OUTPUT_BASE_URL = "./benchmark_output";
+window.BENCHMARK_OUTPUT_BASE_URL =
+  "https://storage.googleapis.com/crfm-helm-public/lite/benchmark_output/";
 window.SUITE = null;
-window.RELEASE = "latest";
+window.RELEASE = "v1.0.0";

--- a/helm-frontend/public/config.js
+++ b/helm-frontend/public/config.js
@@ -1,4 +1,3 @@
-window.BENCHMARK_OUTPUT_BASE_URL =
-  "https://storage.googleapis.com/crfm-helm-public/lite/";
+window.BENCHMARK_OUTPUT_BASE_URL = "./benchmark_output";
 window.SUITE = null;
-window.RELEASE = "v1.0.0";
+window.RELEASE = "latest";

--- a/helm-frontend/src/services/getDisplayPredictionsByName.ts
+++ b/helm-frontend/src/services/getDisplayPredictionsByName.ts
@@ -10,7 +10,7 @@ export default async function getDisplayPredictionsByName(
   try {
     const displayPrediction = await fetch(
       getBenchmarkEndpoint(
-        `/benchmark_output/runs/${
+        `/runs/${
           suite || getBenchmarkSuite()
         }/${runName}/display_predictions.json`,
       ),

--- a/helm-frontend/src/services/getDisplayRequestsByName.ts
+++ b/helm-frontend/src/services/getDisplayRequestsByName.ts
@@ -10,7 +10,7 @@ export default async function getDisplayRequestsByName(
   try {
     const displayRequest = await fetch(
       getBenchmarkEndpoint(
-        `/benchmark_output/runs/${
+        `/runs/${
           suite || getBenchmarkSuite()
         }/${runName}/display_requests.json`,
       ),

--- a/helm-frontend/src/services/getInstances.ts
+++ b/helm-frontend/src/services/getInstances.ts
@@ -10,9 +10,7 @@ export default async function getInstancesByRunName(
   try {
     const instances = await fetch(
       getBenchmarkEndpoint(
-        `/runs/${
-          suite || getBenchmarkSuite()
-        }/${runName}/instances.json`,
+        `/runs/${suite || getBenchmarkSuite()}/${runName}/instances.json`,
       ),
       { signal },
     );

--- a/helm-frontend/src/services/getInstances.ts
+++ b/helm-frontend/src/services/getInstances.ts
@@ -10,7 +10,7 @@ export default async function getInstancesByRunName(
   try {
     const instances = await fetch(
       getBenchmarkEndpoint(
-        `/benchmark_output/runs/${
+        `/runs/${
           suite || getBenchmarkSuite()
         }/${runName}/instances.json`,
       ),

--- a/helm-frontend/src/services/getRunSpecByName.ts
+++ b/helm-frontend/src/services/getRunSpecByName.ts
@@ -4,7 +4,7 @@ import getBenchmarkSuite from "@/utils/getBenchmarkSuite";
 
 export function getRunSpecByNameUrl(runName: string, suite?: string): string {
   return getBenchmarkEndpoint(
-    `/benchmark_output/runs/${
+    `/runs/${
       suite || getBenchmarkSuite()
     }/${runName}/run_spec.json`,
   );

--- a/helm-frontend/src/services/getRunSpecByName.ts
+++ b/helm-frontend/src/services/getRunSpecByName.ts
@@ -4,9 +4,7 @@ import getBenchmarkSuite from "@/utils/getBenchmarkSuite";
 
 export function getRunSpecByNameUrl(runName: string, suite?: string): string {
   return getBenchmarkEndpoint(
-    `/runs/${
-      suite || getBenchmarkSuite()
-    }/${runName}/run_spec.json`,
+    `/runs/${suite || getBenchmarkSuite()}/${runName}/run_spec.json`,
   );
 }
 export default async function getRunSpecByName(

--- a/helm-frontend/src/services/getRunsToRunSuites.ts
+++ b/helm-frontend/src/services/getRunsToRunSuites.ts
@@ -7,7 +7,7 @@ export default async function getRunsToRunSuites(
   try {
     const runsToRunSuites = await fetch(
       getBenchmarkEndpoint(
-        `/benchmark_output/releases/${getBenchmarkRelease()}/runs_to_run_suites.json`,
+        `/releases/${getBenchmarkRelease()}/runs_to_run_suites.json`,
       ),
       { signal },
     );

--- a/helm-frontend/src/services/getScenarioByName.ts
+++ b/helm-frontend/src/services/getScenarioByName.ts
@@ -10,9 +10,7 @@ export default async function getScenarioByName(
   try {
     const scenario = await fetch(
       getBenchmarkEndpoint(
-        `/runs/${
-          suite || getBenchmarkSuite()
-        }/${scenarioName}/scenario.json`,
+        `/runs/${suite || getBenchmarkSuite()}/${scenarioName}/scenario.json`,
       ),
       { signal },
     );

--- a/helm-frontend/src/services/getScenarioByName.ts
+++ b/helm-frontend/src/services/getScenarioByName.ts
@@ -10,7 +10,7 @@ export default async function getScenarioByName(
   try {
     const scenario = await fetch(
       getBenchmarkEndpoint(
-        `/benchmark_output/runs/${
+        `/runs/${
           suite || getBenchmarkSuite()
         }/${scenarioName}/scenario.json`,
       ),

--- a/helm-frontend/src/services/getScenarioStateByName.ts
+++ b/helm-frontend/src/services/getScenarioStateByName.ts
@@ -6,8 +6,6 @@ export function getScenarioStateByNameUrl(
   suite?: string,
 ): string {
   return getBenchmarkEndpoint(
-    `/runs/${
-      suite || getBenchmarkSuite()
-    }/${runName}/scenario_state.json`,
+    `/runs/${suite || getBenchmarkSuite()}/${runName}/scenario_state.json`,
   );
 }

--- a/helm-frontend/src/services/getScenarioStateByName.ts
+++ b/helm-frontend/src/services/getScenarioStateByName.ts
@@ -6,7 +6,7 @@ export function getScenarioStateByNameUrl(
   suite?: string,
 ): string {
   return getBenchmarkEndpoint(
-    `/benchmark_output/runs/${
+    `/runs/${
       suite || getBenchmarkSuite()
     }/${runName}/scenario_state.json`,
   );

--- a/helm-frontend/src/services/getStatsByName.ts
+++ b/helm-frontend/src/services/getStatsByName.ts
@@ -10,9 +10,7 @@ export default async function getStatsByName(
   try {
     const stats = await fetch(
       getBenchmarkEndpoint(
-        `/runs/${
-          suite || getBenchmarkSuite()
-        }/${runName}/stats.json`,
+        `/runs/${suite || getBenchmarkSuite()}/${runName}/stats.json`,
       ),
       { signal },
     );

--- a/helm-frontend/src/services/getStatsByName.ts
+++ b/helm-frontend/src/services/getStatsByName.ts
@@ -10,7 +10,7 @@ export default async function getStatsByName(
   try {
     const stats = await fetch(
       getBenchmarkEndpoint(
-        `/benchmark_output/runs/${
+        `/runs/${
           suite || getBenchmarkSuite()
         }/${runName}/stats.json`,
       ),

--- a/helm-frontend/src/utils/getVersionBaseUrl.ts
+++ b/helm-frontend/src/utils/getVersionBaseUrl.ts
@@ -1,7 +1,7 @@
 export default function getVersionBaseUrl(): string {
   if (window.RELEASE) {
-    return `/benchmark_output/releases/${window.RELEASE}`;
+    return `/releases/${window.RELEASE}`;
   } else {
-    return `/benchmark_output/runs/${window.SUITE}`;
+    return `/runs/${window.SUITE}`;
   }
 }

--- a/helm-frontend/vite.config.ts
+++ b/helm-frontend/vite.config.ts
@@ -4,6 +4,7 @@ import path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: "",
   plugins: [react()],
   resolve: {
     alias: {
@@ -16,5 +17,15 @@ export default defineConfig({
   },
   build: {
     outDir: `${__dirname}/../src/helm/benchmark/static_build`,
+    emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          react: ['react', 'react-dom', 'react-markdown', 'react-router-dom', 'react-spinners'],
+          tremor: ["@tremor/react"],
+          recharts: ["recharts"],
+        }
+      }
+    }
   },
 });

--- a/helm-frontend/vite.config.ts
+++ b/helm-frontend/vite.config.ts
@@ -20,8 +20,9 @@ export default defineConfig({
     emptyOutDir: true,
     rollupOptions: {
       output: {
+        // Manually chunk large libraries to keep chunk size under 500 KB
         manualChunks: {
-          react: ['react', 'react-dom', 'react-markdown', 'react-router-dom', 'react-spinners'],
+          react: ["react", "react-dom", "react-markdown", "react-router-dom", "react-spinners"],
           tremor: ["@tremor/react"],
           recharts: ["recharts"],
         }

--- a/src/helm/benchmark/server.py
+++ b/src/helm/benchmark/server.py
@@ -99,6 +99,11 @@ def main():
         default=None,
         help="Experimental: The release to serve. If unset, don't serve a release, and serve the latest suite instead.",
     )
+    parser.add_argument(
+        "--react",
+        action="store_true",
+        help="Whether to serve the React frontend instead of the jQuery frontend.",
+    )
     args = parser.parse_args()
 
     if args.suite and args.release:
@@ -107,7 +112,8 @@ def main():
     # Determine the location of the static directory.
     # This is a hack: it assumes that the static directory has a physical location,
     # which is not always the case (e.g. when using zipimport).
-    resource_path = resources.files("helm.benchmark.static").joinpath("index.html")
+    static_package_name = "helm.benchmark.static_build" if args.react else "helm.benchmark.static"
+    resource_path = resources.files(static_package_name).joinpath("index.html")
     with resources.as_file(resource_path) as resource_filename:
         static_path = str(resource_filename.parent)
 
@@ -127,6 +133,7 @@ def main():
     app.config["helm.suite"] = args.suite or "latest"
     app.config["helm.release"] = args.release
 
+    print(f"After the web server has started, go to http://localhost:{args.port} to view your website.\n")
     app.run(host="0.0.0.0", port=args.port)
 
 


### PR DESCRIPTION
This allows using the React frontend with `helm-server` with a local `benchmark_output` folder:

1. In `helm_frontend/`, run `yarn build`
2. Run `helm-server --react`

This is preparation for replacing the old frontend with the React frontend entirely.