### PR TITLE
feat: add task-parallel support on multi gpus

### DIFF
--- a/src/helm/benchmark/config_registry.py
+++ b/src/helm/benchmark/config_registry.py
@@ -4,7 +4,7 @@ import importlib_resources as resources
 from helm.benchmark.model_deployment_registry import register_model_deployments_from_path
 from helm.benchmark.model_metadata_registry import register_model_metadata_from_path
 from helm.benchmark.tokenizer_config_registry import register_tokenizer_configs_from_path
-from helm.benchmark.slurm_config_registry import register_slurm_config_from_path
+from helm.benchmark.runner_config_registry import register_runner_config_from_path
 
 
 MODEL_METADATA_FILE: str = "model_metadata.yaml"
@@ -28,9 +28,9 @@ def register_configs_from_directory(dir_path: str) -> None:
     if os.path.isfile(model_deployments_path):
         register_model_deployments_from_path(model_deployments_path)
 
-    slurm_config_path = os.path.join(dir_path, SLURM_CONFIG_FILE)
-    if os.path.isfile(slurm_config_path):
-        register_slurm_config_from_path(slurm_config_path)
+    runner_config_path = os.path.join(dir_path, SLURM_CONFIG_FILE)
+    if os.path.isfile(runner_config_path):
+        register_runner_config_from_path(runner_config_path)
 
 
 def register_builtin_configs_from_helm_package() -> None:

--- a/src/helm/benchmark/config_registry.py
+++ b/src/helm/benchmark/config_registry.py
@@ -10,7 +10,7 @@ from helm.benchmark.runner_config_registry import register_runner_config_from_pa
 MODEL_METADATA_FILE: str = "model_metadata.yaml"
 TOKENIZER_CONFIGS_FILE: str = "tokenizer_configs.yaml"
 MODEL_DEPLOYMENTS_FILE: str = "model_deployments.yaml"
-SLURM_CONFIG_FILE: str = "slurm_config.yaml"
+RUNNER_CONFIG_FILE: str = "runner_config.yaml"
 
 CONFIG_PACKAGE = "helm.config"
 
@@ -28,7 +28,7 @@ def register_configs_from_directory(dir_path: str) -> None:
     if os.path.isfile(model_deployments_path):
         register_model_deployments_from_path(model_deployments_path)
 
-    runner_config_path = os.path.join(dir_path, SLURM_CONFIG_FILE)
+    runner_config_path = os.path.join(dir_path, RUNNER_CONFIG_FILE)
     if os.path.isfile(runner_config_path):
         register_runner_config_from_path(runner_config_path)
 

--- a/src/helm/benchmark/multi_gpu_runner.py
+++ b/src/helm/benchmark/multi_gpu_runner.py
@@ -22,7 +22,8 @@ from helm.benchmark.runner_config_registry import RUNNER_CONFIG
 _MAX_CONCURRENT_WORKERS_ENV_NAME = "HELM_MAX_CONCURRENT_WORKERS"
 
 
-# From https://stackoverflow.com/questions/71300294/how-to-terminate-pythons-processpoolexecutor-when-parent-process-dies
+# From
+# https://stackoverflow.com/questions/71300294/how-to-terminate-pythons-processpoolexecutor-when-parent-process-dies
 def start_thread_to_terminate_when_parent_process_dies(ppid):
     pid = os.getpid()
 

--- a/src/helm/benchmark/multi_gpu_runner.py
+++ b/src/helm/benchmark/multi_gpu_runner.py
@@ -12,9 +12,9 @@ from helm.benchmark.runner import Runner, RunSpec, RunnerError
 
 from helm.common.hierarchical_logger import hlog, htrack_block
 
-from helm.benchmark.slurm_config_registry import SLURM_CONFIG
+from helm.benchmark.runner_config_registry import RUNNER_CONFIG
 
-_MAX_CONCURRENT_WORKER_SLURM_JOBS_ENV_NAME = "HELM_MAX_CONCURRENT_WORKER_SLURM_JOBS"
+_MAX_CONCURRENT_WORKERS_ENV_NAME = "HELM_MAX_CONCURRENT_WORKERS"
 
 
 def worker_initialize(gpu_id: int):
@@ -49,11 +49,11 @@ class MultiGPURunner(Runner):
             exit_on_error=exit_on_error,
         )
         # Configure max concurrent worker jobs from the environment variable.
