### PR TITLE
Remove hardcoded Together model aliases

### DIFF
--- a/src/helm/benchmark/window_services/test_gptj_window_service.py
+++ b/src/helm/benchmark/window_services/test_gptj_window_service.py
@@ -12,7 +12,7 @@ class TestGPTJWindowService:
         register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
-        self.window_service = WindowServiceFactory.get_window_service("together/gpt-j-6b", service)
+        self.window_service = WindowServiceFactory.get_window_service("huggingface/gpt-j-6b", service)
 
     def teardown_method(self, method):
         shutil.rmtree(self.path)

--- a/src/helm/benchmark/window_services/test_gptneox_window_service.py
+++ b/src/helm/benchmark/window_services/test_gptneox_window_service.py
@@ -68,7 +68,7 @@ class TestGPTNeoXWindowService:
         register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
-        self.window_service = WindowServiceFactory.get_window_service("together/gpt-neox-20b", service)
+        self.window_service = WindowServiceFactory.get_window_service("huggingface/gpt-neox-20b", service)
 
     def teardown_method(self, method):
         shutil.rmtree(self.path)

--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -1216,36 +1216,42 @@ model_deployments:
 
   ## BigScience
   - name: together/bloom
-    deprecated: true # Removed from together
+    deprecated: true  # Removed from Together
     model_name: bigscience/bloom
     tokenizer_name: bigscience/bloom
     max_sequence_length: 2048
     max_request_length: 2049
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: bigscience/bloom
 
   - name: together/t0pp
-    deprecated: true # Removed from together
+    deprecated: true  # Removed from Together
     model_name: bigscience/t0pp
     tokenizer_name: bigscience/T0pp
     max_sequence_length: 1024
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: bigscience/T0pp
     window_service_spec:
       class_name: "helm.benchmark.window_services.encoder_decoder_window_service.EncoderDecoderWindowService"
 
   ## EleutherAI
   - name: together/gpt-j-6b
-    deprecated: true # Removed from together
+    deprecated: true  # Removed from Together
     model_name: eleutherai/gpt-j-6b
     tokenizer_name: EleutherAI/gpt-j-6B
     max_sequence_length: 2048
     max_request_length: 2049
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: eleutherai/gpt-j-6b
 
   - name: together/gpt-neox-20b
-    deprecated: true # Removed from together
+    deprecated: true  # Removed from Together
     model_name: eleutherai/gpt-neox-20b
     tokenizer_name: EleutherAI/gpt-neox-20b
     max_sequence_length: 2048
@@ -1255,32 +1261,38 @@ model_deployments:
 
   ## Google
   - name: together/t5-11b
-    deprecated: true # Removed from together
+    deprecated: true  # Removed from Together
     model_name: google/t5-11b
     tokenizer_name: google/t5-11b
     max_sequence_length: 511
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: google/t5-11b
     window_service_spec:
       class_name: "helm.benchmark.window_services.encoder_decoder_window_service.EncoderDecoderWindowService"
 
   - name: together/flan-t5-xxl
-    deprecated: true # Removed from together
+    deprecated: true  # Removed from Together
     model_name: google/flan-t5-xxl
     tokenizer_name: google/flan-t5-xxl
     max_sequence_length: 511
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: google/flan-t5-xxl
     window_service_spec:
       class_name: "helm.benchmark.window_services.encoder_decoder_window_service.EncoderDecoderWindowService"
 
   - name: together/ul2
-    deprecated: true # Removed from together
+    deprecated: true  # Removed from Together
     model_name: google/ul2
     tokenizer_name: google/ul2
     max_sequence_length: 511
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: google/ul2
     window_service_spec:
       class_name: "helm.benchmark.window_services.encoder_decoder_window_service.EncoderDecoderWindowService"
 
@@ -1291,6 +1303,8 @@ model_deployments:
     max_sequence_length: 2047 # Subtract 1 token to work around a off-by-one bug in Together's input validation token counting (#2080)
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: huggyllama/llama-7b
 
   - name: together/llama-13b
     model_name: meta/llama-13b
