### PR TITLE
Sticky cells for leaderboard table

### DIFF
--- a/helm-frontend/src/components/LeaderboardTables.tsx
+++ b/helm-frontend/src/components/LeaderboardTables.tsx
@@ -244,59 +244,64 @@ export default function LeaderboardTables({
           </div>
         </div>
       ) : (
-        <table className="table w-full px-4">
-          <thead>
-            <tr>
-              {activeGroupsTable.header.map((headerValue, idx) => (
-                <th
-                  key={`${activeGroup}-${idx}`}
-                  className={`${
-                    idx === activeSortColumn ? "bg-gray-100" : "bg-white"
-                  } ${
-                    idx === 0 ? "left-0 z-10" : ""
-                  } whitespace-nowrap px-4 sticky top-0`}
-                >
-                  <div className="flex gap-2 items-center">
-                    <span>{getHeaderValue(headerValue)}</span>
-                    {sortable ? (
-                      <button className="link" onClick={() => handleSort(idx)}>
-                        <ChevronUpDownIcon className="w-6 h-6" />
-                      </button>
-                    ) : null}
-                  </div>
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {activeGroupsTable.rows.map((row, idx) => (
-              <tr key={`${activeGroup}-${idx}`}>
-                {row.map((rowValue, cellIdx) => (
-                  <td
-                    key={`${activeGroup}-${cellIdx}`}
+        <div className="overflow-auto h-[75vh] rounded-lg shadow-md bg-white">
+          <table className="table w-full">
+            <thead>
+              <tr>
+                {activeGroupsTable.header.map((headerValue, idx) => (
+                  <th
+                    key={`${activeGroup}-${idx}`}
                     className={`${
-                      cellIdx === 0 ? "text-lg sticky left-0" : ""
-                    } ${idx % 2 === 0 ? "bg-gray-50" : "bg-white"}`}
-                    title={`Click value to see predictions for ${getGroupForRunName(
-                      getHeaderValue(activeGroupsTable.header[cellIdx]),
-                    )}: ${getModelForRunName(String(row[0].value))}`}
+                      idx === activeSortColumn ? "bg-gray-100" : "bg-white"
+                    } ${
+                      idx === 0 ? "left-0 z-10" : ""
+                    } whitespace-nowrap px-4 sticky top-0`}
                   >
-                    <a
-                      href={`#/runs/?q=${getGroupForRunName(
-                        getHeaderValue(activeGroupsTable.header[cellIdx]),
-                      )}.*${getModelForRunName(String(row[0].value))}`}
-                    >
-                      <RowValue
-                        ignoreHref={ignoreHref && cellIdx === 0}
-                        value={{ ...rowValue }}
-                      />
-                    </a>
-                  </td>
+                    <div className="flex gap-2 items-center">
+                      <span>{getHeaderValue(headerValue)}</span>
+                      {sortable ? (
+                        <button
+                          className="link"
+                          onClick={() => handleSort(idx)}
+                        >
+                          <ChevronUpDownIcon className="w-6 h-6" />
+                        </button>
+                      ) : null}
+                    </div>
+                  </th>
                 ))}
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {activeGroupsTable.rows.map((row, idx) => (
+                <tr key={`${activeGroup}-${idx}`}>
+                  {row.map((rowValue, cellIdx) => (
+                    <td
+                      key={`${activeGroup}-${cellIdx}`}
+                      className={`${
+                        cellIdx === 0 ? "text-lg sticky left-0" : ""
+                      } ${idx % 2 === 0 ? "bg-gray-50" : "bg-white"}`}
+                      title={`Click value to see predictions for ${getGroupForRunName(
+                        getHeaderValue(activeGroupsTable.header[cellIdx]),
+                      )}: ${getModelForRunName(String(row[0].value))}`}
+                    >
+                      <a
+                        href={`#/runs/?q=${getGroupForRunName(
+                          getHeaderValue(activeGroupsTable.header[cellIdx]),
+                        )}.*${getModelForRunName(String(row[0].value))}`}
+                      >
+                        <RowValue
+                          ignoreHref={ignoreHref && cellIdx === 0}
+                          value={{ ...rowValue }}
+                        />
+                      </a>
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
     </>
   );

--- a/helm-frontend/src/components/LeaderboardTables.tsx
+++ b/helm-frontend/src/components/LeaderboardTables.tsx
@@ -245,62 +245,64 @@ export default function LeaderboardTables({
         </div>
       ) : (
         <div className="overflow-auto h-[calc(100vh_-_18rem)] rounded-lg shadow-md bg-white">
-          <table className="table w-full">
-            <thead>
-              <tr>
-                {activeGroupsTable.header.map((headerValue, idx) => (
-                  <th
-                    key={`${activeGroup}-${idx}`}
-                    className={`${
-                      idx === activeSortColumn ? "bg-gray-100" : "bg-white"
-                    } ${
-                      idx === 0 ? "left-0 z-10" : ""
-                    } whitespace-nowrap px-4 sticky top-0`}
-                  >
-                    <div className="flex gap-2 items-center">
-                      <span>{getHeaderValue(headerValue)}</span>
-                      {sortable ? (
-                        <button
-                          className="link"
-                          onClick={() => handleSort(idx)}
-                        >
-                          <ChevronUpDownIcon className="w-6 h-6" />
-                        </button>
-                      ) : null}
-                    </div>
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {activeGroupsTable.rows.map((row, idx) => (
-                <tr key={`${activeGroup}-${idx}`}>
-                  {row.map((rowValue, cellIdx) => (
-                    <td
-                      key={`${activeGroup}-${cellIdx}`}
+          <div>
+            <table className="table w-full">
+              <thead>
+                <tr>
+                  {activeGroupsTable.header.map((headerValue, idx) => (
+                    <th
+                      key={`${activeGroup}-${idx}`}
                       className={`${
-                        cellIdx === 0 ? "text-lg sticky left-0" : ""
-                      } ${idx % 2 === 0 ? "bg-gray-50" : "bg-white"}`}
-                      title={`Click value to see predictions for ${getGroupForRunName(
-                        getHeaderValue(activeGroupsTable.header[cellIdx]),
-                      )}: ${getModelForRunName(String(row[0].value))}`}
+                        idx === activeSortColumn ? "bg-gray-100" : "bg-white"
+                      } ${
+                        idx === 0 ? "left-0 z-10" : ""
+                      } whitespace-nowrap px-4 sticky top-0`}
                     >
-                      <a
-                        href={`#/runs/?q=${getGroupForRunName(
-                          getHeaderValue(activeGroupsTable.header[cellIdx]),
-                        )}.*${getModelForRunName(String(row[0].value))}`}
-                      >
-                        <RowValue
-                          ignoreHref={ignoreHref && cellIdx === 0}
-                          value={{ ...rowValue }}
-                        />
-                      </a>
-                    </td>
+                      <div className="flex gap-2 items-center">
+                        <span>{getHeaderValue(headerValue)}</span>
+                        {sortable ? (
+                          <button
+                            className="link"
+                            onClick={() => handleSort(idx)}
+                          >
+                            <ChevronUpDownIcon className="w-6 h-6" />
+                          </button>
+                        ) : null}
+                      </div>
+                    </th>
                   ))}
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {activeGroupsTable.rows.map((row, idx) => (
+                  <tr key={`${activeGroup}-${idx}`}>
+                    {row.map((rowValue, cellIdx) => (
+                      <td
+                        key={`${activeGroup}-${cellIdx}`}
+                        className={`${
+                          cellIdx === 0 ? "text-lg sticky left-0" : ""
+                        } ${idx % 2 === 0 ? "bg-gray-50" : "bg-white"}`}
+                        title={`Click value to see predictions for ${getGroupForRunName(
+                          getHeaderValue(activeGroupsTable.header[cellIdx]),
+                        )}: ${getModelForRunName(String(row[0].value))}`}
+                      >
+                        <a
+                          href={`#/runs/?q=${getGroupForRunName(
+                            getHeaderValue(activeGroupsTable.header[cellIdx]),
+                          )}.*${getModelForRunName(String(row[0].value))}`}
+                        >
+                          <RowValue
+                            ignoreHref={ignoreHref && cellIdx === 0}
+                            value={{ ...rowValue }}
+                          />
+                        </a>
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
       )}
     </>

--- a/helm-frontend/src/components/LeaderboardTables.tsx
+++ b/helm-frontend/src/components/LeaderboardTables.tsx
@@ -244,7 +244,7 @@ export default function LeaderboardTables({
           </div>
         </div>
       ) : (
-        <div className="overflow-auto h-[75vh] rounded-lg shadow-md bg-white">
+        <div className="overflow-auto h-[calc(100vh_-_18rem)] rounded-lg shadow-md bg-white">
           <table className="table w-full">
             <thead>
               <tr>

--- a/helm-frontend/src/components/LeaderboardTables.tsx
+++ b/helm-frontend/src/components/LeaderboardTables.tsx
@@ -244,67 +244,59 @@ export default function LeaderboardTables({
           </div>
         </div>
       ) : (
-        <div className="rounded-lg overflow-hidden shadow-md bg-white p-4">
-          <div className="overflow-x-auto">
-            <table className="table w-full px-4">
-              <thead>
-                <tr>
-                  {activeGroupsTable.header.map((headerValue, idx) => (
-                    <th
-                      key={`${activeGroup}-${idx}`}
-                      className={`${
-                        idx === activeSortColumn ? "bg-gray-100" : ""
-                      } whitespace-nowrap px-4`}
-                    >
-                      <div className="flex gap-2 items-center">
-                        <span>{getHeaderValue(headerValue)}</span>
-                        {sortable ? (
-                          <button
-                            className="link"
-                            onClick={() => handleSort(idx)}
-                          >
-                            <ChevronUpDownIcon className="w-6 h-6" />
-                          </button>
-                        ) : null}
-                      </div>
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {activeGroupsTable.rows.map((row, idx) => (
-                  <tr
-                    key={`${activeGroup}-${idx}`}
-                    className={`${idx % 2 === 0 ? "bg-gray-50" : ""}`}
+        <table className="table w-full px-4">
+          <thead>
+            <tr>
+              {activeGroupsTable.header.map((headerValue, idx) => (
+                <th
+                  key={`${activeGroup}-${idx}`}
+                  className={`${
+                    idx === activeSortColumn ? "bg-gray-100" : "bg-white"
+                  } ${
+                    idx === 0 ? "left-0 z-10" : ""
+                  } whitespace-nowrap px-4 sticky top-0`}
+                >
+                  <div className="flex gap-2 items-center">
+                    <span>{getHeaderValue(headerValue)}</span>
+                    {sortable ? (
+                      <button className="link" onClick={() => handleSort(idx)}>
+                        <ChevronUpDownIcon className="w-6 h-6" />
+                      </button>
+                    ) : null}
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {activeGroupsTable.rows.map((row, idx) => (
+              <tr key={`${activeGroup}-${idx}`}>
+                {row.map((rowValue, cellIdx) => (
+                  <td
+                    key={`${activeGroup}-${cellIdx}`}
+                    className={`${
+                      cellIdx === 0 ? "text-lg sticky left-0" : ""
+                    } ${idx % 2 === 0 ? "bg-gray-50" : "bg-white"}`}
+                    title={`Click value to see predictions for ${getGroupForRunName(
+                      getHeaderValue(activeGroupsTable.header[cellIdx]),
+                    )}: ${getModelForRunName(String(row[0].value))}`}
                   >
-                    {" "}
-                    {/* Added alternating row highlighting */}
-                    {row.map((rowValue, cellIdx) => (
-                      <td
-                        key={`${activeGroup}-${cellIdx}`}
-                        className={`${cellIdx === 0 ? "text-lg" : ""}`}
-                        title={`Click value to see predictions for ${getGroupForRunName(
-                          getHeaderValue(activeGroupsTable.header[cellIdx]),
-                        )}: ${getModelForRunName(String(row[0].value))}`}
-                      >
-                        <a
-                          href={`#/runs/?q=${getGroupForRunName(
-                            getHeaderValue(activeGroupsTable.header[cellIdx]),
-                          )}.*${getModelForRunName(String(row[0].value))}`}
-                        >
-                          <RowValue
-                            ignoreHref={ignoreHref && cellIdx === 0}
-                            value={{ ...rowValue }}
-                          />
-                        </a>
-                      </td>
-                    ))}
-                  </tr>
+                    <a
+                      href={`#/runs/?q=${getGroupForRunName(
+                        getHeaderValue(activeGroupsTable.header[cellIdx]),
+                      )}.*${getModelForRunName(String(row[0].value))}`}
+                    >
+                      <RowValue
+                        ignoreHref={ignoreHref && cellIdx === 0}
+                        value={{ ...rowValue }}
+                      />
+                    </a>
+                  </td>
                 ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       )}
     </>
   );

--- a/helm-frontend/src/components/MiniLeaderboard.tsx
+++ b/helm-frontend/src/components/MiniLeaderboard.tsx
@@ -67,7 +67,6 @@ export default function MiniLeaderboard() {
           title={groupMetadata.display_name}
           subtitle={groupMetadata.description}
           markdown={true}
-          className="mr-8"
         />
         <div className="divider"></div>
         <p className="text-center mt-8">Group currently has no results.</p>

--- a/helm-frontend/src/components/NavBar/NavBar.tsx
+++ b/helm-frontend/src/components/NavBar/NavBar.tsx
@@ -7,6 +7,7 @@ import ReleaseDropdown from "../ReleaseDropdown";
 
 export default function NavBar() {
   const navbarStyle: React.CSSProperties = {
+    position: "sticky",
     top: "0",
     zIndex: "1000",
     backgroundColor: "rgba(255, 255, 255, 0.9)",
@@ -15,7 +16,7 @@ export default function NavBar() {
   return (
     <nav
       style={navbarStyle}
-      className="navbar h-24 px-8 md:px-12 bg-base-100 max-w[1500]px"
+      className="navbar sticky-nav h-24 px-8 md:px-12 bg-base-100 max-w[1500]px"
     >
       <div>
         <div className="dropdown md:hidden mr-4">

--- a/helm-frontend/src/components/NavBar/NavBar.tsx
+++ b/helm-frontend/src/components/NavBar/NavBar.tsx
@@ -7,7 +7,6 @@ import ReleaseDropdown from "../ReleaseDropdown";
 
 export default function NavBar() {
   const navbarStyle: React.CSSProperties = {
-    position: "sticky",
     top: "0",
     zIndex: "1000",
     backgroundColor: "rgba(255, 255, 255, 0.9)",
@@ -16,7 +15,7 @@ export default function NavBar() {
   return (
     <nav
       style={navbarStyle}
-      className="navbar sticky-nav h-24 px-8 md:px-12 bg-base-100 max-w[1500]px"
+      className="navbar h-24 px-8 md:px-12 bg-base-100 max-w[1500]px"
     >
       <div>
         <div className="dropdown md:hidden mr-4">

--- a/helm-frontend/src/components/PageTitle/PageTitle.tsx
+++ b/helm-frontend/src/components/PageTitle/PageTitle.tsx
@@ -11,10 +11,9 @@ export default function PageTitle({
   title,
   subtitle,
   markdown = false,
-  className,
 }: Props) {
   return (
-    <header className={`m-8 ml-0 ${className}`}>
+    <header className={`m-4 ml-0`}>
       <h1 className="text-4xl">{title}</h1>
       {markdown && subtitle !== undefined ? (
         <h2 className="mt-2 text-neutral">

--- a/helm-frontend/src/layouts/Main.tsx
+++ b/helm-frontend/src/layouts/Main.tsx
@@ -5,7 +5,7 @@ export default function Main() {
   return (
     <>
       <Nav />
-      <main className="p-8 md:pt-12 pt-0">
+      <main className="p-8 pt-0">
         <div className="mx-auto max-w-[1500]px">
           <Outlet />
         </div>

--- a/helm-frontend/src/routes/Leaderboard.tsx
+++ b/helm-frontend/src/routes/Leaderboard.tsx
@@ -104,7 +104,7 @@ export default function Leaderboard() {
             }
             markdown={true}
           />
-          <div className="w-64 py-10 ">
+          <div className="w-64 pt-8">
             <label
               htmlFor="group"
               className="block text-sm font-medium text-gray-700"

--- a/helm-frontend/src/routes/Leaderboard.tsx
+++ b/helm-frontend/src/routes/Leaderboard.tsx
@@ -86,7 +86,6 @@ export default function Leaderboard() {
           title={groupMetadata.display_name}
           subtitle={groupMetadata.description}
           markdown={true}
-          className="mr-8"
         />
         <div className="divider"></div>
         <p className="text-center mt-8">Group currently has no results.</p>
@@ -104,7 +103,6 @@ export default function Leaderboard() {
               "HELM is a framework for evaluating foundation models. Our leaderboard shows how the various models (with particular adaptation procedures) perform across different groups of scenarios and different metrics."
             }
             markdown={true}
-            className="mr-8 mb-16"
           />
           <div className="w-64 py-10 ">
             <label


### PR DESCRIPTION
- Moves the vertical scroll bar from the page viewport to the table wrapper div.
- Set the table height using the viewport height to avoid page scrolling in most situations.
- Sets cell background to opaque, so that the sticky cells are readable when overlapping other cells.
- Removes `className` prop from `PageTitle`, which was causing HTML elements to have the string "undefined" as a class name.
- Removes a lot of unnecessary whitespace, which leaves more room for the table.

![sticky-screenshot](https://github.com/stanford-crfm/helm/assets/185227/ac218dc8-628c-44c1-ac3e-0fda65c5af86)