### PR TITLE
Fixing leaderboard feedback

### DIFF
--- a/helm-frontend/src/components/LeaderboardTables.tsx
+++ b/helm-frontend/src/components/LeaderboardTables.tsx
@@ -63,6 +63,25 @@ export default function LeaderboardTables({
     void fetchData();
     return () => controller.abort();
   }, []);
+
+  const getModelDesc = (model: string): string => {
+    if (schema) {
+      const foundItem = schema.models.find(
+        (item) => item.display_name === model,
+      );
+      if (foundItem) {
+        let toRet = foundItem.description;
+        if (toRet.includes("/")) {
+          toRet = toRet.replace("/", "_");
+          return toRet;
+        } else {
+          return toRet;
+        }
+      }
+    }
+    return "";
+  };
+
   const getModelForRunName = (model: string): string => {
     if (schema) {
       const foundItem = schema.models.find(
@@ -283,13 +302,34 @@ export default function LeaderboardTables({
                           cellIdx === 0 ? "text-lg sticky left-0" : ""
                         } ${idx % 2 === 0 ? "bg-gray-50" : "bg-white"}`}
                       >
-                        <RowValue
-                          ignoreHref={ignoreHref && cellIdx === 0}
-                          value={{ ...rowValue }}
-                          title={`Click value to see predictions for ${getGroupForRunName(
-                            getHeaderValue(activeGroupsTable.header[cellIdx]),
-                          )}: ${getModelForRunName(String(row[0].value))}`}
-                        />
+                        {cellIdx == 1 ? (
+                          <RowValue
+                            value={{
+                              ...rowValue,
+                              href:
+                                "/runs/?q=" +
+                                getModelForRunName(String(row[0].value)),
+                            }}
+                            title={`Click value to see all predictions for: ${getModelForRunName(
+                              String(row[0].value),
+                            )}`}
+                          />
+                        ) : (
+                          <RowValue
+                            value={{ ...rowValue }}
+                            title={
+                              String(row[0].value) === rowValue.value
+                                ? getModelDesc(String(row[0].value))
+                                : `Click value to see predictions for ${getGroupForRunName(
+                                    getHeaderValue(
+                                      activeGroupsTable.header[cellIdx],
+                                    ),
+                                  )}: ${getModelForRunName(
+                                    String(row[0].value),
+                                  )}`
+                            }
+                          />
+                        )}
                       </td>
                     ))}
                   </tr>

--- a/helm-frontend/src/components/LeaderboardTables.tsx
+++ b/helm-frontend/src/components/LeaderboardTables.tsx
@@ -3,6 +3,8 @@ import { useEffect, useState } from "react";
 import { ChevronUpDownIcon } from "@heroicons/react/24/solid";
 import type GroupsTable from "@/types/GroupsTable";
 import RowValue from "@/components/RowValue";
+import Schema from "@/types/Schema";
+import getSchema from "@/services/getSchema";
 
 interface Props {
   groupsTables: GroupsTable[];
@@ -47,6 +49,58 @@ export default function LeaderboardTables({
     } else {
       return headerValueObject.value;
     }
+  };
+
+  const [schema, setSchema] = useState<Schema | undefined>(undefined);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    async function fetchData() {
+      const schema = await getSchema(controller.signal);
+      setSchema(schema);
+    }
+
+    void fetchData();
+    return () => controller.abort();
+  }, []);
+  const getModelForRunName = (model: string): string => {
+    if (schema) {
+      const foundItem = schema.models.find(
+        (item) => item.display_name === model,
+      );
+      if (foundItem) {
+        let toRet = foundItem.name;
+        if (toRet.includes("/")) {
+          toRet = toRet.replace("/", "_");
+          return toRet;
+        } else {
+          return toRet;
+        }
+      }
+    }
+    return "";
+  };
+  // create delimiter to parse out run group name (need to replace hyphen as some run names have hyphens in them)
+  function replaceLastHyphen(str: string): string {
+    const lastIndex = str.lastIndexOf(" - ");
+    if (lastIndex === -1) {
+      return str;
+    }
+    return str.substring(0, lastIndex) + "*" + str.substring(lastIndex + 1);
+  }
+  const getGroupForRunName = (rawGroup: string): string => {
+    const groupSplit = replaceLastHyphen(rawGroup).split("*");
+    const group = groupSplit[0].trim();
+    if (schema) {
+      const foundItem = schema.run_groups.find(
+        (item) =>
+          item.display_name === group || item.short_display_name === group,
+      );
+      if (foundItem) {
+        return foundItem.name;
+      }
+    }
+    return "";
   };
 
   useEffect(() => {
@@ -134,6 +188,9 @@ export default function LeaderboardTables({
                         className={`${
                           idx === activeSortColumn ? "bg-gray-100" : ""
                         } whitespace-nowrap px-4`}
+                        title={
+                          headerValue.description ? headerValue.description : ""
+                        }
                       >
                         <div className="flex gap-2 items-center">
                           <span>{getHeaderValue(headerValue)}</span>
@@ -160,10 +217,7 @@ export default function LeaderboardTables({
                       key={`${activeGroup}-${idx}`}
                       className={`${idx % 2 === 0 ? "bg-gray-50" : ""}`}
                     >
-                      {" "}
-                      {/* Added alternating row highlighting */}
                       {row
-                        // Filtering columns if filteredCols is provided
                         .filter(
                           (_, cellIdx) =>
                             filteredCols.length === 0 ||
@@ -200,6 +254,9 @@ export default function LeaderboardTables({
                       } ${
                         idx === 0 ? "left-0 z-10" : ""
                       } whitespace-nowrap px-4 sticky top-0`}
+                      title={
+                        headerValue.description ? headerValue.description : ""
+                      }
                     >
                       <div className="flex gap-2 items-center">
                         <span>{getHeaderValue(headerValue)}</span>
@@ -229,9 +286,9 @@ export default function LeaderboardTables({
                         <RowValue
                           ignoreHref={ignoreHref && cellIdx === 0}
                           value={{ ...rowValue }}
-                          title={`Click value to see predictions for ${getHeaderValue(
-                            activeGroupsTable.header[cellIdx],
-                          )}: ${String(row[0].value)}`}
+                          title={`Click value to see predictions for ${getGroupForRunName(
+                            getHeaderValue(activeGroupsTable.header[cellIdx]),
+                          )}: ${getModelForRunName(String(row[0].value))}`}
                         />
                       </td>
                     ))}

--- a/helm-frontend/src/components/RowValue.tsx
+++ b/helm-frontend/src/components/RowValue.tsx
@@ -17,6 +17,11 @@ function formatNumber(value: string | number): string {
 }
 
 export default function RowValue({ value, title }: Props) {
+  // TODO remove this once we stop adding ⚠ to output JSONs
+  if (typeof value.value === "string" && value.value.includes("⚠")) {
+    value.value = value.value.replace("⚠", "");
+  }
+
   if (value.value === undefined) {
     return "-";
   }

--- a/helm-frontend/src/components/RowValue.tsx
+++ b/helm-frontend/src/components/RowValue.tsx
@@ -45,13 +45,28 @@ export default function RowValue({ value, title }: Props) {
         </Link>
       );
     } else {
-      return <>{formatNumber(value.value)}</>;
+      if (title) {
+        return <a title={title}>{formatNumber(value.value)}</a>;
+      } else {
+        return <>{formatNumber(value.value)}</>;
+      }
     }
+  }
+
+  if (value.href) {
+    return (
+      <Link to={value.href} inTable title={title}>
+        {formatNumber(value.value)}
+      </Link>
+    );
   }
 
   if (value.markdown) {
     return <MarkdownValue value={String(value.value)} />;
   }
 
+  if (title) {
+    return <a title={title}>{formatNumber(value.value)}</a>;
+  }
   return <>{formatNumber(value.value)}</>;
 }


### PR DESCRIPTION
Should address all feedback for the leaderboard in https://github.com/stanford-crfm/helm/issues/2291

-  When mousing over a model name, should show more information about the model, either as a tooltip (preferred) or via a link to the models page (need a href anchor). 
   - Fully addressed
-  We still write ‘Model/adapter’ - should just be ‘Model’ for simplicity 
   - Could not find where this still appears in the leaderboard upon a quick visual inspection, let me know if i missed something 
-  When mouseover heading (e.g., F1), should tooltip show the description based on the schema
   - Fully addressed
-  We still show ⚠; would just drop all the train-test contamination stuff from the frontend since we’re not consistently updating this
   - Mostly addressed, this won't appear in the front end leaderboard anymore, but the JSONs contain this still so we'll want to remove whatever outputs this if we don't want it appearing elsewhere.