### PR TITLE
Upgrade datasets

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires=
     bottle~=0.12.23
 
     # Basic Scenarios
-    datasets~=2.5
+    datasets~=2.15
     pyarrow>=11.0.0,  # Pinned transitive dependency for datasets; workaround for #1026
     pyarrow-hotfix~=0.6  # Hotfix for CVE-2023-47248
 


### PR DESCRIPTION
Upgrade `datasets` to fix a failure in MathScenario. Sample stack trace:

```
  File "/u/scr/maiyifan/miniconda3/envs/crfm-helm-main/lib/python3.8/site-packages/helm/benchmark/scenarios/math_scenario.py", line 357, in get_instances
    data = typing.cast(DatasetDict, load_dataset("competition_math")).sort("problem").shuffle(seed=42)
  File "/u/scr/maiyifan/miniconda3/envs/crfm-helm-main/lib/python3.8/site-packages/datasets/load.py", line 1705, in load_dataset
    ds = builder_instance.as_dataset(split=split, ignore_verifications=ignore_verifications, in_memory=keep_in_memory)
  File "/u/scr/maiyifan/miniconda3/envs/crfm-helm-main/lib/python3.8/site-packages/datasets/builder.py", line 992, in as_dataset
    raise NotImplementedError(f"Loading a dataset cached in a {type(self._fs).__name__} is not supported.")
```

caused by an upstream error https://github.com/huggingface/datasets/issues/6352