### PR TITLE
Fix models documentation

### DIFF
--- a/docs/mkdocs_hooks.py
+++ b/docs/mkdocs_hooks.py
@@ -1,0 +1,5 @@
+from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
+
+
+def on_startup(command: str, dirty: bool):
+    register_builtin_configs_from_helm_package()

--- a/docs/mkdocs_macros.py
+++ b/docs/mkdocs_macros.py
@@ -5,12 +5,6 @@ from helm.benchmark.run_expander import RUN_EXPANDERS, RunExpander
 
 
 def define_env(env):
-    @env.macro
-    def model_types_and_tags() -> Dict[str, str]:
-        return {
-            "Text": TEXT_MODEL_TAG,
-            "Code": CODE_MODEL_TAG,
-        }
 
     @env.macro
     def models_by_organization_with_tag(tag: str) -> Dict[str, List[ModelMetadata]]:

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,9 +1,23 @@
 # Models
 
-Please visit the models [page](https://crfm.stanford.edu/helm/latest/?models) of HELM's website 
-for a list of available models and their descriptions.
+{% for model_type, model_tag in model_types_and_tags().items() %}
 
+## {{ model_type }} Models
+
+{% for organization, models in models_by_organization_with_tag(model_tag).items() %}
+
+### {{ organization }}
+
+{% for model in models %}
+
+#### {{ model.display_name }} (`{{ model.name }}`)
+
+{{ model.description }}
+
+{% endfor %}
+{% endfor %}
+{% endfor %}
 
 ## HEIM (text-to-image evaluation)
 
-Please visit the [models page](https://crfm.stanford.edu/heim/latest/?models) of the HEIM results website.
+For a list of image-generation models, please visit the [models page](https://crfm.stanford.edu/heim/latest/?models) of the HEIM results website.

--- a/docs/models.md
+++ b/docs/models.md
@@ -20,4 +20,4 @@
 
 ## HEIM (text-to-image evaluation)
 
-For a list of image-generation models, please visit the [models page](https://crfm.stanford.edu/heim/latest/?models) of the HEIM results website.
+For a list of text-to-image models, please visit the [models page](https://crfm.stanford.edu/heim/latest/?models) of the HEIM results website.

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,16 +1,16 @@
 # Models
 
-{% for model_type, model_tag in model_types_and_tags().items() %}
+## Text Models
 
-## {{ model_type }} Models
+{% for tag in ["TEXT_MODEL_TAG", "CODE_MODEL_TAG"] %}
 
-{% for organization, models in models_by_organization_with_tag(model_tag).items() %}
+{% for organization, models in models_by_organization_with_tag(tag).items() %}
 
 ### {{ organization }}
 
 {% for model in models %}
 
-#### {{ model.display_name }} (`{{ model.name }}`)
+#### {{ model.display_name }} &mdash; `{{ model.name }}`
 
 {{ model.description }}
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,8 @@ plugins:
               ignore_init_summary: true
 
   - include-markdown
+hooks:
+  - docs/mkdocs_hooks.py
 extra_css:
   - docstrings.css
 markdown_extensions:


### PR DESCRIPTION
This fixes the mkdocs build.

This also puts the text and code models back on the documentation page, because we now only list _evaluated_ models on the [HELM website](https://crfm.stanford.edu/helm/lite/latest/#/models), rather than _available_ models.