### PR TITLE
Bump PyTorch version to 2.1.2

### DIFF
--- a/.github/workflows/update-requirements.yml
+++ b/.github/workflows/update-requirements.yml
@@ -38,7 +38,7 @@ jobs:
         # PyTorch has to be installed manually in a separate step with --no-cache-dir
         # to avoid pip getting killed because PyTorch is too big
         # See: https://stackoverflow.com/a/54329850
-        run: pip install --no-cache-dir --find-links https://download.pytorch.org/whl/torch_stable.html torch==1.12.1+cu113 torchvision==0.13.1+cu113
+        run: pip install torch==2.1.0 torchvision==0.16.0 --index-url https://download.pytorch.org/whl/cu121 --no-cache-dir
       - name: Install dependencies
         run: pip install -e .[all]
       - name: Install development dependencies

--- a/.github/workflows/update-requirements.yml
+++ b/.github/workflows/update-requirements.yml
@@ -38,7 +38,7 @@ jobs:
         # PyTorch has to be installed manually in a separate step with --no-cache-dir
         # to avoid pip getting killed because PyTorch is too big
         # See: https://stackoverflow.com/a/54329850
-        run: pip install torch==2.1.0 torchvision==0.16.0 --index-url https://download.pytorch.org/whl/cu121 --no-cache-dir
+        run: pip install torch==2.1.2 torchvision==0.16.2 --index-url https://download.pytorch.org/whl/cu121 --no-cache-dir
       - name: Install dependencies
         run: pip install -e .[all]
       - name: Install development dependencies

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -6,8 +6,8 @@ set -e
 
 # On Mac OS, skip installing pytorch with CUDA because CUDA is not supported
 if [[ $OSTYPE != 'darwin'* ]]; then
-  # Manually install pytorch to avoid pip getting killed: https://stackoverflow.com/a/54329850
-  pip install --no-cache-dir --find-links https://download.pytorch.org/whl/torch_stable.html torch==1.12.1+cu113 torchvision==0.13.1+cu113
+  # Manually install pytorch with `--no-cache-dir` to avoid pip getting killed: https://stackoverflow.com/a/54329850
+  pip install torch==2.1.2 torchvision==0.16.2 --index-url https://download.pytorch.org/whl/cu121 --no-cache-dir
 fi
 # Install all pinned dependencies
 pip install -r requirements.txt

--- a/install-heim-extras.sh
+++ b/install-heim-extras.sh
@@ -11,7 +11,7 @@ set -e
 # On Mac OS, skip installing pytorch with CUDA because CUDA is not supported
 if [[ $OSTYPE != 'darwin'* ]]; then
   # Manually install pytorch to avoid pip getting killed: https://stackoverflow.com/a/54329850
-  pip install --no-cache-dir --find-links https://download.pytorch.org/whl/torch_stable.html torch==1.12.1+cu113 torchvision==0.13.1+cu113
+  pip install torch==2.1.2 torchvision==0.16.2 --index-url https://download.pytorch.org/whl/cu121 --no-cache-dir
 
   # DALLE mini requires jax install
   pip install jax==0.3.25 jaxlib==0.3.25+cuda11.cudnn805 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -163,10 +163,8 @@ tls-client==0.1.8
 tokenizers>=0.13.3
 toml==0.10.2
 tomli==2.0.1
-torch==1.12.1 ; sys_platform == "darwin"
-torchvision==0.13.1 ; sys_platform == "darwin"
-torch==1.12.1+cu113 ; sys_platform == "linux"
-torchvision==0.13.1+cu113 ; sys_platform == "linux"
+torch~=2.1.2
+torchvision~=0.16.2
 tqdm==4.64.1
 transformers==4.36.0
 trio==0.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -163,8 +163,8 @@ tls-client==0.1.8
 tokenizers>=0.13.3
 toml==0.10.2
 tomli==2.0.1
-torch~=2.1.2
-torchvision~=0.16.2
+torch>=1.13.1
+torchvision>=0.14.1
 tqdm==4.64.1
 transformers==4.36.0
 trio==0.22.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,6 +77,8 @@ metrics =
     numba~=0.56.4  # For copyright_metrics
     pytrec_eval==0.5  # For ranking_metrics
     sacrebleu~=2.2.1  # For disinformation_metrics, machine_translation_metrics
+
+summarization =
     summ-eval~=0.892  # For summarization_metrics
 
 plots =
@@ -192,6 +194,9 @@ all =
     crfm-helm[models]
     crfm-helm[mongo]
     crfm-helm[heim]
+    # crfm-helm[dev] is excluded because end-users don't need it.
+    # crfm-helm[summarize] is excluded because it requires torch<2.0
+    # TODO(#2280): Add crfm-helm[summarize] back.
 
 # Development only
 # Do not include in all

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,8 +54,8 @@ install_requires=
     # Models and Metrics Extras
     transformers~=4.36.0  # For anthropic_client, vision_language.huggingface_vlm_client, huggingface_client, huggingface_tokenizer, test_openai_token_cost_estimator, model_summac (via summarization_metrics)
     # TODO: Upgrade torch - we need > 2.0.0 for newer versions of transformers
-    torch>=1.12.1,<3.0.0  # For huggingface_client, yalm_tokenizer, model_summac (via summarization_metrics)
-    torchvision>=0.13.1,<3.0.0  # For huggingface_client, yalm_tokenizer, model_summac (via summarization_metrics)
+    torch>=1.13.1,<3.0.0  # For huggingface_client, yalm_tokenizer, model_summac (via summarization_metrics)
+    torchvision>=0.14.1,<3.0.0  # For huggingface_client, yalm_tokenizer, model_summac (via summarization_metrics)
 
     # Metrics Extras
     google-api-python-client~=2.64.0  # For perspective_api_client via toxicity_metrics

--- a/src/helm/benchmark/metrics/summarization_metrics.py
+++ b/src/helm/benchmark/metrics/summarization_metrics.py
@@ -58,7 +58,7 @@ class SummarizationMetric(Metric):
         try:
             from summ_eval.data_stats_metric import DataStatsMetric
         except ModuleNotFoundError as e:
-            handle_module_not_found_error(e, ["metrics"])
+            handle_module_not_found_error(e, ["summarization"])
 
         self.data_stats_metric = DataStatsMetric()
         self.task: str = task


### PR DESCRIPTION
Now that we have CUDA 12 on our internal machines, we should use PyTorch 2.1.2 everywhere to take advantage of CUDA 12. This aligns with VLM, which _already_ [uses PyTorch 2.1.2](https://github.com/stanford-crfm/helm/blob/76e168e5cff3558ea652537698ddf8ea6753f355/setup.cfg#L138).

Also bump the minimum supported version of PyTorch to 1.13.1 to address the security vulnerability reported in [CVE-2022-45907](https://nvd.nist.gov/vuln/detail/CVE-2022-45907).