### PR TITLE
Remove scrollbars on tables

### DIFF
--- a/helm-frontend/src/components/GroupsTables.tsx
+++ b/helm-frontend/src/components/GroupsTables.tsx
@@ -76,8 +76,8 @@ export default function GroupsTables({
   }, [sortFirstMetric, activeSortColumn]);
 
   return (
-    <div className="overflow-auto h-[calc(100vh_-_18rem)]">
-      <table className="table">
+    <div>
+      <table className="rounded-lg shadow-md table">
         <thead>
           <tr>
             {activeGroupsTable.header.map((headerValue, idx) => (

--- a/helm-frontend/src/components/LeaderboardTables.tsx
+++ b/helm-frontend/src/components/LeaderboardTables.tsx
@@ -187,9 +187,9 @@ export default function LeaderboardTables({
           </div>
         </div>
       ) : (
-        <div className="overflow-auto h-[calc(100vh_-_18rem)] rounded-lg shadow-md bg-white">
+        <div>
           <div>
-            <table className="table w-full">
+            <table className="rounded-lg shadow-md table">
               <thead>
                 <tr>
                   {activeGroupsTable.header.map((headerValue, idx) => (
@@ -244,4 +244,5 @@ export default function LeaderboardTables({
       )}
     </>
   );
+  // TODO: Remove unnecessary divs
 }

--- a/helm-frontend/src/components/NavBar/NavBar.tsx
+++ b/helm-frontend/src/components/NavBar/NavBar.tsx
@@ -6,18 +6,8 @@ import NavDropdown from "@/components/NavDropdown";
 import ReleaseDropdown from "../ReleaseDropdown";
 
 export default function NavBar() {
-  const navbarStyle: React.CSSProperties = {
-    position: "sticky",
-    top: "0",
-    zIndex: "100",
-    backgroundColor: "rgba(255, 255, 255, 0.9)",
-    // Add any additional inline styles for the sticky navbar here
-  };
   return (
-    <nav
-      style={navbarStyle}
-      className="navbar sticky-nav h-24 px-8 md:px-12 bg-base-100 max-w[1500]px"
-    >
+    <nav className="navbar h-24 px-8 md:px-12 bg-base-100 max-w[1500]px">
       <div>
         <div className="dropdown md:hidden mr-4">
           <label


### PR DESCRIPTION
This removes scrollbars on tables. This means that the header row and column on table is sticky relative to the browser viewport. This also makes the navbar un-sticky, because it would otherwise cover the table header row.