### PR TITLE
Register configs at the start of test session

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,5 @@
+from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
+
+
+def pytest_sessionstart(session):
+    register_builtin_configs_from_helm_package()

--- a/src/helm/benchmark/adaptation/adapters/test_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/test_adapter.py
@@ -1,7 +1,6 @@
 import shutil
 import tempfile
 
-from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from helm.common.authentication import Authentication
 from helm.proxy.services.server_service import ServerService
 from helm.benchmark.window_services.tokenizer_service import TokenizerService
@@ -13,7 +12,6 @@ class TestAdapter:
     """
 
     def setup_method(self):
-        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service = ServerService(base_path=self.path, root_mode=True)
         self.tokenizer_service = TokenizerService(service, Authentication("test"))

--- a/src/helm/benchmark/test_model_deployment_definition.py
+++ b/src/helm/benchmark/test_model_deployment_definition.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 import pytest
 from tempfile import TemporaryDirectory
-from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from helm.benchmark.model_deployment_registry import (
     get_model_deployment,
     ModelDeployment,
@@ -23,13 +22,6 @@ from helm.benchmark.window_services.window_service_factory import WindowServiceF
 from helm.proxy.clients.auto_client import AutoClient
 from helm.proxy.tokenizers.auto_tokenizer import AutoTokenizer
 
-
-# HACK: This looks like it should be done in a setup_class()
-# for the test below but apparently pytest first check the parametrize
-# before running the setup_class().
-# Therefore ALL_MODEL_DEPLOYMENTS is empty and no test would be run,
-# so we need to do this here.
-register_builtin_configs_from_helm_package()
 
 INT_MAX: int = 2**31 - 1
 

--- a/src/helm/benchmark/window_services/image_generation/test_clip_window_service.py
+++ b/src/helm/benchmark/window_services/image_generation/test_clip_window_service.py
@@ -1,7 +1,6 @@
 import shutil
 import tempfile
 
-from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from helm.benchmark.window_services.tokenizer_service import TokenizerService
 from helm.benchmark.window_services.test_utils import get_tokenizer_service
 from helm.benchmark.window_services.window_service_factory import WindowServiceFactory
@@ -9,7 +8,6 @@ from helm.benchmark.window_services.window_service_factory import WindowServiceF
 
 class TestCLIPWindowService:
     def setup_method(self):
-        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("huggingface/dreamlike-photoreal-v2-0", service)

--- a/src/helm/benchmark/window_services/image_generation/test_openai_dalle_window_service.py
+++ b/src/helm/benchmark/window_services/image_generation/test_openai_dalle_window_service.py
@@ -1,7 +1,6 @@
 import shutil
 import tempfile
 
-from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from helm.benchmark.window_services.tokenizer_service import TokenizerService
 from helm.proxy.clients.image_generation.dalle2_client import DALLE2Client
 from helm.benchmark.window_services.test_utils import get_tokenizer_service, TEST_PROMPT
@@ -10,7 +9,6 @@ from helm.benchmark.window_services.window_service_factory import WindowServiceF
 
 class TestOpenAIDALLEWindowService:
     def setup_method(self):
-        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("openai/dall-e-2", service)

--- a/src/helm/benchmark/window_services/test_anthropic_window_service.py
+++ b/src/helm/benchmark/window_services/test_anthropic_window_service.py
@@ -2,7 +2,6 @@ import shutil
 import tempfile
 from typing import List
 
-from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
 from .test_utils import get_tokenizer_service, TEST_PROMPT
@@ -120,7 +119,6 @@ class TestAnthropicWindowService:
     ]
 
     def setup_method(self):
-        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("anthropic/claude-v1.3", service)

--- a/src/helm/benchmark/window_services/test_bloom_window_service.py
+++ b/src/helm/benchmark/window_services/test_bloom_window_service.py
@@ -2,7 +2,6 @@ import shutil
 import tempfile
 from typing import List
 
-from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
 from .test_utils import get_tokenizer_service, TEST_PROMPT
@@ -64,7 +63,6 @@ class TestBloomWindowService:
     ]
 
     def setup_method(self):
-        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("together/bloom", service)

--- a/src/helm/benchmark/window_services/test_cohere_window_service.py
+++ b/src/helm/benchmark/window_services/test_cohere_window_service.py
@@ -6,7 +6,6 @@ from typing import List
 
 from sqlitedict import SqliteDict
 
-from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from helm.common.general import ensure_directory_exists
 from .test_cohere_window_service_utils import REQUESTS_TO_RESPONSES, TEST_PROMPT, TOKENIZED_PROMPT
 from .tokenizer_service import TokenizerService
@@ -17,7 +16,6 @@ from .test_utils import get_tokenizer_service
 class TestCohereWindowService:
     @classmethod
     def setup_class(cls):
-        register_builtin_configs_from_helm_package()
         cls.path: str = tempfile.mkdtemp()
         cache_path: str = os.path.join(cls.path, "cache")
         ensure_directory_exists(cache_path)

--- a/src/helm/benchmark/window_services/test_flan_t5_window_service.py
+++ b/src/helm/benchmark/window_services/test_flan_t5_window_service.py
@@ -1,6 +1,5 @@
 import tempfile
 
-from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from helm.benchmark.window_services.test_t511b_window_service import TestT511bWindowService
 from helm.benchmark.window_services.window_service_factory import TokenizerService, WindowServiceFactory
 from helm.benchmark.window_services.test_utils import get_tokenizer_service
@@ -8,7 +7,6 @@ from helm.benchmark.window_services.test_utils import get_tokenizer_service
 
 class TestFlanT5WindowService(TestT511bWindowService):
     def setup_method(self):
-        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("together/flan-t5-xxl", service)

--- a/src/helm/benchmark/window_services/test_gpt2_window_service.py
+++ b/src/helm/benchmark/window_services/test_gpt2_window_service.py
@@ -1,7 +1,6 @@
 import shutil
 import tempfile
 
-from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from helm.benchmark.window_services.tokenizer_service import TokenizerService
 
 from .test_utils import get_tokenizer_service, TEST_PROMPT, GPT2_TEST_TOKENS, GPT2_TEST_TOKEN_IDS
@@ -10,7 +9,6 @@ from .window_service_factory import WindowServiceFactory
 
 class TestGPT2WindowService:
     def setup_method(self):
-        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("huggingface/gpt2", service)

--- a/src/helm/benchmark/window_services/test_gpt4_window_service.py
+++ b/src/helm/benchmark/window_services/test_gpt4_window_service.py
@@ -1,7 +1,6 @@
 import shutil
 import tempfile
 
-from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .test_utils import get_tokenizer_service, TEST_PROMPT, GPT4_TEST_TOKEN_IDS, GPT4_TEST_TOKENS
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
@@ -9,7 +8,6 @@ from .window_service_factory import WindowServiceFactory
 
 class TestOpenAIWindowService:
     def setup_method(self):
-        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("openai/gpt-3.5-turbo-0301", service)

--- a/src/helm/benchmark/window_services/test_gptj_window_service.py
+++ b/src/helm/benchmark/window_services/test_gptj_window_service.py
@@ -1,7 +1,6 @@
 import shutil
 import tempfile
 
-from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
 from .test_utils import get_tokenizer_service, GPT2_TEST_TOKENS, GPT2_TEST_TOKEN_IDS, TEST_PROMPT
@@ -9,7 +8,6 @@ from .test_utils import get_tokenizer_service, GPT2_TEST_TOKENS, GPT2_TEST_TOKEN
 
 class TestGPTJWindowService:
     def setup_method(self):
-        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("together/gpt-j-6b", service)

--- a/src/helm/benchmark/window_services/test_gptneox_window_service.py
+++ b/src/helm/benchmark/window_services/test_gptneox_window_service.py
@@ -2,7 +2,6 @@ import shutil
 import tempfile
 from typing import List
 
-from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
 from .test_utils import get_tokenizer_service, TEST_PROMPT
@@ -65,7 +64,6 @@ class TestGPTNeoXWindowService:
     ]
 
     def setup_method(self):
-        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("together/gpt-neox-20b", service)

--- a/src/helm/benchmark/window_services/test_ice_window_service.py
+++ b/src/helm/benchmark/window_services/test_ice_window_service.py
@@ -2,7 +2,6 @@ import shutil
 import tempfile
 from typing import List
 
-from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
 from .test_utils import get_tokenizer_service, TEST_PROMPT
@@ -64,7 +63,6 @@ class TestICEWindowService:
     ]
 
     def setup_method(self):
-        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("together/glm", service)

--- a/src/helm/benchmark/window_services/test_mt_nlg_window_service.py
+++ b/src/helm/benchmark/window_services/test_mt_nlg_window_service.py
@@ -1,7 +1,6 @@
 import shutil
 import tempfile
 
-from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .test_utils import get_tokenizer_service, TEST_PROMPT, GPT2_TEST_TOKENS, GPT2_TEST_TOKEN_IDS
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
@@ -9,7 +8,6 @@ from .window_service_factory import WindowServiceFactory
 
 class TestMTNLGWindowService:
     def setup_method(self):
-        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("microsoft/TNLGv2_7B", service)

--- a/src/helm/benchmark/window_services/test_openai_window_service.py
+++ b/src/helm/benchmark/window_services/test_openai_window_service.py
@@ -1,7 +1,6 @@
 import shutil
 import tempfile
 
-from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .test_utils import get_tokenizer_service, TEST_PROMPT, GPT2_TEST_TOKENS, GPT2_TEST_TOKEN_IDS
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
@@ -9,7 +8,6 @@ from .window_service_factory import WindowServiceFactory
 
 class TestOpenAIWindowService:
     def setup_method(self):
-        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("openai/davinci", service)

--- a/src/helm/benchmark/window_services/test_opt_window_service.py
+++ b/src/helm/benchmark/window_services/test_opt_window_service.py
@@ -1,7 +1,6 @@
 import shutil
 import tempfile
 
-from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .test_utils import get_tokenizer_service, TEST_PROMPT
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
@@ -9,7 +8,6 @@ from .window_service_factory import WindowServiceFactory
 
 class TestOPTWindowService:
     def setup_method(self):
-        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("huggingface/opt-175b", service)

--- a/src/helm/benchmark/window_services/test_palmyra_window_service.py
+++ b/src/helm/benchmark/window_services/test_palmyra_window_service.py
@@ -1,7 +1,6 @@
 from tempfile import TemporaryDirectory
 from typing import List
 
-from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
 from .test_utils import get_tokenizer_service, TEST_PROMPT
@@ -117,7 +116,6 @@ class TestPalmyraWindowService:
     ]
 
     def setup_method(self):
-        register_builtin_configs_from_helm_package()
         self.temporary_directory = TemporaryDirectory()
         service: TokenizerService = get_tokenizer_service(self.temporary_directory.name)
         self.window_service = WindowServiceFactory.get_window_service("writer/palmyra-large", service)

--- a/src/helm/benchmark/window_services/test_t0pp_window_service.py
+++ b/src/helm/benchmark/window_services/test_t0pp_window_service.py
@@ -2,7 +2,6 @@ import shutil
 import tempfile
 from typing import List
 
-from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
 from .test_utils import get_tokenizer_service, TEST_PROMPT
@@ -70,7 +69,6 @@ class TestT0ppWindowService:
     ]
 
     def setup_method(self):
-        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("together/t0pp", service)

--- a/src/helm/benchmark/window_services/test_t511b_window_service.py
+++ b/src/helm/benchmark/window_services/test_t511b_window_service.py
@@ -2,7 +2,6 @@ import shutil
 import tempfile
 from typing import List
 
-from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
 from .test_utils import get_tokenizer_service, TEST_PROMPT
@@ -70,7 +69,6 @@ class TestT511bWindowService:
     ]
 
     def setup_method(self):
-        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("together/t5-11b", service)

--- a/src/helm/benchmark/window_services/test_ul2_window_service.py
+++ b/src/helm/benchmark/window_services/test_ul2_window_service.py
@@ -2,7 +2,6 @@ import shutil
 import tempfile
 from typing import List
 
-from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
 from .tokenizer_service import TokenizerService
 from .window_service_factory import WindowServiceFactory
 from .test_utils import get_tokenizer_service, TEST_PROMPT
@@ -70,7 +69,6 @@ class TestUL2WindowService:
     ]
 
     def setup_method(self):
-        register_builtin_configs_from_helm_package()
         self.path: str = tempfile.mkdtemp()
         service: TokenizerService = get_tokenizer_service(self.path)
         self.window_service = WindowServiceFactory.get_window_service("together/ul2", service)


### PR DESCRIPTION
Put `register_builtin_configs_from_helm_package()` in conftest.py ([doc](https://docs.pytest.org/en/7.1.x/reference/fixtures.html#conftest-py-sharing-fixtures-across-multiple-files)). This eliminates the need to call `register_builtin_configs_from_helm_package()` from within tests, and ensures that `register_builtin_configs_from_helm_package()` is not called multiple times unnecessarily during testing.