### PR TITLE
Remove top_logprobs: all remaining references.

### DIFF
--- a/src/helm/proxy/clients/aleph_alpha_client.py
+++ b/src/helm/proxy/clients/aleph_alpha_client.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import List
 
 from helm.common.cache import CacheConfig
 from helm.common.media_object import TEXT_TYPE
@@ -86,10 +86,8 @@ class AlephAlphaClient(CachingClient):
 
             # `completion_tokens` is the list of selected tokens.
             for i, token in enumerate(completion.get("completion_tokens", [])):
-                # Get the top K logprobs for the ith token
-                top_logprobs: Dict[str, float] = completion["log_probs"][i]
                 # Use the selected token value to get the logprob
-                logprob: float = top_logprobs[token]
+                logprob: float = completion["log_probs"][i][token]
                 sequence_logprob += logprob
                 tokens.append(
                     Token(

--- a/src/helm/proxy/clients/goose_ai_client.py
+++ b/src/helm/proxy/clients/goose_ai_client.py
@@ -74,9 +74,7 @@ class GooseAIClient(CachingClient):
             tokens: List[Token] = []
 
             raw_data = raw_completion["logprobs"]
-            for text, logprob, top_logprobs in zip(
-                raw_data["tokens"], raw_data["token_logprobs"], raw_data["top_logprobs"]
-            ):
+            for text, logprob in zip(raw_data["tokens"], raw_data["token_logprobs"]):
                 tokens.append(Token(text=text, logprob=logprob or 0))
                 sequence_logprob += logprob or 0
 

--- a/src/helm/proxy/clients/microsoft_client.py
+++ b/src/helm/proxy/clients/microsoft_client.py
@@ -150,9 +150,7 @@ class MicrosoftClient(CachingClient):
                 tokens: List[Token] = []
 
                 raw_data = raw_completion["logprobs"]
-                for text, logprob, top_logprobs in zip(
-                    raw_data["tokens"], raw_data["token_logprobs"], raw_data["top_logprobs"]
-                ):
+                for text, logprob in zip(raw_data["tokens"], raw_data["token_logprobs"]):
                     tokens.append(Token(text=text, logprob=logprob or 0))
                     sequence_logprob += logprob or 0
 

--- a/src/helm/proxy/clients/openai_client.py
+++ b/src/helm/proxy/clients/openai_client.py
@@ -212,9 +212,7 @@ class OpenAIClient(CachingClient):
                 tokens = []
 
                 raw_data = raw_completion["logprobs"]
-                for text, logprob, top_logprobs in zip(
-                    raw_data["tokens"], raw_data["token_logprobs"], raw_data["top_logprobs"]
-                ):
+                for text, logprob in zip(raw_data["tokens"], raw_data["token_logprobs"]):
                     tokens.append(Token(text=text, logprob=logprob or 0))
                     sequence_logprob += logprob or 0
                 completion = Sequence(

--- a/src/helm/proxy/clients/together_client.py
+++ b/src/helm/proxy/clients/together_client.py
@@ -288,9 +288,7 @@ class TogetherClient(CachingClient):
             # Waiting for a fix.
             if "logprobs" in raw_completion:
                 raw_data = raw_completion["logprobs"]
-                for text, logprob, top_logprobs in zip(
-                    raw_data["tokens"], raw_data["token_logprobs"], raw_data["top_logprobs"]
-                ):
+                for text, logprob in zip(raw_data["tokens"], raw_data["token_logprobs"]):
                     # TODO #1654: Check if this is still needed
                     text = cleanup_str(text, "together")
                     tokens.append(Token(text=text, logprob=logprob or 0))

--- a/src/helm/proxy/services/test_service.py
+++ b/src/helm/proxy/services/test_service.py
@@ -197,18 +197,6 @@ def helper_prod_test_service(request: Request, expected_text: str):
         # Consistency of log probs
         assert completion.logprob == sum(token.logprob for token in completion.tokens)
 
-        for token in completion.tokens[1:]:
-            assert len(token.top_logprobs) == request.top_k_per_token
-
-            # If generated token was one of the top, make sure has the right probability
-            if token.text in token.top_logprobs:
-                assert token.logprob == token.top_logprobs[token.text]
-
-            # If temperature = 0, then make sure we're getting the top probability token
-            if request.temperature == 0:
-                assert token.text in token.top_logprobs
-                assert token.logprob == max(token.top_logprobs.values())
-
     # Make sure we get the expected_text in one of the completions
     assert any(completion.text == expected_text for completion in result.completions)
 


### PR DESCRIPTION
This PR removes every identifier containing "top_logprobs" and the code associated, as none of it does anything anymore.