### PR TITLE
Use legacy group names for quota accounting

### DIFF
--- a/src/helm/proxy/services/server_service.py
+++ b/src/helm/proxy/services/server_service.py
@@ -102,6 +102,21 @@ class ServerService(Service):
             requests.append(request)
         return QueryResult(requests=requests)
 
+    def _get_group_for_model_deployment(self, model_deployment: str) -> str:
+        if model_deployment.startswith("openai/"):
+            if model_deployment.startswith("openai/code-"):
+                return "codex"
+            elif model_deployment.startswith("openai/dall-e-"):
+                return "dall_e"
+            elif model_deployment.startswith("openai/gpt-4-"):
+                return "gpt4"
+            else:
+                return "gpt3"
+        elif model_deployment.startswith("ai21/"):
+            return "jurassic"
+        else:
+            return get_model_deployment_host_organization(model_deployment)
+
     def make_request(self, auth: Authentication, request: Request) -> RequestResult:
         """Actually make a request to an API."""
         # TODO: try to invoke the API even if we're not authenticated, and if
@@ -109,7 +124,7 @@ class ServerService(Service):
         #       https://github.com/stanford-crfm/benchmarking/issues/56
 
         self.accounts.authenticate(auth)
-        host_organization: str = get_model_deployment_host_organization(request.model_deployment)
+        host_organization: str = self._get_group_for_model_deployment(request.model_deployment)
         # Make sure we can use
         self.accounts.check_can_use(auth.api_key, host_organization)
 

--- a/src/helm/proxy/services/server_service.py
+++ b/src/helm/proxy/services/server_service.py
@@ -102,7 +102,7 @@ class ServerService(Service):
             requests.append(request)
         return QueryResult(requests=requests)
 
-    def _get_group_for_model_deployment(self, model_deployment: str) -> str:
+    def _get_model_group_for_model_deployment(self, model_deployment: str) -> str:
         if model_deployment.startswith("openai/"):
             if model_deployment.startswith("openai/code-"):
                 return "codex"
@@ -124,9 +124,9 @@ class ServerService(Service):
         #       https://github.com/stanford-crfm/benchmarking/issues/56
 
         self.accounts.authenticate(auth)
-        host_organization: str = self._get_group_for_model_deployment(request.model_deployment)
+        model_group: str = self._get_model_group_for_model_deployment(request.model_deployment)
         # Make sure we can use
-        self.accounts.check_can_use(auth.api_key, host_organization)
+        self.accounts.check_can_use(auth.api_key, model_group)
 
         # Use!
         request_result: RequestResult = self.client.make_request(request)
@@ -135,7 +135,7 @@ class ServerService(Service):
         if not request_result.cached:
             # Count the number of tokens used
             count: int = self.token_counter.count_tokens(request, request_result.completions)
-            self.accounts.use(auth.api_key, host_organization, count)
+            self.accounts.use(auth.api_key, model_group, count)
 
         return request_result
 


### PR DESCRIPTION
On the crfm-models playground server, we have existing users with quota under legacy group names such as `codex`, `dall_e`, `gpt3`, `gpt4` and `jurassic` which do not correspond to the model host organization name. This change allows existing users to continue using quota in under these legacy group names.

Fixes #2293