### PR TITLE
Loosen version specifiers for core dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,23 +24,23 @@ include_package_data = True
 
 install_requires=
     # Common
-    cattrs~=22.2.0
-    dacite~=1.6.0
-    importlib-resources~=5.10.0
-    Mako~=1.2.3
-    numpy~=1.23.3
+    cattrs~=22.2
+    dacite~=1.6
+    importlib-resources~=5.10
+    Mako~=1.2
+    numpy~=1.23
     pyhocon~=0.3.59
-    retrying~=1.3.4
-    spacy~=3.5.3
-    tqdm~=4.64.1
+    retrying~=1.3
+    spacy~=3.5
+    tqdm~=4.64
     zstandard~=0.18.0
     # sqlitedict==2.0.0 is slow! https://github.com/RaRe-Technologies/sqlitedict/issues/152
     # Keep sqlitedict version at 1.7.0.
-    sqlitedict~=1.7.0
-    bottle~=0.12.23
+    sqlitedict~=1.7
+    bottle~=0.12
 
     # Basic Scenarios
-    datasets~=2.5.2
+    datasets~=2.5
     pyarrow>=11.0.0,  # Pinned transitive dependency for datasets; workaround for #1026
     pyarrow-hotfix~=0.6  # Hotfix for CVE-2023-47248
 
@@ -48,18 +48,18 @@ install_requires=
     nltk~=3.7
     pyext~=0.7
     rouge-score~=0.1.2
-    scipy~=1.10.0
+    scipy~=1.10
     uncertainty-calibration~=0.1.4
-    scikit-learn~=1.1.2
+    scikit-learn~=1.1
 
     # Models and Metrics Extras
-    transformers~=4.36.0  # For anthropic_client, vision_language.huggingface_vlm_client, huggingface_client, huggingface_tokenizer, test_openai_token_cost_estimator, model_summac (via summarization_metrics)
+    transformers~=4.36  # For anthropic_client, vision_language.huggingface_vlm_client, huggingface_client, huggingface_tokenizer, test_openai_token_cost_estimator, model_summac (via summarization_metrics)
     # TODO: Upgrade torch - we need > 2.0.0 for newer versions of transformers
     torch>=1.13.1,<3.0.0  # For huggingface_client, yalm_tokenizer, model_summac (via summarization_metrics)
     torchvision>=0.14.1,<3.0.0  # For huggingface_client, yalm_tokenizer, model_summac (via summarization_metrics)
 
     # Metrics Extras
-    google-api-python-client~=2.64.0  # For perspective_api_client via toxicity_metrics
+    google-api-python-client~=2.64  # For perspective_api_client via toxicity_metrics
 
 [options.extras_require]
 proxy-server =

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires=
     # sqlitedict==2.0.0 is slow! https://github.com/RaRe-Technologies/sqlitedict/issues/152
     # Keep sqlitedict version at 1.7.0.
     sqlitedict~=1.7
-    bottle~=0.12
+    bottle~=0.12.23
 
     # Basic Scenarios
     datasets~=2.5


### PR DESCRIPTION
This will allow pip to install more recent versions when performing dependency resolution. This is particularly important for `datasets` and `transformers`, which have recent bugfixes and new features.