### PR TITLE
Raise an exception if shell commands exit with non-zero exit code

### DIFF
--- a/src/helm/common/general.py
+++ b/src/helm/common/general.py
@@ -63,7 +63,7 @@ def shell(args: List[str]):
     hlog(f"Executing: {cmd}")
     exit_code = subprocess.call(args)
     if exit_code != 0:
-        hlog(f"Failed with exit code {exit_code}: {cmd}")
+        raise Exception(f"Failed with exit code {exit_code}: {cmd}")
 
 
 @htrack(None)


### PR DESCRIPTION
Currently, `ensure_file_downloaded()` silently does the wrong thing if a shell command fails. For instance, `ensure_file_downloaded()` writes an empty file if the source URL is not found.

Fixes #1932.