### PR TITLE
Use the React frontend in helm-server by default

### DIFF
--- a/src/helm/benchmark/server.py
+++ b/src/helm/benchmark/server.py
@@ -100,9 +100,9 @@ def main():
         help="Experimental: The release to serve. If unset, don't serve a release, and serve the latest suite instead.",
     )
     parser.add_argument(
-        "--react",
+        "--jquery",
         action="store_true",
-        help="Whether to serve the React frontend instead of the jQuery frontend.",
+        help="Whether to serve the legacy jQuery frontend instead of the React frontend.",
     )
     args = parser.parse_args()
 
@@ -112,7 +112,7 @@ def main():
     # Determine the location of the static directory.
     # This is a hack: it assumes that the static directory has a physical location,
     # which is not always the case (e.g. when using zipimport).
-    static_package_name = "helm.benchmark.static_build" if args.react else "helm.benchmark.static"
+    static_package_name = "helm.benchmark.static" if args.jquery else "helm.benchmark.static_build"
     resource_path = resources.files(static_package_name).joinpath("index.html")
     with resources.as_file(resource_path) as resource_filename:
         static_path = str(resource_filename.parent)


### PR DESCRIPTION
- Makes `helm-server` use the React frontend by default
- Removes the `--react` flag
- Adds the `--jquery` flag for falling back to the legacy frontend