### PR TITLE
Trigger GitHub Actions workflows when workflow files are modified

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -8,6 +8,7 @@ on:
       - 'main'
     paths:
       - 'helm-frontend/**'
+      - '.github/workflows/build-frontend.yml'
 
 jobs:
   build:

--- a/.github/workflows/update-requirements.yml
+++ b/.github/workflows/update-requirements.yml
@@ -10,6 +10,7 @@ on:
       - "main"
     paths:
       - "setup.cfg"
+      - '.github/workflows/build-frontend.yml'
 
 jobs:
   update-requirements:

--- a/.github/workflows/update-requirements.yml
+++ b/.github/workflows/update-requirements.yml
@@ -10,7 +10,7 @@ on:
       - "main"
     paths:
       - "setup.cfg"
-      - '.github/workflows/build-frontend.yml'
+      - '.github/workflows/update-requirements.yml'
 
 jobs:
   update-requirements:


### PR DESCRIPTION
The "Build Frontend" and "Update requirements.txt" workflows should trigger themselves when their workflow definition files are modified, because changes to the workflow definitions would also change the workflow output.