### PR TITLE
Fix sample requests in proxy server

### DIFF
--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -902,6 +902,25 @@ model_deployments:
   # OpenAI
 
   ## GPT 3 Models
+
+  - name: openai/davinci-002
+    model_name: openai/davinci-002
+    tokenizer_name: openai/cl100k_base
+    # Claimed sequence length is 16,384 tokens but we round down to 16,000 tokens
+    # to provide a margin of error.
+    max_sequence_length: 16000
+    client_spec:
+      class_name: "helm.proxy.clients.openai_client.OpenAIClient"
+
+  - name: openai/babbage-002
+    model_name: openai/babbage-002
+    tokenizer_name: openai/cl100k_base
+    # Claimed sequence length is 16,384 tokens but we round down to 16,000 tokens
+    # to provide a margin of error.
+    max_sequence_length: 16000
+    client_spec:
+      class_name: "helm.proxy.clients.openai_client.OpenAIClient"
+
   # The list of models can be found here: https://beta.openai.com/docs/engines/gpt-3
   # DEPRECATED: Announced on July 06 2023 that these models will be shut down on January 04 2024.
 

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -1228,6 +1228,23 @@ models:
 
   ## GPT 3 Models
   # The list of models can be found here: https://beta.openai.com/docs/engines/gpt-3
+
+  - name: openai/davinci-002
+    display_name: davinci-002
+    description: Replacement for the GPT-3 curie and davinci base models.
+    creator_organization_name: OpenAI
+    access: limited
+    release_date: 2023-08-22
+    tags: [TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG]
+
+  - name: openai/babbage-002
+    display_name: babbage-002
+    description: Replacement for the GPT-3 ada and babbage base models.
+    creator_organization_name: OpenAI
+    access: limited
+    release_date: 2023-08-22
+    tags: [TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG]
+
   # DEPRECATED: Announced on July 06 2023 that these models will be shut down on January 04 2024.
 
   - name: openai/davinci # DEPRECATED

--- a/src/helm/proxy/example_queries.py
+++ b/src/helm/proxy/example_queries.py
@@ -21,6 +21,8 @@ example_queries = [
             """
             temperature: 0.5  # Medium amount of randomness
             stop_sequences: [.]  # Stop when you hit a period
+            model: openai/gpt-3.5-turbo-0613
+            model_deployment: openai/gpt-3.5-turbo-0613
             """
         ),
         environments="",
@@ -31,7 +33,9 @@ example_queries = [
             """
             temperature: 0.5  # Medium amount of randomness
             stop_sequences: [\\n]  # Stop when you hit a newline
-            num_completions: 10  # Generate many samples
+            num_completions: 5  # Generate many samples
+            model: openai/gpt-3.5-turbo-0613
+            model_deployment: openai/gpt-3.5-turbo-0613
             """
         ),
         environments="",
@@ -42,7 +46,9 @@ example_queries = [
             """
             echo_prompt: true  # Analyze the prompt
             max_tokens: 0  # Don't generate any more
-            top_k_per_token: 10  # Show alternatives for each position
+            top_k_per_token: 5  # Show alternatives for each position
+            model: openai/davinci-002
+            model_deployment: openai/davinci-002
             """
         ),
         environments=dedent(""),
@@ -53,6 +59,8 @@ example_queries = [
             """
             temperature: 0  # Deterministic
             max_tokens: 50
+            model: openai/gpt-3.5-turbo-0613
+            model_deployment: openai/gpt-3.5-turbo-0613
             """
         ),
         environments="",
@@ -63,13 +71,15 @@ example_queries = [
             """
             temperature: 0
             stop_sequences: [.]
-            model_deployment: ${model_deployment}  # Try out multiple models
+            # Try out multiple models
+            model: ${model}
+            model_deployment: ${model}
             """
         ),
         environments=dedent(
             """
             occupation: [mathematician, lawyer, doctor]
-            model_deployment: [openai/davinci, ai21/j1-jumbo]
+            model: [openai/gpt-3.5-turbo-0613, openai/gpt-3.5-turbo-1106]
             """
         ),
     ),
@@ -88,12 +98,14 @@ example_queries = [
             temperature: 0.5
             stop_sequences: [\\n]
             num_completions: 5
-            model_deployment: ${model_deployment}  # Try out GPT-3 and Jurassic
+            # Try out multiple models
+            model: ${model}
+            model_deployment: ${model}
             """
         ),
         environments=dedent(
             """
-            model_deployment: [openai/davinci, ai21/j1-jumbo]
+            model: [openai/gpt-3.5-turbo-0613, openai/gpt-3.5-turbo-1106]
             """
         ),
     ),
@@ -122,20 +134,23 @@ example_queries = [
             temperature: 0
             max_tokens: 1
             top_k_per_token: 4
-            model_deployment: ${model_deployment}  # Try out GPT-3 and Jurassic
+            # Try out multiple models
+            model: ${model}
+            model_deployment: ${model}
             """
         ),
         environments=dedent(
             """
-            model_deployment: [openai/davinci, ai21/j1-jumbo]
+            model: [openai/gpt-3.5-turbo-0613, openai/gpt-3.5-turbo-1106]
             """
         ),
     ),
     Query(
-        prompt="Takes two vectors a and b and returns their Euclidean distance",
+        prompt="Write a Python function that takes two vectors a and b and returns their Euclidean distance.",
         settings=dedent(
             """
-            model_deployment: openai/code-davinci-001  # Codex for code generation
+            model: openai/gpt-3.5-turbo-0613
+            model_deployment: openai/gpt-3.5-turbo-0613
             """
         ),
         environments="",
@@ -144,19 +159,16 @@ example_queries = [
         prompt="The quick brown fox",
         settings=dedent(
             """
-            model_deployment: ${model_deployment}
             temperature: 0.3
             stop_sequences: [\\n]
+            # Try out multiple models
+            model: ${model}
+            model_deployment: ${model}
             """
         ),
         environments=dedent(
             """
-            model_deployment: [
-                "openai/davinci", "openai/text-davinci-002",
-                "openai/text-davinci-003", "ai21/j1-grande-v2-beta",
-                "together/gpt-j-6b", "together/gpt-jt-6b-v1",
-                "together/bloom", "together/opt-175b"
-            ]
+            model: [openai/gpt-3.5-turbo-0613, openai/gpt-3.5-turbo-1106]
             """
         ),
     ),


### PR DESCRIPTION
- Change sample requests to send the `model_deployment` field.
- Add `davinci-002` and `babbage-002` as replacements for deprecated text completion models, as all other text completion models have been deprecated.
- Switch sample requests to use `davinci-002` or `gpt-3.5-turbo-*`.