@@ -1298,6 +1312,8 @@ model_deployments:
     max_sequence_length: 2047 # Subtract 1 token to work around a off-by-one bug in Together's input validation token counting (#2080)
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: huggyllama/llama-13b
 
   - name: together/llama-30b
     model_name: meta/llama-30b
@@ -1305,6 +1321,8 @@ model_deployments:
     max_sequence_length: 2047 # Subtract 1 token to work around a off-by-one bug in Together's input validation token counting (#2080)
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: huggyllama/llama-30b
 
   - name: together/llama-65b
     model_name: meta/llama-65b
@@ -1312,6 +1330,8 @@ model_deployments:
     max_sequence_length: 2047 # Subtract 1 tokens to work around a off-by-one bug in Together's input validation token counting (#2080)
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: huggyllama/llama-65b
 
   - name: together/llama-2-7b
     model_name: meta/llama-2-7b
@@ -1319,6 +1339,8 @@ model_deployments:
     max_sequence_length: 4094 # Subtract 2 tokens to work around a off-by-two bug in Together's token counting (#2080 and #2094)
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: togethercomputer/llama-2-7b
 
   - name: together/llama-2-13b
     model_name: meta/llama-2-13b
@@ -1326,6 +1348,8 @@ model_deployments:
     max_sequence_length: 4094 # Subtract 2 tokens to work around a off-by-two bug in Together's token counting (#2080 and #2094)
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: togethercomputer/llama-2-13b
 
   - name: together/llama-2-70b
     model_name: meta/llama-2-70b
@@ -1333,6 +1357,8 @@ model_deployments:
     max_sequence_length: 4094 # Subtract 2 tokens to work around a off-by-two bug in Together's token counting (#2080 and #2094)
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: togethercomputer/llama-2-70b
 
   # 01.AI
   - name: together/yi-6b
@@ -1341,6 +1367,8 @@ model_deployments:
     max_sequence_length: 4095
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: zero-one-ai/Yi-6B
 
   - name: together/yi-34b
     model_name: 01-ai/yi-34b
@@ -1348,6 +1376,8 @@ model_deployments:
     max_sequence_length: 4095
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: zero-one-ai/Yi-34B
 
   ## MistralAI
   - name: together/mistral-7b-v0.1
@@ -1356,6 +1386,8 @@ model_deployments:
     max_sequence_length: 4095 # Subtract 1 token to work around a off-by-one bug in Together's input validation token counting (#2080)
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: mistralai/Mistral-7B-v0.1
 
   - name: together/mixtral-8x7b-32kseqlen
     model_name: mistralai/mixtral-8x7b-32kseqlen
@@ -1363,6 +1395,8 @@ model_deployments:
     max_sequence_length: 4095 # Subtract 1 token to work around a off-by-one bug in Together's input validation token counting (#2080)
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: mistralai/mixtral-8x7b-32kseqlen
 
   ## Stanford
   - name: together/alpaca-7b
@@ -1371,6 +1405,8 @@ model_deployments:
     max_sequence_length: 2048
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: togethercomputer/alpaca-7b
 
   ## Tiiuae
   - name: together/falcon-7b
@@ -1379,6 +1415,8 @@ model_deployments:
     max_sequence_length: 2047 # Subtract 1 token to work around a off-by-one bug in Together's input validation token counting (#2080)
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: togethercomputer/falcon-7b
 
   - name: together/falcon-7b-instruct
     model_name: tiiuae/falcon-7b-instruct
@@ -1386,6 +1424,8 @@ model_deployments:
     max_sequence_length: 2047 # Subtract 1 token to work around a off-by-one bug in Together's input validation token counting (#2080)
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: togethercomputer/falcon-7b-instruct
 
   - name: together/falcon-40b
     model_name: tiiuae/falcon-40b
@@ -1393,6 +1433,8 @@ model_deployments:
     max_sequence_length: 2047 # Subtract 1 token to work around a off-by-one bug in Together's input validation token counting (#2080)
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: togethercomputer/falcon-40b
 
   - name: together/falcon-40b-instruct
     model_name: tiiuae/falcon-40b-instruct
