### PR TITLE
Find the slowest pytest tests in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       - run: source venv/bin/activate && ./install-dev.sh
       - run: source venv/bin/activate && ./pre-commit.sh
       - name: Run tests
-        run: source venv/bin/activate && pytest
+        run: source venv/bin/activate && pytest --durations=20
         env:
           TEST: ${{ matrix.test }}
           VERSION: ${{ github.head_ref || 'main' }}


### PR DESCRIPTION
HELM CI tests now take 25 minutes, compared to 10 minutes a couple months ago. This determines the slowest tests so that they can be marked and run in a separate parallel test run.