### PR TITLE
Switch caching over to using Mapping instead of Dict.

### DIFF
--- a/src/helm/common/cache.py
+++ b/src/helm/common/cache.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Dict, Callable, Generator, Optional, Tuple
+from typing import Dict, Callable, Generator, Mapping, Optional, Tuple
 import json
 import threading
 
@@ -118,7 +118,7 @@ def create_key_value_store(config: KeyValueStoreCacheConfig) -> KeyValueStore:
 
 
 @retry
-def write_to_key_value_store(key_value_store: KeyValueStore, key: Dict, response: Dict) -> bool:
+def write_to_key_value_store(key_value_store: KeyValueStore, key: Mapping, response: Dict) -> bool:
     """
     Write to the key value store with retry. Returns boolean indicating whether the write was successful or not.
     """
@@ -188,7 +188,7 @@ class Cache(object):
         else:
             raise ValueError(f"CacheConfig with unknown type: {config}")
 
-    def get(self, request: Dict, compute: Callable[[], Dict]) -> Tuple[Dict, bool]:
+    def get(self, request: Mapping, compute: Callable[[], Dict]) -> Tuple[Dict, bool]:
         """Get the result of `request` (by calling `compute` as needed)."""
         cache_stats.increment_query(self.config.cache_stats_key)
 

--- a/src/helm/common/key_value_store.py
+++ b/src/helm/common/key_value_store.py
@@ -1,12 +1,12 @@
 from abc import abstractmethod
 import contextlib
 import json
-from typing import Dict, Generator, Iterable, Optional, Tuple
+from typing import Dict, Generator, Iterable, Mapping, Optional, Tuple
 
 from sqlitedict import SqliteDict
 
 
-def request_to_key(request: Dict) -> str:
+def request_to_key(request: Mapping) -> str:
     """Normalize a `request` into a `key` so that we can hash using it."""
     return json.dumps(request, sort_keys=True)
 
@@ -27,7 +27,7 @@ class KeyValueStore(contextlib.AbstractContextManager):
         pass
 
     @abstractmethod
-    def put(self, key: Dict, value: Dict) -> None:
+    def put(self, key: Mapping, value: Dict) -> None:
         pass
 
     @abstractmethod
@@ -68,7 +68,7 @@ class SqliteKeyValueStore(KeyValueStore):
         for key, value in self._sqlite_dict.items():
             yield (key, value)
 
-    def put(self, key: Dict, value: Dict) -> None:
+    def put(self, key: Mapping, value: Dict) -> None:
         key_string = request_to_key(key)
         self._sqlite_dict[key_string] = value
         self._sqlite_dict.commit()

--- a/src/helm/common/mongo_key_value_store.py
+++ b/src/helm/common/mongo_key_value_store.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, Generator, Iterable, Optional, Tuple
+from typing import Dict, Generator, Iterable, Mapping, Optional, Tuple
 
 from helm.common.key_value_store import KeyValueStore
 from helm.common.optional_dependencies import handle_module_not_found_error
@@ -35,7 +35,7 @@ class MongoKeyValueStore(KeyValueStore):
     def __exit__(self, exc_type, exc_value, traceback) -> None:
         return
 
-    def _canonicalize_key(self, key: Dict) -> SON:
+    def _canonicalize_key(self, key: Mapping) -> SON:
         serialized = json.dumps(key, sort_keys=True)
         return json.loads(serialized, object_pairs_hook=SON)
 
@@ -63,7 +63,7 @@ class MongoKeyValueStore(KeyValueStore):
             else:
                 yield (request, response)
 
-    def put(self, key: Dict, value: Dict) -> None:
+    def put(self, key: Mapping, value: Dict) -> None:
         request = self._canonicalize_key(key)
         document = SON([(self._REQUEST_KEY, request), (self._RESPONSE_KEY, value)])
         # The MongoDB collection should have a unique indexed on "request"

--- a/src/helm/proxy/clients/client.py
+++ b/src/helm/proxy/clients/client.py
@@ -1,6 +1,6 @@
 import json
 from abc import ABC, abstractmethod
-from typing import Dict, List, Mapping, Optional
+from typing import List, Mapping, Optional
 
 from helm.common.hierarchical_logger import hlog
 from helm.common.media_object import MultimediaObject, TEXT_TYPE