-        env_max_concurrent_worker_slurm_jobs = os.getenv(_MAX_CONCURRENT_WORKER_SLURM_JOBS_ENV_NAME)
-        self.max_concurrent_worker_slurm_jobs = (
-            int(env_max_concurrent_worker_slurm_jobs)
-            if env_max_concurrent_worker_slurm_jobs
-            else SLURM_CONFIG.helm_max_concurrent_worker_slurm_jobs
+        env_max_concurrent_workers = os.getenv(_MAX_CONCURRENT_WORKERS_ENV_NAME)
+        self.max_concurrent_workers = (
+            int(env_max_concurrent_workers)
+            if env_max_concurrent_workers
+            else RUNNER_CONFIG.helm_max_concurrent_workers
         )
 
     def safe_run_one(self, run_spec: RunSpec):
@@ -74,9 +74,9 @@ class MultiGPURunner(Runner):
         # Set the start method to forkserver to avoid issues with CUDA.
         multiprocessing.set_start_method("forkserver")
 
-        with multiprocessing.Pool(processes=self.max_concurrent_worker_slurm_jobs) as pool:
+        with multiprocessing.Pool(processes=self.max_concurrent_workers) as pool:
             # Pin GPUs to each worker process
-            pool.starmap(worker_initialize, [(i,) for i in range(self.max_concurrent_worker_slurm_jobs)])
+            pool.starmap(worker_initialize, [(i,) for i in range(self.max_concurrent_workers)])
 
             # Run all queued tasks
             error_msgs = pool.map(self.safe_run_one, run_specs)

--- a/src/helm/benchmark/multi_gpu_runner.py
+++ b/src/helm/benchmark/multi_gpu_runner.py
@@ -1,0 +1,90 @@
+import traceback
+from typing import List
+import os
+import torch.multiprocessing as multiprocessing
+
+from helm.benchmark.config_registry import (
+    register_configs_from_directory,
+    register_builtin_configs_from_helm_package,
+)
+from helm.benchmark.executor import ExecutionSpec
+from helm.benchmark.runner import Runner, RunSpec, RunnerError
+
+from helm.common.hierarchical_logger import hlog, htrack_block
+
+from helm.benchmark.slurm_config_registry import SLURM_CONFIG
+
+_MAX_CONCURRENT_WORKER_SLURM_JOBS_ENV_NAME = "HELM_MAX_CONCURRENT_WORKER_SLURM_JOBS"
+
+
+def worker_initialize(gpu_id: int):
+    os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
+    hlog(f"Worker {gpu_id} initializing with CUDA_VISIBLE_DEVICES={os.environ['CUDA_VISIBLE_DEVICES']}")
+
+
+class MultiGPURunner(Runner):
+    """Runner that runs the entire benchmark on multiple GPUs.
+
+    This is a thin wrapper around `Runner` that runs the entire benchmark on multiple GPUs using `multiprocessing`."""
+
+    def __init__(
+        self,
+        execution_spec: ExecutionSpec,
+        output_path: str,
+        suite: str,
+        skip_instances: bool,
+        cache_instances: bool,
+        cache_instances_only: bool,
+        skip_completed_runs: bool,
+        exit_on_error: bool,
+    ):
+        super().__init__(
+            execution_spec=execution_spec,
+            output_path=output_path,
+            suite=suite,
+            skip_instances=skip_instances,
+            cache_instances=cache_instances,
+            cache_instances_only=cache_instances_only,
+            skip_completed_runs=skip_completed_runs,
+            exit_on_error=exit_on_error,
+        )
+        # Configure max concurrent worker jobs from the environment variable.
+        env_max_concurrent_worker_slurm_jobs = os.getenv(_MAX_CONCURRENT_WORKER_SLURM_JOBS_ENV_NAME)
+        self.max_concurrent_worker_slurm_jobs = (
+            int(env_max_concurrent_worker_slurm_jobs)
+            if env_max_concurrent_worker_slurm_jobs
+            else SLURM_CONFIG.helm_max_concurrent_worker_slurm_jobs
+        )
+
+    def safe_run_one(self, run_spec: RunSpec):
+        register_builtin_configs_from_helm_package()
+        if self.executor.execution_spec.local_path is not None:
+            register_configs_from_directory(self.executor.execution_spec.local_path)
+
+        try:
+            with htrack_block(f"Running {run_spec.name}"):
+                self.run_one(run_spec)
+        except Exception as e:
+            hlog(f"Error when running {run_spec.name}:\n{traceback.format_exc()}")
+            return e
+
+    def run_all(self, run_specs: List[RunSpec]):
+        """Run the entire benchmark on multiple GPU"""
+
+        # Set the start method to forkserver to avoid issues with CUDA.
+        multiprocessing.set_start_method("forkserver")
+
+        with multiprocessing.Pool(processes=self.max_concurrent_worker_slurm_jobs) as pool:
+            # Pin GPUs to each worker process
+            pool.starmap(worker_initialize, [(i,) for i in range(self.max_concurrent_worker_slurm_jobs)])
+
+            # Run all queued tasks
+            error_msgs = pool.map(self.safe_run_one, run_specs)
+
+        # Raise exception for failed runs, if any.
+        failed_run_names = [
+            run_spec.name for error_msg, run_spec in zip(error_msgs, run_specs) if error_msg is not None
+        ]
+        if failed_run_names:
+            failed_runs_str = ", ".join([f'"{run_name}"' for run_name in failed_run_names])
+            raise RunnerError(f"Failed runs: [{failed_runs_str}]")

--- a/src/helm/benchmark/runner_config_registry.py
+++ b/src/helm/benchmark/runner_config_registry.py
@@ -5,17 +5,17 @@ import yaml
 
 
 @dataclass
-class SlurmConfigSpec:
-    helm_max_concurrent_worker_slurm_jobs: int = 8
+class RunnerConfigSpec:
+    helm_max_concurrent_workers: int = 8
     slurm_monitor_interval: int = 60
     slurm_args: Optional[Dict[str, Any]] = None
 
 
-SLURM_CONFIG = SlurmConfigSpec()
+RUNNER_CONFIG = RunnerConfigSpec()
 
 
-def register_slurm_config_from_path(dir_path: str) -> None:
-    global SLURM_CONFIG
+def register_runner_config_from_path(dir_path: str) -> None:
+    global RUNNER_CONFIG
     with open(dir_path, "r") as f:
         raw = yaml.safe_load(f)
-    SLURM_CONFIG = dacite.from_dict(SlurmConfigSpec, raw)
+    RUNNER_CONFIG = dacite.from_dict(RunnerConfigSpec, raw)

--- a/src/helm/benchmark/slurm_runner.py
+++ b/src/helm/benchmark/slurm_runner.py
@@ -28,7 +28,7 @@ from helm.benchmark.slurm_jobs import (
 from helm.common.general import ensure_directory_exists
 from helm.common.hierarchical_logger import hlog, htrack_block
 
-from helm.benchmark.slurm_config_registry import SLURM_CONFIG
+from helm.benchmark.runner_config_registry import RUNNER_CONFIG
 
 _MAX_CONCURRENT_WORKER_SLURM_JOBS_ENV_NAME = "HELM_MAX_CONCURRENT_WORKER_SLURM_JOBS"
 _SLURM_NODE_NAMES_ENV_NAME = "HELM_SLURM_NODE_NAMES"
@@ -97,7 +97,7 @@ class SlurmRunner(Runner):
         self.max_concurrent_worker_slurm_jobs = (
             int(env_max_concurrent_worker_slurm_jobs)
             if env_max_concurrent_worker_slurm_jobs
-            else SLURM_CONFIG.helm_max_concurrent_worker_slurm_jobs
+            else RUNNER_CONFIG.helm_max_concurrent_workers
         )
 
     def run_all(self, run_specs: List[RunSpec]):
@@ -225,7 +225,7 @@ class SlurmRunner(Runner):
                         break
 
                     # Refresh every minute
-                    time.sleep(SLURM_CONFIG.slurm_monitor_interval)
+                    time.sleep(RUNNER_CONFIG.slurm_monitor_interval)
         finally:
             # Cleanup by cancelling all jobs during program termination or if an exception is raised.
             cancel_all_jobs()
@@ -263,7 +263,7 @@ class SlurmRunner(Runner):
                 run_spec_path,
             ]
         )
-        if SLURM_CONFIG.slurm_args is None:
+        if RUNNER_CONFIG.slurm_args is None:
             raw_slurm_args: Dict[str, str] = {
                 "account": "nlp",
                 "cpus_per_task": "4",
@@ -295,7 +295,7 @@ class SlurmRunner(Runner):
                 raw_slurm_args["nodelist"] = slurm_node_names
 
         else:
-            raw_slurm_args = SLURM_CONFIG.slurm_args
+            raw_slurm_args = RUNNER_CONFIG.slurm_args
 
             dynamic_slurm_args = {
                 "job_name": run_name,


### PR DESCRIPTION
Basic multi gpu support by adapting `SlurmRunner` 

Note: `start_thread_to_terminate_when_parent_process_dies` is included due to https://github.com/stanford-crfm/helm/blob/9fbb212ceb1dd6f075214385c5dc81f5c60fee04/src/helm/proxy/retry.py#L56