### PR TITLE
Remove AdapterSpec from metrics

### DIFF
--- a/src/helm/benchmark/metrics/cleva_harms_metrics.py
+++ b/src/helm/benchmark/metrics/cleva_harms_metrics.py
@@ -9,7 +9,6 @@ from helm.common.perspective_api_request import PerspectiveAPIRequest, Perspecti
 from helm.common.request import RequestResult
 from helm.common.hierarchical_logger import hlog
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.metrics.cleva_metrics_helper import ChineseTokenizer
 from helm.proxy.clients.perspective_api_client import PerspectiveAPIClientCredentialsError
 from helm.common.general import ensure_file_downloaded, ensure_directory_exists
@@ -167,7 +166,6 @@ class CLEVAToxicityMetric(ToxicityMetric):
 
     def evaluate_generation(
         self,
-        adapter_spec: AdapterSpec,
         request_state: RequestState,
         metric_service: MetricService,
         eval_cache_path: str,

--- a/src/helm/benchmark/metrics/code_metrics.py
+++ b/src/helm/benchmark/metrics/code_metrics.py
@@ -6,9 +6,7 @@ from typing import List, Union, Sequence, cast
 
 from helm.common.hierarchical_logger import hlog
 from helm.common.request import RequestResult
-from helm.benchmark.adaptation.scenario_state import ScenarioState
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.scenarios.code_scenario import CodeReference
 from . import code_metrics_helper
 from .metric import Metric, MetricResult
@@ -60,17 +58,16 @@ class APPSMetric(Metric):
         # resource.setrlimit(resource.RLIMIT_AS, (MAXIMUM_MEMORY_BYTES, MAXIMUM_MEMORY_BYTES))
 
     def evaluate(
-        self, scenario_state: ScenarioState, metric_service: MetricService, eval_cache_path: str, parallelism: int
+        self, request_states: List[RequestState], metric_service: MetricService, eval_cache_path: str, parallelism: int
     ) -> MetricResult:
         # Running with parallelism > 1 causes the run to get stuck.
         hlog(
             f"Setting parallelism from {parallelism} to 1, since evaluating code with parallelism > 1 isn't supported."
         )
-        return super().evaluate(scenario_state, metric_service, eval_cache_path, parallelism=1)
+        return super().evaluate(request_states, metric_service, eval_cache_path, parallelism=1)
 
     def evaluate_generation(
         self,
-        adapter_spec: AdapterSpec,
         request_state: RequestState,
         metric_service: MetricService,
         eval_cache_path: str,

--- a/src/helm/benchmark/metrics/copyright_metrics.py
+++ b/src/helm/benchmark/metrics/copyright_metrics.py
@@ -5,7 +5,6 @@ import numpy as np
 from nltk.tokenize.treebank import TreebankWordTokenizer
 
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.scenarios.scenario import Reference
 from helm.common.optional_dependencies import handle_module_not_found_error
 from helm.common.request import RequestResult
@@ -119,7 +118,6 @@ class BasicCopyrightMetric(Metric):
 
     def evaluate_generation(
         self,
-        adapter_spec: AdapterSpec,
         request_state: RequestState,
         metric_service: MetricService,
         eval_cache_path: str,

--- a/src/helm/benchmark/metrics/efficiency_metrics.py
+++ b/src/helm/benchmark/metrics/efficiency_metrics.py
@@ -5,7 +5,6 @@ import importlib_resources as resources
 
 from helm.common.hierarchical_logger import hlog
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.window_services.window_service import WindowService
 from helm.benchmark.window_services.window_service_factory import WindowServiceFactory
 from helm.benchmark.window_services.tokenizer_service import TokenizerService
@@ -59,9 +58,7 @@ class EfficiencyMetric:
         with data_package.joinpath(TRAINING_EFFICIENCY_JSON_FILENAME).open("r") as f:
             self.training_efficiency_dict = json.load(f)
 
-    def compute_efficiency_metrics(
-        self, adapter_spec: AdapterSpec, request_state: RequestState, metric_service: MetricService
-    ) -> List[Stat]:
+    def compute_efficiency_metrics(self, request_state: RequestState, metric_service: MetricService) -> List[Stat]:
         """Compute efficiency metrics for both inference and training.
         For inference, we record both the actual runtime and an estimated idealized runtime
         for the given request with an optimized software implementation run on A100 GPU(s),
@@ -89,7 +86,7 @@ class EfficiencyMetric:
         # and calculate the number of tokens in the prompt.
         tokenizer_service: TokenizerService = metric_service
         window_service: WindowService = WindowServiceFactory.get_window_service(
-            adapter_spec.model_deployment, tokenizer_service
+            request_state.request.model_deployment, tokenizer_service
         )
         prompt: str = request_state.request.prompt
         num_prompt_tokens: int = window_service.get_num_tokens(prompt)

--- a/src/helm/benchmark/metrics/evaluate_instances_metric.py
+++ b/src/helm/benchmark/metrics/evaluate_instances_metric.py
@@ -4,8 +4,8 @@ from typing import List, Dict
 from helm.benchmark.metrics.metric import MetricInterface, MetricResult, add_context
 
 
-from helm.benchmark.adaptation.scenario_state import ScenarioState
 from helm.benchmark.adaptation.request_state import RequestState
+from helm.benchmark.metrics.metric import group_request_states_by_train_trial
 from .metric_name import MetricName, MetricContext
 from .metric_service import MetricService
 from .statistic import Stat, merge_stat
@@ -18,7 +18,7 @@ class EvaluateInstancesMetric(MetricInterface, ABC):
     """
 
     def evaluate(
-        self, scenario_state: ScenarioState, metric_service: MetricService, eval_cache_path: str, parallelism: int
+        self, request_states: List[RequestState], metric_service: MetricService, eval_cache_path: str, parallelism: int
     ) -> MetricResult:
         """Aggregate over calls to evaluate_instances, which is defined by the subclass.
 
@@ -26,10 +26,8 @@ class EvaluateInstancesMetric(MetricInterface, ABC):
         2. For each train trial, take the mean for each Stat.
         3. Returns Stats built from those means (e.g. the mean in the result is the mean-of-means).
         """
-        adapter_spec = scenario_state.adapter_spec
         global_stats: Dict[MetricName, Stat] = {}
-
-        for train_trial_index in range(adapter_spec.num_train_trials):
+        for trial_request_states in group_request_states_by_train_trial(request_states):
 
             # Aggregate these stats
             trial_stats: Dict[MetricName, Stat] = {}  # Statistics just for this trial
@@ -37,13 +35,10 @@ class EvaluateInstancesMetric(MetricInterface, ABC):
             # Compute statistics that depend on all the `RequestStates` (e.g., bias metrics).
             # Aggregate request states and call evaluate_instances in case the metric needs it.
             grouped_request_states: Dict[MetricContext, List[RequestState]] = defaultdict(list)
-            for instance in scenario_state.instances:
-                # TODO: do we need to support reference_index that is not None?
-                grouped_request_states[MetricContext.from_instance(instance)].extend(
-                    scenario_state.get_request_states(train_trial_index, instance, None)
-                )
-            for context, request_states in grouped_request_states.items():
-                for stat in self.evaluate_instances(request_states):
+            for request_state in trial_request_states:
+                grouped_request_states[MetricContext.from_instance(request_state.instance)].append(request_state)
+            for context, request_states_for_context in grouped_request_states.items():
+                for stat in self.evaluate_instances(request_states_for_context):
                     merge_stat(trial_stats, add_context(stat, context))
 
             # We take the mean value for each trial.

--- a/src/helm/benchmark/metrics/image_generation/aesthetics_metrics.py
+++ b/src/helm/benchmark/metrics/image_generation/aesthetics_metrics.py
@@ -4,7 +4,6 @@ from typing import List, Optional
 from helm.common.images_utils import is_blacked_out_image
 from helm.common.request import RequestResult
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.metrics.statistic import Stat
 from helm.benchmark.metrics.metric import Metric
 from helm.benchmark.metrics.metric_name import MetricName
@@ -27,7 +26,6 @@ class AestheticsMetric(Metric):
 
     def evaluate_generation(
         self,
-        adapter_spec: AdapterSpec,
         request_state: RequestState,
         metric_service: MetricService,
         eval_cache_path: str,

--- a/src/helm/benchmark/metrics/image_generation/clip_score_metrics.py
+++ b/src/helm/benchmark/metrics/image_generation/clip_score_metrics.py
@@ -5,7 +5,6 @@ from helm.common.general import singleton
 from helm.common.request import RequestResult
 from helm.common.clip_score_request import DEFAULT_CLIP_SCORE_MODEL, CLIPScoreResult, CLIPScoreRequest
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.metrics.statistic import Stat
 from helm.benchmark.metrics.metric import Metric
 from helm.benchmark.metrics.metric_name import MetricName
@@ -30,7 +29,6 @@ class CLIPScoreMetric(Metric):
 
     def evaluate_generation(
         self,
-        adapter_spec: AdapterSpec,
         request_state: RequestState,
         metric_service: MetricService,
         eval_cache_path: str,

--- a/src/helm/benchmark/metrics/image_generation/denoised_runtime_metric.py
+++ b/src/helm/benchmark/metrics/image_generation/denoised_runtime_metric.py
@@ -1,12 +1,12 @@
 from collections import defaultdict
 from tqdm import tqdm
-from typing import Dict
+from typing import Dict, List
 import math
 import numpy as np
 
 from helm.common.request import RequestResult
+from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.scenarios.scenario import Instance
-from helm.benchmark.adaptation.scenario_state import ScenarioState
 from helm.benchmark.metrics.statistic import Stat
 from helm.benchmark.metrics.metric import MetricInterface, MetricResult
 from helm.benchmark.metrics.metric_name import MetricName
@@ -19,14 +19,14 @@ class DenoisedRuntimeMetric(MetricInterface):
 
     def evaluate(
         self,
-        scenario_state: ScenarioState,
+        request_states: List[RequestState],
         metric_service: MetricService,
         eval_cache_path: str,
         parallelism: int,
     ) -> MetricResult:
 
         instance_to_min_request_times: Dict[Instance, float] = defaultdict(lambda: math.inf)
-        for request_state in tqdm(scenario_state.request_states):
+        for request_state in tqdm(request_states):
             assert request_state.result is not None
             request_result: RequestResult = request_state.result
 

--- a/src/helm/benchmark/metrics/image_generation/detection_metrics.py
+++ b/src/helm/benchmark/metrics/image_generation/detection_metrics.py
@@ -4,7 +4,6 @@ from statistics import mean
 
 from helm.common.request import RequestResult
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.metrics.statistic import Stat
 from helm.benchmark.metrics.metric import Metric
 from helm.benchmark.metrics.metric_name import MetricName
@@ -28,7 +27,6 @@ class DetectionMetric(Metric):
 
     def evaluate_generation(
         self,
-        adapter_spec: AdapterSpec,
         request_state: RequestState,
         metric_service: MetricService,
         eval_cache_path: str,

--- a/src/helm/benchmark/metrics/image_generation/efficiency_metrics.py
+++ b/src/helm/benchmark/metrics/image_generation/efficiency_metrics.py
@@ -2,7 +2,6 @@ from typing import List
 
 from helm.common.request import RequestResult
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.metrics.statistic import Stat
 from helm.benchmark.metrics.metric import Metric
 from helm.benchmark.metrics.metric_name import MetricName
@@ -20,7 +19,6 @@ class EfficiencyMetric(Metric):
 
     def evaluate_generation(
         self,
-        adapter_spec: AdapterSpec,
         request_state: RequestState,
         metric_service: MetricService,
         eval_cache_path: str,

--- a/src/helm/benchmark/metrics/image_generation/fidelity_metrics.py
+++ b/src/helm/benchmark/metrics/image_generation/fidelity_metrics.py
@@ -3,13 +3,13 @@ from typing import Dict, List, Set, Optional
 import math
 import os
 import shutil
+from helm.benchmark.adaptation.request_state import RequestState
 
 from helm.common.general import ensure_directory_exists, generate_unique_id, get_file_name, hlog
 from helm.common.gpu_utils import is_cuda_available, get_torch_device
 from helm.common.request import RequestResult
 from helm.benchmark.augmentations.perturbation_description import PerturbationDescription
 from helm.benchmark.scenarios.scenario import Instance
-from helm.benchmark.adaptation.scenario_state import ScenarioState
 from helm.benchmark.metrics.statistic import Stat
 from helm.benchmark.metrics.metric import MetricInterface, MetricResult
 from helm.benchmark.metrics.metric_name import MetricName
@@ -54,7 +54,7 @@ class FidelityMetric(MetricInterface):
 
     def evaluate(
         self,
-        scenario_state: ScenarioState,
+        request_states: List[RequestState],
         metric_service: MetricService,
         eval_cache_path: str,
         parallelism: int,
@@ -74,7 +74,7 @@ class FidelityMetric(MetricInterface):
         # The library requires the gold and generated images to be in two separate directories.
         # Gather the gold images and the unique perturbations
         num_gold_images: int = 0
-        for request_state in tqdm(scenario_state.request_states):
+        for request_state in tqdm(request_states):
             instance: Instance = request_state.instance
             unique_perturbations.add(instance.perturbation)
 
@@ -100,7 +100,7 @@ class FidelityMetric(MetricInterface):
             ensure_directory_exists(generated_images_path)
 
             num_generated_images: int = 0
-            for request_state in tqdm(scenario_state.request_states):
+            for request_state in tqdm(request_states):
                 if request_state.instance.perturbation != perturbation:
                     continue
 

--- a/src/helm/benchmark/metrics/image_generation/fractal_dimension_metric.py
+++ b/src/helm/benchmark/metrics/image_generation/fractal_dimension_metric.py
@@ -4,7 +4,6 @@ from typing import List
 
 from helm.common.request import RequestResult
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.metrics.statistic import Stat
 from helm.benchmark.metrics.metric import Metric
 from helm.benchmark.metrics.metric_name import MetricName
@@ -26,7 +25,6 @@ class FractalDimensionMetric(Metric):
 
     def evaluate_generation(
         self,
-        adapter_spec: AdapterSpec,
         request_state: RequestState,
         metric_service: MetricService,
         eval_cache_path: str,

--- a/src/helm/benchmark/metrics/image_generation/gender_metrics.py
+++ b/src/helm/benchmark/metrics/image_generation/gender_metrics.py
@@ -2,7 +2,6 @@ from statistics import mean
 from typing import List
 
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.metrics.statistic import Stat
 from helm.benchmark.metrics.metric import Metric
 from helm.benchmark.metrics.metric_name import MetricName
@@ -29,7 +28,6 @@ class GenderMetric(Metric):
 
     def evaluate_generation(
         self,
-        adapter_spec: AdapterSpec,
         request_state: RequestState,
         metric_service: MetricService,
         eval_cache_path: str,

--- a/src/helm/benchmark/metrics/image_generation/lpips_metrics.py
+++ b/src/helm/benchmark/metrics/image_generation/lpips_metrics.py
@@ -8,7 +8,6 @@ from helm.common.images_utils import open_image
 from helm.common.optional_dependencies import handle_module_not_found_error
 from helm.common.request import RequestResult
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.metrics.statistic import Stat
 from helm.benchmark.metrics.metric import Metric
 from helm.benchmark.metrics.metric_name import MetricName
@@ -36,7 +35,6 @@ class LearnedPerceptualImagePatchSimilarityMetric(Metric):
 
     def evaluate_generation(
         self,
-        adapter_spec: AdapterSpec,
         request_state: RequestState,
         metric_service: MetricService,
         eval_cache_path: str,

--- a/src/helm/benchmark/metrics/image_generation/multi_scale_ssim_metrics.py
+++ b/src/helm/benchmark/metrics/image_generation/multi_scale_ssim_metrics.py
@@ -8,7 +8,6 @@ from helm.common.images_utils import open_image
 from helm.common.optional_dependencies import handle_module_not_found_error
 from helm.common.request import RequestResult
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.metrics.statistic import Stat
 from helm.benchmark.metrics.metric import Metric
 from helm.benchmark.metrics.metric_name import MetricName
@@ -37,7 +36,6 @@ class MultiScaleStructuralSimilarityIndexMeasureMetric(Metric):
 
     def evaluate_generation(
         self,
-        adapter_spec: AdapterSpec,
         request_state: RequestState,
         metric_service: MetricService,
         eval_cache_path: str,

--- a/src/helm/benchmark/metrics/image_generation/nsfw_metrics.py
+++ b/src/helm/benchmark/metrics/image_generation/nsfw_metrics.py
@@ -2,7 +2,6 @@ from typing import List, Optional
 
 from helm.common.request import RequestResult
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.metrics.statistic import Stat
 from helm.benchmark.metrics.metric import Metric
 from helm.benchmark.metrics.metric_name import MetricName
@@ -28,7 +27,6 @@ class NSFWMetric(Metric):
 
     def evaluate_generation(
         self,
-        adapter_spec: AdapterSpec,
         request_state: RequestState,
         metric_service: MetricService,
         eval_cache_path: str,

--- a/src/helm/benchmark/metrics/image_generation/nudity_metrics.py
+++ b/src/helm/benchmark/metrics/image_generation/nudity_metrics.py
@@ -3,7 +3,6 @@ from typing import List
 from helm.common.nudity_check_request import NudityCheckRequest, NudityCheckResult
 from helm.common.request import RequestResult
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.metrics.statistic import Stat
 from helm.benchmark.metrics.metric import Metric
 from helm.benchmark.metrics.metric_name import MetricName
@@ -21,7 +20,6 @@ class NudityMetric(Metric):
 
     def evaluate_generation(
         self,
-        adapter_spec: AdapterSpec,
         request_state: RequestState,
         metric_service: MetricService,
         eval_cache_path: str,

--- a/src/helm/benchmark/metrics/image_generation/photorealism_critique_metrics.py
+++ b/src/helm/benchmark/metrics/image_generation/photorealism_critique_metrics.py
@@ -3,8 +3,6 @@ from typing import Dict, List
 import numpy as np
 
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.scenario_state import ScenarioState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.metrics.metric import MetricInterface, MetricResult, PerInstanceStats, add_context
 from helm.benchmark.metrics.metric_name import MetricContext, MetricName
 from helm.benchmark.metrics.metric_service import MetricService
@@ -42,18 +40,15 @@ class PhotorealismCritiqueMetric(MetricInterface):
 
     def evaluate(
         self,
-        scenario_state: ScenarioState,
+        request_states: List[RequestState],
         metric_service: MetricService,
         eval_cache_path: str,
         parallelism: int,
     ) -> MetricResult:
-        request_states: List[RequestState] = []
         if self._use_perturbed:
-            for request_state in scenario_state.request_states:
+            for request_state in request_states:
                 if request_state.instance.perturbation is not None:
                     request_states.append(request_state)
-        else:
-            request_states = scenario_state.request_states
 
         np.random.seed(0)
         if self._num_examples < len(request_states):
@@ -70,7 +65,6 @@ class PhotorealismCritiqueMetric(MetricInterface):
         for request_state in request_states:
             context = MetricContext.from_instance(request_state.instance)
             stats_without_context = self.evaluate_generation(
-                scenario_state.adapter_spec,
                 request_state,
                 metric_service,
                 eval_cache_path,
@@ -91,7 +85,6 @@ class PhotorealismCritiqueMetric(MetricInterface):
 
     def evaluate_generation(
         self,
-        adapter_spec: AdapterSpec,
         request_state: RequestState,
         metric_service: MetricService,
         eval_cache_path: str,

--- a/src/helm/benchmark/metrics/image_generation/psnr_metrics.py
+++ b/src/helm/benchmark/metrics/image_generation/psnr_metrics.py
@@ -8,7 +8,6 @@ from helm.common.images_utils import open_image
 from helm.common.request import RequestResult
 from helm.common.optional_dependencies import handle_module_not_found_error
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.metrics.statistic import Stat
 from helm.benchmark.metrics.metric import Metric
 from helm.benchmark.metrics.metric_name import MetricName
@@ -34,7 +33,6 @@ class PeakSignalToNoiseRatioMetric(Metric):
 
     def evaluate_generation(
         self,
-        adapter_spec: AdapterSpec,
         request_state: RequestState,
         metric_service: MetricService,
         eval_cache_path: str,

--- a/src/helm/benchmark/metrics/image_generation/q16_toxicity_metrics.py
+++ b/src/helm/benchmark/metrics/image_generation/q16_toxicity_metrics.py
@@ -3,7 +3,6 @@ from typing import List
 
 from helm.common.request import RequestResult
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.metrics.statistic import Stat
 from helm.benchmark.metrics.metric import Metric
 from helm.benchmark.metrics.metric_name import MetricName
@@ -26,7 +25,6 @@ class Q16ToxicityMetric(Metric):
 
     def evaluate_generation(
         self,
-        adapter_spec: AdapterSpec,
         request_state: RequestState,
         metric_service: MetricService,
         eval_cache_path: str,

--- a/src/helm/benchmark/metrics/image_generation/skin_tone_metrics.py
+++ b/src/helm/benchmark/metrics/image_generation/skin_tone_metrics.py
@@ -3,7 +3,6 @@ from typing import List, Optional, Dict
 import numpy as np
 
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.metrics.statistic import Stat
 from helm.benchmark.metrics.metric import Metric
 from helm.benchmark.metrics.metric_name import MetricName
@@ -127,7 +126,6 @@ class SkinToneMetric(Metric):
 
     def evaluate_generation(
         self,
-        adapter_spec: AdapterSpec,
         request_state: RequestState,
         metric_service: MetricService,
         eval_cache_path: str,

--- a/src/helm/benchmark/metrics/image_generation/uiqi_metrics.py
+++ b/src/helm/benchmark/metrics/image_generation/uiqi_metrics.py
@@ -10,8 +10,6 @@ from helm.common.images_utils import open_image
 from helm.common.optional_dependencies import handle_module_not_found_error
 from helm.common.request import RequestResult
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.scenario_state import ScenarioState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.metrics.statistic import Stat
 from helm.benchmark.metrics.metric import Metric
 from helm.benchmark.metrics.metric import MetricResult
@@ -39,14 +37,13 @@ class UniversalImageQualityIndexMetric(Metric):
         return "UniversalImageQualityIndexMetric()"
 
     def evaluate(
-        self, scenario_state: ScenarioState, metric_service: MetricService, eval_cache_path: str, parallelism: int
+        self, request_states: List[RequestState], metric_service: MetricService, eval_cache_path: str, parallelism: int
     ) -> MetricResult:
         hlog(f"Setting parallelism from {parallelism} to 1, since computing UIQI with parallelism > 1 isn't supported.")
-        return super().evaluate(scenario_state, metric_service, eval_cache_path, parallelism=1)
+        return super().evaluate(request_states, metric_service, eval_cache_path, parallelism=1)
 
     def evaluate_generation(
         self,
-        adapter_spec: AdapterSpec,
         request_state: RequestState,
         metric_service: MetricService,
         eval_cache_path: str,

--- a/src/helm/benchmark/metrics/image_generation/watermark_metrics.py
+++ b/src/helm/benchmark/metrics/image_generation/watermark_metrics.py
@@ -3,7 +3,6 @@ from typing import List
 
 from helm.common.request import RequestResult
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.metrics.statistic import Stat
 from helm.benchmark.metrics.metric import Metric
 from helm.benchmark.metrics.metric_name import MetricName
@@ -26,7 +25,6 @@ class WatermarkMetric(Metric):
 
     def evaluate_generation(
         self,
-        adapter_spec: AdapterSpec,
         request_state: RequestState,
         metric_service: MetricService,
         eval_cache_path: str,

--- a/src/helm/benchmark/metrics/instruction_following_critique_metrics.py
+++ b/src/helm/benchmark/metrics/instruction_following_critique_metrics.py
@@ -1,7 +1,6 @@
 from typing import Dict, List
 
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from .metric import Metric
 from .metric_name import MetricName
 from .metric_service import MetricService
@@ -143,7 +142,6 @@ class InstructionFollowingCritiqueMetric(Metric):
 
     def evaluate_generation(
         self,
-        adapter_spec: AdapterSpec,
         request_state: RequestState,
         metric_service: MetricService,
         eval_cache_path: str,

--- a/src/helm/benchmark/metrics/numeracy_metrics.py
+++ b/src/helm/benchmark/metrics/numeracy_metrics.py
@@ -2,7 +2,6 @@ from typing import List
 
 from helm.common.request import RequestResult
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.scenarios.numeracy_scenario import (  # noqa
     NumeracyScenario,
     Polynomial,
@@ -35,7 +34,6 @@ class DistanceMetric(Metric):
 
     def evaluate_generation(
         self,
-        adapter_spec: AdapterSpec,
         request_state: RequestState,
         metric_service: MetricService,
         eval_cache_path: str,

--- a/src/helm/benchmark/metrics/ranking_metrics.py
+++ b/src/helm/benchmark/metrics/ranking_metrics.py
@@ -3,7 +3,6 @@ from typing import Callable, Dict, List, Tuple, Optional
 
 from helm.benchmark.adaptation.adapters.adapter_factory import ADAPT_RANKING_BINARY
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.common.optional_dependencies import handle_module_not_found_error
 from helm.benchmark.scenarios.scenario import unpack_tag, CORRECT_TAG, Reference
 from helm.common.request import RequestResult
@@ -339,7 +338,6 @@ class RankingMetric(Metric):
 
     def evaluate_references(
         self,
-        adapter_spec: AdapterSpec,
         reference_request_states: List[RequestState],
         metric_service: MetricService,
         eval_cache_path: str,

--- a/src/helm/benchmark/metrics/summarization_critique_metrics.py
+++ b/src/helm/benchmark/metrics/summarization_critique_metrics.py
@@ -1,7 +1,6 @@
 from typing import Dict, List
 
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from .metric import Metric
 from .metric_name import MetricName
 from .metric_service import MetricService
@@ -63,7 +62,6 @@ class SummarizationCritiqueMetric(Metric):
 
     def evaluate_generation(
         self,
-        adapter_spec: AdapterSpec,
         request_state: RequestState,
         metric_service: MetricService,
         eval_cache_path: str,

--- a/src/helm/benchmark/metrics/toxicity_metrics.py
+++ b/src/helm/benchmark/metrics/toxicity_metrics.py
@@ -4,7 +4,6 @@ from helm.common.perspective_api_request import PerspectiveAPIRequest, Perspecti
 from helm.common.request import RequestResult
 from helm.common.hierarchical_logger import hlog
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.proxy.clients.perspective_api_client import PerspectiveAPIClientCredentialsError
 from .metric import Metric
 from .metric_name import MetricName
@@ -28,7 +27,6 @@ class ToxicityMetric(Metric):
 
     def evaluate_generation(
         self,
-        adapter_spec: AdapterSpec,
         request_state: RequestState,
         metric_service: MetricService,
         eval_cache_path: str,

--- a/src/helm/benchmark/runner.py
+++ b/src/helm/benchmark/runner.py
@@ -319,7 +319,7 @@ class Runner:
             for metric in metrics:
                 with htrack_block(metric):
                     metric_result: MetricResult = metric.evaluate(
-                        scenario_state,
+                        scenario_state.request_states,
                         self.metric_service,
                         self.eval_cache_path,
                         self.executor.execution_spec.parallelism,


### PR DESCRIPTION
This removes the coupling between the adapter and the metrics, allowing the metrics to be computed _only_ using the requests and results from the model clients.