### PR TITLE
Various fixes to run predictions frontend

### DIFF
--- a/helm-frontend/src/components/NavBar/NavBar.tsx
+++ b/helm-frontend/src/components/NavBar/NavBar.tsx
@@ -6,18 +6,8 @@ import NavDropdown from "@/components/NavDropdown";
 import ReleaseDropdown from "../ReleaseDropdown";
 
 export default function NavBar() {
-  const navbarStyle: React.CSSProperties = {
-    position: "sticky",
-    top: "0",
-    zIndex: "1000",
-    backgroundColor: "rgba(255, 255, 255, 0.9)",
-    // Add any additional inline styles for the sticky navbar here
-  };
   return (
-    <nav
-      style={navbarStyle}
-      className="navbar sticky-nav h-24 px-8 md:px-12 bg-base-100 max-w[1500]px"
-    >
+    <nav className="navbar h-24 px-8 md:px-12 bg-base-100 max-w[1500]px">
       <div>
         <div className="dropdown md:hidden mr-4">
           <label

--- a/helm-frontend/src/components/NavBar/NavBar.tsx
+++ b/helm-frontend/src/components/NavBar/NavBar.tsx
@@ -6,8 +6,18 @@ import NavDropdown from "@/components/NavDropdown";
 import ReleaseDropdown from "../ReleaseDropdown";
 
 export default function NavBar() {
+  const navbarStyle: React.CSSProperties = {
+    position: "sticky",
+    top: "0",
+    zIndex: "100",
+    backgroundColor: "rgba(255, 255, 255, 0.9)",
+    // Add any additional inline styles for the sticky navbar here
+  };
   return (
-    <nav className="navbar h-24 px-8 md:px-12 bg-base-100 max-w[1500]px">
+    <nav
+      style={navbarStyle}
+      className="navbar sticky-nav h-24 px-8 md:px-12 bg-base-100 max-w[1500]px"
+    >
       <div>
         <div className="dropdown md:hidden mr-4">
           <label

--- a/helm-frontend/src/components/Preview.tsx
+++ b/helm-frontend/src/components/Preview.tsx
@@ -16,8 +16,8 @@ export default function Preview({ value }: Props) {
         onMouseOut={() => setShowButton(false)}
         className="relative"
       >
-        <div className="bg-base-200 p-2 block overflow-auto w-full max-h-72 mb-2">
-          <pre>{value}</pre>
+        <div className="bg-base-200 p-2 block overflow-auto w-full max-h-72 mb-2 whitespace-pre-wrap">
+          {value}
         </div>
 
         {showButton ? (
@@ -35,13 +35,11 @@ export default function Preview({ value }: Props) {
       </div>
       <dialog
         open={showModal}
-        className="modal p-16"
+        className="modal p-16 bg-opacity-80 bg-white"
         onClick={() => setShowModal(false)}
       >
-        <div className="modal-box max-w-none p-16">
-          <div>
-            <pre className="p-6">{value}</pre>
-          </div>
+        <div className="modal-box max-w-none p-4 whitespace-pre-wrap bg-base-200">
+          {value}
         </div>
       </dialog>
     </>

--- a/helm-frontend/src/routes/Leaderboard.tsx
+++ b/helm-frontend/src/routes/Leaderboard.tsx
@@ -101,7 +101,7 @@ export default function Leaderboard() {
           <PageTitle
             title={"HELM Leaderboard"}
             subtitle={
-              "HELM is a framework for evaluating foundation models. Our leaderboard shows how the various models (with particular adaptation procedures) perform across different groups of scenarios and different metrics."
+              "The HELM leaderboard shows how the various models perform across different scenarios and metrics."
             }
             markdown={true}
             className="mr-8 mb-16"

--- a/helm-frontend/src/routes/Run.tsx
+++ b/helm-frontend/src/routes/Run.tsx
@@ -229,7 +229,7 @@ export default function Run() {
       </div>
       {activeTab === 0 ? (
         <>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8">
+          <div className="grid gap-8">
             {pagedInstances.map((instance, idx) => (
               <InstanceData
                 key={`${instance.id}-${idx}`}


### PR DESCRIPTION
- Remove columns for instances so that the entire text can be displayed without scrolling.
- Switch from `pre` to `whitespace: pre-wrap` which is more appropriate, and what the jQuery UI uses.
- Clean up the model view

Fixes #2258

![Screenshot 2024-01-23 142720](https://github.com/stanford-crfm/helm/assets/185227/7e8119d5-26f8-444b-8a1a-55c298aefece)

![Screenshot 2024-01-23 142737](https://github.com/stanford-crfm/helm/assets/185227/21b87de5-24c2-4d5a-b501-fe0d018ad831)