--- a/src/helm/proxy/clients/client.py
+++ b/src/helm/proxy/clients/client.py
@@ -1,6 +1,6 @@
 import json
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional
+from typing import Dict, List, Mapping, Optional
 
 from helm.common.hierarchical_logger import hlog
 from helm.common.media_object import MultimediaObject, TEXT_TYPE
@@ -30,14 +30,14 @@ class CachingClient(Client):
         self.cache = Cache(cache_config) if cache_config is not None else None
 
     @staticmethod
-    def make_cache_key(raw_request: Dict, request: Request) -> Dict:
+    def make_cache_key(raw_request: Mapping, request: Request) -> Mapping:
         """
         Construct the key for the cache using the raw request.
         Add `request.random` to the key, if defined.
         """
         if request.random is not None:
             assert "random" not in raw_request
-            cache_key = {**raw_request, "random": request.random}
+            cache_key: Mapping = {**raw_request, "random": request.random}
         else:
             cache_key = raw_request
         return cache_key

--- a/src/helm/proxy/clients/google_client.py
+++ b/src/helm/proxy/clients/google_client.py
@@ -32,7 +32,7 @@ class GoogleClient(CachingClient):
 
     def make_request(self, request: Request) -> RequestResult:
         raw_request = GoogleClient.convert_to_raw_request(request)
-        cache_key: Dict = CachingClient.make_cache_key(raw_request, request)
+        cache_key = CachingClient.make_cache_key(raw_request, request)
 
         try:
 

--- a/src/helm/proxy/clients/huggingface_client.py
+++ b/src/helm/proxy/clients/huggingface_client.py
@@ -5,7 +5,7 @@ from transformers.generation.stopping_criteria import (
     StoppingCriteria,
     StoppingCriteriaList,
 )
-from typing import Any, Dict, List, Optional, TypedDict
+from typing import Any, Dict, List, Optional
 
 from helm.common.cache import CacheConfig
 from helm.common.hierarchical_logger import htrack_block, hlog
@@ -240,7 +240,7 @@ class HuggingFaceClient(CachingClient):
         if request.embedding:
             return EMBEDDING_UNAVAILABLE_REQUEST_RESULT
 