@@ -1400,6 +1442,8 @@ model_deployments:
     max_sequence_length: 2047 # Subtract 1 token to work around a off-by-one bug in Together's input validation token counting (#2080)
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: togethercomputer/falcon-40b-instruct
 
   ## Together
   # These are models fine-tuned by Together (and not simply hosted by Together).
@@ -1410,6 +1454,8 @@ model_deployments:
     max_request_length: 2049
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: togethercomputer/GPT-JT-6B-v1
 
   - name: together/gpt-neoxt-chat-base-20b
     model_name: together/gpt-neoxt-chat-base-20b
@@ -1418,6 +1464,8 @@ model_deployments:
     max_request_length: 2049
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: togethercomputer/GPT-NeoXT-Chat-Base-20B
 
   - name: together/redpajama-incite-base-3b-v1
     model_name: together/redpajama-incite-base-3b-v1
@@ -1426,6 +1474,8 @@ model_deployments:
     max_request_length: 2049
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: togethercomputer/RedPajama-INCITE-Base-3B-v1
 
   - name: together/redpajama-incite-instruct-3b-v1
     model_name: together/redpajama-incite-instruct-3b-v1
@@ -1434,6 +1484,8 @@ model_deployments:
     max_request_length: 2049
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: togethercomputer/RedPajama-INCITE-Instruct-3B-v1
 
   - name: together/redpajama-incite-base-7b
     model_name: together/redpajama-incite-base-7b
@@ -1442,6 +1494,8 @@ model_deployments:
     max_request_length: 2049
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: togethercomputer/RedPajama-INCITE-7B-Base
 
   - name: together/redpajama-incite-instruct-7b
     model_name: together/redpajama-incite-instruct-7b
@@ -1450,16 +1504,20 @@ model_deployments:
     max_request_length: 2049
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: togethercomputer/RedPajama-INCITE-7B-Instruct
 
   ## Tsinghua
   - name: together/glm
-    deprecated: true # Not available on Together yet
+    deprecated: true  # Removed from Together
     model_name: tsinghua/glm
     tokenizer_name: TsinghuaKEG/ice
     max_sequence_length: 2048
     max_request_length: 2049
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: tsinghua/glm
     window_service_spec:
       class_name: "helm.benchmark.window_services.ice_window_service.ICEWindowService"
 
@@ -1474,13 +1532,15 @@ model_deployments:
 
   ## Yandex
   - name: together/yalm
-    deprecated: true # Not available on Together yet
+    deprecated: true  # Removed from Together
     model_name: yandex/yalm
     tokenizer_name: Yandex/yalm
     max_sequence_length: 2048
     max_request_length: 2049
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: yandex/yalm
     window_service_spec:
       class_name: "helm.benchmark.window_services.yalm_window_service.YaLMWindowService"
 

--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -500,6 +500,14 @@ model_deployments:
     client_spec:
       class_name: "helm.proxy.clients.huggingface_client.HuggingFaceClient"
 
+  - name: huggingface/gpt-neox-20b
+    model_name: eleutherai/gpt-neox-20b
+    tokenizer_name: EleutherAI/gpt-neox-20b
+    max_sequence_length: 2048
+    max_request_length: 2049
+    client_spec:
+      class_name: "helm.proxy.clients.huggingface_client.HuggingFaceClient"
+
   ## LMSYS
   - name: huggingface/vicuna-7b-v1.3
     model_name: lmsys/vicuna-7b-v1.3
@@ -1223,8 +1231,6 @@ model_deployments:
     max_request_length: 2049
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
-      args:
-        together_model: bigscience/bloom
 
   - name: together/t0pp
     deprecated: true  # Removed from Together
@@ -1233,31 +1239,8 @@ model_deployments:
     max_sequence_length: 1024
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
-      args:
-        together_model: bigscience/T0pp
     window_service_spec:
       class_name: "helm.benchmark.window_services.encoder_decoder_window_service.EncoderDecoderWindowService"
