### PR TITLE
Prevent accounts with no quota from using the crfm-models server

### DIFF
--- a/src/helm/proxy/accounts.py
+++ b/src/helm/proxy/accounts.py
@@ -350,10 +350,12 @@ class Accounts:
 
         with SqliteDict(self.path) as cache:
             account: Account = from_dict(Account, cache[api_key])
-            granular_check_can_use(account, model_group, "daily", compute_daily_period)
-            granular_check_can_use(account, model_group, "monthly", compute_monthly_period)
-            granular_check_can_use(account, model_group, "total", compute_total_period)
-            check_non_empty_quota(account, model_group)
+        if account.is_admin:
+            return
+        granular_check_can_use(account, model_group, "daily", compute_daily_period)
+        granular_check_can_use(account, model_group, "monthly", compute_monthly_period)
+        granular_check_can_use(account, model_group, "total", compute_total_period)
+        check_non_empty_quota(account, model_group)
 
     def use(self, api_key: str, model_group: str, delta: int):
         """

--- a/src/helm/proxy/accounts.py
+++ b/src/helm/proxy/accounts.py
@@ -25,6 +25,7 @@ DEFAULT_QUOTAS = {
     "cohere": {"daily": 10000},
     "dall_e": {"daily": 5},  # In terms of the number of generated images
     "together_vision": {"daily": 30},
+    "simple": {"daily": 10000},
 }
 
 

--- a/src/helm/proxy/accounts.py
+++ b/src/helm/proxy/accounts.py
@@ -334,10 +334,8 @@ class Accounts:
             To enforce this rule, this helper raises a InsufficientQuotaError if the quota is None
             at every granularity."""
             model_group_usages = account.usages.get(model_group)
-            print(model_group_usages)
             if model_group_usages is None:
                 raise InsufficientQuotaError(f"No quota for {model_group}")
-
             if all(
                 [
                     granularity_usage.quota is None or granularity_usage.quota <= 0
@@ -347,10 +345,7 @@ class Accounts:
                 raise InsufficientQuotaError(f"No quota for {model_group}")
 
         if self.root_mode:
-            print("root")
             return
-        else:
-            print("not root")
 
         with SqliteDict(self.path) as cache:
             account: Account = from_dict(Account, cache[api_key])

--- a/src/helm/proxy/services/test_remote_service.py
+++ b/src/helm/proxy/services/test_remote_service.py
@@ -17,7 +17,7 @@ from sqlitedict import SqliteDict
 from helm.common.authentication import Authentication
 from helm.common.request import Request, RequestResult
 from helm.common.tokenization_request import TokenizationRequest, TokenizationRequestResult
-from helm.proxy.accounts import Account
+from helm.proxy.accounts import Account, set_default_quotas
 from .remote_service import RemoteService
 from .service import ACCOUNTS_FILE
 
@@ -55,6 +55,7 @@ class TestRemoteServerService:
 
             with SqliteDict(os.path.join(path, ACCOUNTS_FILE)) as cache:
                 account: Account = Account(TestRemoteServerService._ADMIN_API_KEY, is_admin=True)
+                set_default_quotas(account)
                 cache[TestRemoteServerService._ADMIN_API_KEY] = asdict(account)
                 cache.commit()
             return path

--- a/src/helm/proxy/test_accounts.py
+++ b/src/helm/proxy/test_accounts.py
@@ -1,0 +1,32 @@
+import os
+import pytest
+import tempfile
+
+from helm.proxy.accounts import Accounts, Authentication, InsufficientQuotaError, Usage
+
+
+class TestAutoTokenCounter:
+    def setup_method(self, method):
+        accounts_file = tempfile.NamedTemporaryFile(delete=False)
+        self.accounts_path: str = accounts_file.name
+        self.accounts = Accounts(self.accounts_path)
+        self.root_auth = Authentication(Accounts.DEFAULT_API_KEY)
+
+    def teardown_method(self, method):
+        os.remove(self.accounts_path)
+
+    def test_check_can_use(self):
+        model_group = "anthropic"
+        account = self.accounts.create_account(self.root_auth)
+
+        # Cannot use this account because no quota was added
+        with pytest.raises(InsufficientQuotaError):
+            self.accounts.check_can_use(account.api_key, model_group)
+
+        # Add monthly quota
+        account.usages[model_group] = {}
+        account.usages[model_group]["monthly"] = Usage(quota=1000)
+        self.accounts.update_account(self.root_auth, account)
+
+        # Now this accout has quota and can be used
+        self.accounts.check_can_use(account.api_key, model_group)

--- a/src/helm/proxy/test_accounts.py
+++ b/src/helm/proxy/test_accounts.py
@@ -28,5 +28,5 @@ class TestAutoTokenCounter:
         account.usages[model_group]["monthly"] = Usage(quota=1000)
         self.accounts.update_account(self.root_auth, account)
 
-        # Now this accout has quota and can be used
+        # Now this account has quota and can be used
         self.accounts.check_can_use(account.api_key, model_group)


### PR DESCRIPTION
Previously, users who were never allocated quota actually have infinite quota, because we currently treat quotas of `None` as infinite quota.

Also grants admins unlimited quota.

Fixes #1495