-        raw_request: HuggingFaceRequest = {
+        raw_request = {
             "engine": request.model_engine,
             "prompt": request.prompt,
             "temperature": 1e-7 if request.temperature == 0 else request.temperature,

--- a/src/helm/proxy/clients/huggingface_client.py
+++ b/src/helm/proxy/clients/huggingface_client.py
@@ -5,7 +5,7 @@ from transformers.generation.stopping_criteria import (
     StoppingCriteria,
     StoppingCriteriaList,
 )
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, TypedDict
 
 from helm.common.cache import CacheConfig
 from helm.common.hierarchical_logger import htrack_block, hlog
@@ -240,7 +240,7 @@ class HuggingFaceClient(CachingClient):
         if request.embedding:
             return EMBEDDING_UNAVAILABLE_REQUEST_RESULT
 
-        raw_request = {
+        raw_request: HuggingFaceRequest = {
             "engine": request.model_engine,
             "prompt": request.prompt,
             "temperature": 1e-7 if request.temperature == 0 else request.temperature,

--- a/src/helm/proxy/clients/image_generation/adobe_vision_client.py
+++ b/src/helm/proxy/clients/image_generation/adobe_vision_client.py
@@ -43,7 +43,7 @@ class AdobeVisionClient(Client):
 
         raw_request = AdobeVisionClient.convert_to_raw_request(request)
         raw_request.pop("random", None)
-        cache_key: Dict = CachingClient.make_cache_key(raw_request, request)
+        cache_key = CachingClient.make_cache_key(raw_request, request)
 
         try:
 

--- a/src/helm/proxy/clients/image_generation/aleph_alpha_image_generation_client.py
+++ b/src/helm/proxy/clients/image_generation/aleph_alpha_image_generation_client.py
@@ -63,7 +63,7 @@ class AlephAlphaImageGenerationClient(Client):
 
         raw_request = AlephAlphaImageGenerationClient.convert_to_raw_request(request)
         raw_request.pop("random", None)
-        cache_key: Dict = CachingClient.make_cache_key(raw_request, request)
+        cache_key = CachingClient.make_cache_key(raw_request, request)
 
         try:
 

--- a/src/helm/proxy/clients/image_generation/cogview2_client.py
+++ b/src/helm/proxy/clients/image_generation/cogview2_client.py
@@ -162,7 +162,7 @@ class CogView2Client(Client):
                     return result
 
             # Include the model name and number of completions in the cache key
-            cache_key: Dict = CachingClient.make_cache_key(
+            cache_key = CachingClient.make_cache_key(
                 {"model": request.model_engine, "n": request.num_completions, **raw_request}, request
             )
             results, cached = self._cache.get(cache_key, wrap_request_time(do_it))

--- a/src/helm/proxy/clients/image_generation/dalle_mini_client.py
+++ b/src/helm/proxy/clients/image_generation/dalle_mini_client.py
@@ -161,7 +161,7 @@ class DALLEMiniClient(Client):
                     return result
 
             # Include the model name and number of completions in the cache key
-            cache_key: Dict = CachingClient.make_cache_key(
+            cache_key = CachingClient.make_cache_key(
                 {"model": request.model_engine, "n": request.num_completions, **raw_request}, request
             )
             results, cached = self._cache.get(cache_key, wrap_request_time(do_it))

--- a/src/helm/proxy/clients/image_generation/dalle_mini_client.py
+++ b/src/helm/proxy/clients/image_generation/dalle_mini_client.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import List
 
 import numpy as np
 from functools import partial

--- a/src/helm/proxy/clients/image_generation/deep_floyd_client.py
+++ b/src/helm/proxy/clients/image_generation/deep_floyd_client.py
@@ -43,7 +43,7 @@ class DeepFloydClient(Client):
             raise ValueError(f"Unsupported model: {request.model_engine}")
 
         raw_request = DeepFloydClient.convert_to_raw_request(request)
-        cache_key: Dict = CachingClient.make_cache_key(raw_request, request)
+        cache_key = CachingClient.make_cache_key(raw_request, request)
 
         try:
 

--- a/src/helm/proxy/clients/image_generation/huggingface_diffusers_client.py
+++ b/src/helm/proxy/clients/image_generation/huggingface_diffusers_client.py
@@ -173,7 +173,7 @@ class HuggingFaceDiffusersClient(Client):
                     return result
 
             # Include the model name and number of completions in the cache key
-            cache_key: Dict = CachingClient.make_cache_key(
+            cache_key = CachingClient.make_cache_key(
                 {"model": request.model_engine, "n": request.num_completions, **raw_request}, request
             )
             results, cached = self._cache.get(cache_key, wrap_request_time(do_it))

--- a/src/helm/proxy/clients/image_generation/lexica_client.py
+++ b/src/helm/proxy/clients/image_generation/lexica_client.py
@@ -40,7 +40,7 @@ class LexicaClient(Client):
             "prompt": request.prompt,
             "n": request.num_completions,
         }
-        cache_key: Dict = CachingClient.make_cache_key(raw_request, request)
+        cache_key = CachingClient.make_cache_key(raw_request, request)
 
         try:
 

--- a/src/helm/proxy/clients/image_generation/together_image_generation_client.py
+++ b/src/helm/proxy/clients/image_generation/together_image_generation_client.py
@@ -64,7 +64,7 @@ class TogetherImageGenerationClient(Client):
             raw_request["width"] = request.image_generation_parameters.output_image_width
             raw_request["height"] = request.image_generation_parameters.output_image_height
 
-        cache_key: Dict = CachingClient.make_cache_key(raw_request, request)
+        cache_key = CachingClient.make_cache_key(raw_request, request)
 
         try:
 

--- a/src/helm/proxy/clients/image_generation/together_image_generation_client.py
+++ b/src/helm/proxy/clients/image_generation/together_image_generation_client.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Optional
+from typing import List, Optional
 import base64
 import requests
 

--- a/src/helm/proxy/clients/together_client.py
+++ b/src/helm/proxy/clients/together_client.py
@@ -183,7 +183,7 @@ class TogetherClient(CachingClient):
 
     def make_request(self, request: Request) -> RequestResult:
         raw_request = TogetherClient.convert_to_raw_request(request)
-        cache_key: Dict = CachingClient.make_cache_key(raw_request, request)
+        cache_key = CachingClient.make_cache_key(raw_request, request)
 
         if not self.api_key:
             raise TogetherClientError("togetherApiKey not set in credentials.conf")


### PR DESCRIPTION
`Mapping` is the immutable base class of `dict`. By using `Mapping` we gain two benefits:

1. Type checking ensures we aren't trying to mutate the arguments within caching.
2. Caching will accept dict-like objects like TypedDict.