-
-  ## EleutherAI
-  - name: together/gpt-j-6b
-    deprecated: true  # Removed from Together
-    model_name: eleutherai/gpt-j-6b
-    tokenizer_name: EleutherAI/gpt-j-6B
-    max_sequence_length: 2048
-    max_request_length: 2049
-    client_spec:
-      class_name: "helm.proxy.clients.together_client.TogetherClient"
-      args:
-        together_model: eleutherai/gpt-j-6b
-
-  - name: together/gpt-neox-20b
-    deprecated: true  # Removed from Together
-    model_name: eleutherai/gpt-neox-20b
-    tokenizer_name: EleutherAI/gpt-neox-20b
-    max_sequence_length: 2048
-    max_request_length: 2049
-    client_spec:
-      class_name: "helm.proxy.clients.huggingface_client.HuggingFaceClient"
 
   ## Google
   - name: together/t5-11b
@@ -1267,8 +1250,6 @@ model_deployments:
     max_sequence_length: 511
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
-      args:
-        together_model: google/t5-11b
     window_service_spec:
       class_name: "helm.benchmark.window_services.encoder_decoder_window_service.EncoderDecoderWindowService"
 
@@ -1279,8 +1260,6 @@ model_deployments:
     max_sequence_length: 511
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
-      args:
-        together_model: google/flan-t5-xxl
     window_service_spec:
       class_name: "helm.benchmark.window_services.encoder_decoder_window_service.EncoderDecoderWindowService"
 
@@ -1291,8 +1270,6 @@ model_deployments:
     max_sequence_length: 511
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
-      args:
-        together_model: google/ul2
     window_service_spec:
       class_name: "helm.benchmark.window_services.encoder_decoder_window_service.EncoderDecoderWindowService"
 
@@ -1516,8 +1493,6 @@ model_deployments:
     max_request_length: 2049
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
-      args:
-        together_model: tsinghua/glm
     window_service_spec:
       class_name: "helm.benchmark.window_services.ice_window_service.ICEWindowService"
 
@@ -1539,8 +1514,6 @@ model_deployments:
     max_request_length: 2049
     client_spec:
       class_name: "helm.proxy.clients.together_client.TogetherClient"
-      args:
-        together_model: yandex/yalm
     window_service_spec:
       class_name: "helm.benchmark.window_services.yalm_window_service.YaLMWindowService"
 

--- a/src/helm/proxy/clients/test_together_client.py
+++ b/src/helm/proxy/clients/test_together_client.py
@@ -12,7 +12,10 @@ class TestTogetherClient:
     def setup_method(self, method):
         cache_file = tempfile.NamedTemporaryFile(delete=False)
         self.cache_path: str = cache_file.name
-        self.client = TogetherClient(cache_config=SqliteCacheConfig(self.cache_path))
+        self.client = TogetherClient(
+            cache_config=SqliteCacheConfig(self.cache_path),
+            together_model="togethercomputer/RedPajama-INCITE-Base-3B-v1",
+        )
 
     def teardown_method(self, method):
         os.remove(self.cache_path)
@@ -90,7 +93,7 @@ class TestTogetherClient:
         ],
     )
     def test_convert_to_raw_request(self, test_input, expected):
-        assert expected == TogetherClient.convert_to_raw_request(test_input)
+        assert expected == self.client.convert_to_raw_request(test_input)
 
     def test_api_key_error(self):
         with pytest.raises(TogetherClientError):

--- a/src/helm/proxy/clients/test_together_client.py
+++ b/src/helm/proxy/clients/test_together_client.py
@@ -12,18 +12,15 @@ class TestTogetherClient:
     def setup_method(self, method):
         cache_file = tempfile.NamedTemporaryFile(delete=False)
         self.cache_path: str = cache_file.name
