### PR TITLE
Set trust_remote_code in WMT14Scenario

### DIFF
--- a/src/helm/benchmark/scenarios/wmt_14_scenario.py
+++ b/src/helm/benchmark/scenarios/wmt_14_scenario.py
@@ -61,7 +61,7 @@ class WMT14Scenario(Scenario):
     def get_instances(self, output_path: str) -> List[Instance]:
         with htrack_block("Loading the HuggingFace dataset. The first time could take several minutes."):
             subset_name = f"{self.source_language if self.source_language!='en' else self.target_language}-en"
-            hf_dataset: Any = load_dataset("wmt14", subset_name)
+            hf_dataset: Any = load_dataset("wmt14", subset_name, trust_remote_code=True)
             splits = {"train": TRAIN_SPLIT, "validation": VALID_SPLIT, "test": TEST_SPLIT}
 
         instances: List[Instance] = []


### PR DESCRIPTION
This avoids a future breakage:

```
FutureWarning: The repository for wmt14 contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/wmt14
You can avoid this message in future by passing the argument `trust_remote_code=True`.
Passing `trust_remote_code=True` will be mandatory to load this dataset from the next major release of `datasets`.
```