-        self.client = TogetherClient(
-            cache_config=SqliteCacheConfig(self.cache_path),
-            together_model="togethercomputer/RedPajama-INCITE-Base-3B-v1",
-        )
 
     def teardown_method(self, method):
         os.remove(self.cache_path)
 
     @pytest.mark.parametrize(
-        "test_input,expected",
+        "together_model,test_input,expected",
         [
             (
+                "togethercomputer/RedPajama-INCITE-Base-3B-v1",
                 Request(
                     model="together/redpajama-incite-base-3b-v1",
                     model_deployment="together/redpajama-incite-base-3b-v1",
@@ -43,6 +40,7 @@ class TestTogetherClient:
                 },
             ),
             (
+                "huggyllama/llama-7b",
                 Request(
                     model="meta/llama-7b",
                     model_deployment="together/llama-7b",
@@ -70,6 +68,7 @@ class TestTogetherClient:
                 },
             ),
             (
+                "togethercomputer/alpaca-7b",
                 Request(
                     model="stanford/alpaca-7b",
                     model_deployment="together/alpaca-7b",
@@ -92,9 +91,22 @@ class TestTogetherClient:
             # TODO(#1828): Add test for `SET_DETAILS_TO_TRUE` after Together supports it.
         ],
     )
-    def test_convert_to_raw_request(self, test_input, expected):
-        assert expected == self.client.convert_to_raw_request(test_input)
+    def test_convert_to_raw_request(self, together_model, test_input, expected):
+        client = TogetherClient(
+            cache_config=SqliteCacheConfig(self.cache_path),
+            together_model=together_model,
+        )
+        assert expected == client.convert_to_raw_request(test_input)
 
     def test_api_key_error(self):
+        client = TogetherClient(
+            cache_config=SqliteCacheConfig(self.cache_path),
+            together_model="togethercomputer/RedPajama-INCITE-Base-3B-v1",
+        )
         with pytest.raises(TogetherClientError):
-            self.client.make_request(Request(model="bigscience/bloom", model_deployment="together/bloom"))
+            client.make_request(
+                Request(
+                    model="together/redpajama-incite-base-3b-v1",
+                    model_deployment="together/redpajama-incite-base-3b-v1",
+                )
+            )

--- a/src/helm/proxy/clients/together_client.py
+++ b/src/helm/proxy/clients/together_client.py
@@ -101,7 +101,7 @@ class TogetherClient(CachingClient):
         # Following the examples from https://github.com/togethercomputer/open-models-api
         raw_request = {
             "request_type": "language-model-inference",
-            "model": self.together_model,
+            "model": self.together_model or request.model,
             "prompt": request.prompt,
             "temperature": request.temperature,
             "n": request.num_completions,
@@ -114,7 +114,7 @@ class TogetherClient(CachingClient):
         }
         return _rewrite_raw_request_for_model_tags(raw_request, request.model_engine)
 
-    def __init__(self, cache_config: CacheConfig, together_model: str, api_key: Optional[str] = None):
+    def __init__(self, cache_config: CacheConfig, together_model: Optional[str], api_key: Optional[str] = None):
         super().__init__(cache_config=cache_config)
         # TODO: the endpoint currently doesn't require an API key. When an API key is not specified
         #       in credentials.conf, we rely on offline evaluation only.

--- a/src/helm/proxy/clients/together_client.py
+++ b/src/helm/proxy/clients/together_client.py
@@ -9,45 +9,6 @@ from helm.common.request import wrap_request_time, Request, RequestResult, Seque
 from .client import CachingClient, truncate_sequence, cleanup_str
 
 
-MODEL_ALIASES: Dict[str, str] = {
-    # Legacy models
-    "flan-t5-xxl": "flan-t5-xxl-hf",
-    # Production models
-    "redpajama-incite-base-3b-v1": "togethercomputer/RedPajama-INCITE-Base-3B-v1",
-    "redpajama-incite-instruct-3b-v1": "togethercomputer/RedPajama-INCITE-Instruct-3B-v1",
-    "redpajama-incite-base-7b": "togethercomputer/RedPajama-INCITE-7B-Base",
-    "redpajama-incite-instruct-7b": "togethercomputer/RedPajama-INCITE-7B-Instruct",
-    "alpaca-7b": "togethercomputer/alpaca-7b",
-    "falcon-7b": "togethercomputer/falcon-7b",
-    "falcon-7b-instruct": "togethercomputer/falcon-7b-instruct",
-    "falcon-40b": "togethercomputer/falcon-40b",
-    "falcon-40b-instruct": "togethercomputer/falcon-40b-instruct",
-    "gpt-jt-6b-v1": "togethercomputer/GPT-JT-6B-v1",
-    "gpt-neoxt-chat-base-20b": "togethercomputer/GPT-NeoXT-Chat-Base-20B",
-    "llama-7b": "huggyllama/llama-7b",
-    "llama-13b": "huggyllama/llama-13b",
-    "llama-30b": "huggyllama/llama-30b",
-    "llama-65b": "huggyllama/llama-65b",
-    "llama-2-7b": "togethercomputer/llama-2-7b",
-    "llama-2-13b": "togethercomputer/llama-2-13b",
-    "llama-2-70b": "togethercomputer/llama-2-70b",
-    "mistral-7b-v0.1": "mistralai/Mistral-7B-v0.1",
-    "mixtral-8x7b-32kseqlen": "mistralai/mixtral-8x7b-32kseqlen",
-    "yi-6b": "zero-one-ai/Yi-6B",
-    "yi-34b": "zero-one-ai/Yi-34B",
-}
-"""Together model name aliases.
-
-HELM users use a shorter model name (e.g. together/flan-t5-xxl)
-whereas the Together client sends and caches requests using
-a longer model name that is suffixed with the implementation framework
-(e.g. flan-t5-xxl-hf). This allows tracking exactly which
-implementation was used in the cached results, since some results may
-be different depending on the implementation (e.g. efficiency metrics).
-This also allows future migration of results in the case of changes of
-available implementations on Together."""
-
-
 class _RewriteRequestTags:
     """Tags that indicate that the request for the model must be rewritten before sending to Together."""
 
@@ -136,12 +97,11 @@ class TogetherClient(CachingClient):
     INFERENCE_ENDPOINT: str = "https://api.together.xyz/api/inference"
     RETRIEVE_JOB_MAX_WAIT_SECONDS: int = 60
 
-    @staticmethod
-    def convert_to_raw_request(request: Request) -> Dict:
+    def convert_to_raw_request(self, request: Request) -> Dict:
         # Following the examples from https://github.com/togethercomputer/open-models-api
         raw_request = {
             "request_type": "language-model-inference",
-            "model": MODEL_ALIASES.get(request.model_engine, request.model_engine),
+            "model": self.together_model,
             "prompt": request.prompt,
             "temperature": request.temperature,
             "n": request.num_completions,
@@ -154,17 +114,18 @@ class TogetherClient(CachingClient):
         }
         return _rewrite_raw_request_for_model_tags(raw_request, request.model_engine)
 
-    def __init__(self, cache_config: CacheConfig, api_key: Optional[str] = None):
+    def __init__(self, cache_config: CacheConfig, together_model: str, api_key: Optional[str] = None):
         super().__init__(cache_config=cache_config)
         # TODO: the endpoint currently doesn't require an API key. When an API key is not specified
         #       in credentials.conf, we rely on offline evaluation only.
         self.api_key: Optional[str] = api_key
+        self.together_model = together_model
 
     def _get_job_url(self, job_id: str) -> str:
         return f"https://api.together.xyz/jobs/job/{job_id}"
 
     def make_request(self, request: Request) -> RequestResult:
-        raw_request = TogetherClient.convert_to_raw_request(request)
+        raw_request = self.convert_to_raw_request(request)
         cache_key = CachingClient.make_cache_key(raw_request, request)
 
         if not self.api_key:

--- a/src/helm/proxy/clients/together_client.py
+++ b/src/helm/proxy/clients/together_client.py
@@ -114,7 +114,7 @@ class TogetherClient(CachingClient):
         }
         return _rewrite_raw_request_for_model_tags(raw_request, request.model_engine)
 
-    def __init__(self, cache_config: CacheConfig, together_model: Optional[str], api_key: Optional[str] = None):
+    def __init__(self, cache_config: CacheConfig, together_model: Optional[str] = None, api_key: Optional[str] = None):
         super().__init__(cache_config=cache_config)
         # TODO: the endpoint currently doesn't require an API key. When an API key is not specified
         #       in credentials.conf, we rely on offline evaluation only.


### PR DESCRIPTION
This removes the hardcoded constant mapping of HELM model names to Together model names from `together_client.py`.

This allows a HELM user to run _any_ Together model on HELM without pulling the HELM repository or modifying any HELM code. The user can simply add the Together model to their local `prod_env/model_deployments.yaml`.

This also removes the need for HELM maintainers to keep `together_client.py` in sync with the current Together model list, which frequently changes.