### PR TITLE
Various MistralAIClient fixes

### DIFF
--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -890,6 +890,8 @@ model_deployments:
     max_sequence_length: 32000
     client_spec:
       class_name: "helm.proxy.clients.mistral_client.MistralAIClient"
+      args:
+        mistral_model: "mistral-tiny"
 
   - name: mistralai/mistral-medium
     model_name: mistralai/mistral-medium

--- a/src/helm/proxy/clients/mistral_client.py
+++ b/src/helm/proxy/clients/mistral_client.py
@@ -1,6 +1,7 @@
 import requests
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, TypedDict
 
+from helm.proxy.retry import NonRetriableException
 from helm.common.cache import CacheConfig
 from helm.common.optional_dependencies import handle_module_not_found_error
 from helm.common.request import wrap_request_time, Request, RequestResult, Sequence, Token
@@ -8,7 +9,6 @@ from helm.common.tokenization_request import (
     TokenizationRequest,
     TokenizationRequestResult,
 )
-from helm.proxy.retry import NonRetriableException
 from helm.proxy.tokenizers.tokenizer import Tokenizer
 from .client import CachingClient, truncate_sequence
 
@@ -19,28 +19,42 @@ except ModuleNotFoundError as e:
     handle_module_not_found_error(e, ["mistral"])
 
 
+class MistralAIRequest(TypedDict):
+    """Data passed between make_request and _send_request. Used as the cache key."""
+
+    model: str
+    prompt: str
+    max_tokens: int
+    temperature: float
+    top_p: float
+    random_seed: Optional[int]
+
+
 class MistralAIClient(CachingClient):
     """
     Client for Mistral API.
     """
 
-    # Aliases to match HELM names to Model names in Mistral API
-    _model_aliases: Dict[str, str] = {
-        "mistral-7b-v0.1": "mistral-tiny",
-    }
-
-    def __init__(self, tokenizer: Tokenizer, tokenizer_name: str, cache_config: CacheConfig, api_key: str):
+    def __init__(
+        self,
+        tokenizer: Tokenizer,
+        tokenizer_name: str,
+        cache_config: CacheConfig,
+        api_key: str,
+        mistral_model: Optional[str] = None,
+    ):
         super().__init__(cache_config=cache_config)
         self.api_key: str = api_key
         self.tokenizer = tokenizer
         self.tokenizer_name = tokenizer_name
         self._client = MistralClient(api_key=self.api_key)
+        self.mistral_model = mistral_model
 
-    def _send_request(self, model_name: str, raw_request: Dict[str, Any]) -> Dict[str, Any]:
+    def _send_request(self, raw_request: MistralAIRequest) -> Dict[str, Any]:
         messages = [ChatMessage(role="user", content=raw_request["prompt"])]
 
         chat_response: ChatCompletionResponse = self._client.chat(
-            model=model_name,
+            model=raw_request["model"],
             messages=messages,
             temperature=raw_request["temperature"],
             max_tokens=raw_request["max_tokens"],
@@ -48,66 +62,75 @@ class MistralAIClient(CachingClient):
             random_seed=raw_request["random_seed"],
             safe_prompt=False,  # Disable safe_prompt
         )
+        return chat_response.model_dump()
 
-        return chat_response.dict()
+    def _get_random_seed(self, request: Request, completion_index: int) -> Optional[int]:
+        if request.random is None and completion_index == 0:
+            return None
+
+        # Treat the user's request.random as an integer for the random seed.
+        try:
+            request_random_seed = int(request.random) if request.random is not None else 0
+        except ValueError:
+            raise NonRetriableException("MistralAIClient only supports integer values for request.random")
+
+        # A large prime is used so that the resulting values are unlikely to collide
+        # with request.random values chosen by the user.
+        fixed_large_prime = 1911011
+        completion_index_random_seed = completion_index * fixed_large_prime
+
+        return request_random_seed + completion_index_random_seed
 
     def make_request(self, request: Request) -> RequestResult:
         """Make a request"""
-        raw_request = {
-            "prompt": request.prompt,
-            "max_tokens": request.max_tokens,
-            "temperature": request.temperature,
-            "top_p": request.top_p,
-            "random_seed": request.random,
-        }
-
         completions: List[Sequence] = []
-        model_name: str = self._model_aliases.get(request.model_engine, request.model_engine)
 
-        if request.num_completions > 1:
-            raise NonRetriableException("MistralAIClient does not support num_completions > 1")
-        try:
+        # `num_completions` is not supported, so instead make `num_completions` separate requests.
+        for completion_index in range(request.num_completions):
+            try:
+                raw_request: MistralAIRequest = {
+                    "model": self.mistral_model or request.model_engine,
+                    "prompt": request.prompt,
+                    "max_tokens": request.max_tokens,
+                    "temperature": request.temperature,
+                    "top_p": request.top_p,
+                    "random_seed": self._get_random_seed(request, completion_index),
+                }
 
-            def do_it():
-                result: Dict[str, Any] = self._send_request(model_name, raw_request)
-                return result
+                def do_it():
+                    result: Dict[str, Any] = self._send_request(raw_request)
+                    return result
 
-            # We need to include the engine's name to differentiate among requests made for different model
-            # engines since the engine name is not included in the request itself.
-            # In addition, we want to make `request.num_completions` fresh
-            # requests, cache key should contain the completion_index.
-            # Echoing the original prompt is not officially supported by Mistral. We instead prepend the
-            # completion with the prompt when `echo_prompt` is true, so keep track of it in the cache key.
-            cache_key = CachingClient.make_cache_key(
-                {
-                    "engine": model_name,
-                    **raw_request,
-                },
-                request,
+                # We need to include the engine's name to differentiate among requests made for different model
+                # engines since the engine name is not included in the request itself.
+                # In addition, we want to make `request.num_completions` fresh
+                # requests, cache key should contain the completion_index.
+                # Echoing the original prompt is not officially supported by Mistral. We instead prepend the
+                # completion with the prompt when `echo_prompt` is true, so keep track of it in the cache key.
+                cache_key = CachingClient.make_cache_key(raw_request, request)
+
+                response, cached = self.cache.get(cache_key, wrap_request_time(do_it))
+            except (requests.exceptions.RequestException, AssertionError) as e:
+                error: str = f"MistralClient error: {e}"
+                return RequestResult(success=False, cached=False, error=error, completions=[], embedding=[])
+
+            response_message: Dict[str, Any] = response["choices"][0]["message"]
+            assert response_message["role"] == "assistant"
+            response_text: str = response_message["content"]
+
+            # The Mistral API doesn't support echo. If `echo_prompt` is true, combine the prompt and completion.
+            text: str = request.prompt + response_text if request.echo_prompt else response_text
+            # The Mistral API doesn't return us tokens or logprobs, so we tokenize ourselves.
+            tokenization_result: TokenizationRequestResult = self.tokenizer.tokenize(
+                TokenizationRequest(text, tokenizer=self.tokenizer_name)
             )
 
-            response, cached = self.cache.get(cache_key, wrap_request_time(do_it))
-        except (requests.exceptions.RequestException, AssertionError) as e:
-            error: str = f"MistralClient error: {e}"
-            return RequestResult(success=False, cached=False, error=error, completions=[], embedding=[])
+            # Log probs are not currently not supported by Mistral, so set to 0 for now.
+            tokens: List[Token] = [Token(text=str(text), logprob=0) for text in tokenization_result.raw_tokens]
 
-        response_message: Dict[str, Any] = response["choices"][0]["message"]
-        assert response_message["role"] == "assistant"
-        response_text: str = response_message["content"]
-
-        # The Mistral API doesn't support echo. If `echo_prompt` is true, combine the prompt and completion.
-        text: str = request.prompt + response_text if request.echo_prompt else response_text
-        # The Mistral API doesn't return us tokens or logprobs, so we tokenize ourselves.
-        tokenization_result: TokenizationRequestResult = self.tokenizer.tokenize(
-            TokenizationRequest(text, tokenizer=self.tokenizer_name)
-        )
-
-        # Log probs are not currently not supported by Mistral, so set to 0 for now.
-        tokens: List[Token] = [Token(text=str(text), logprob=0) for text in tokenization_result.raw_tokens]
-
-        completion = Sequence(text=response_text, logprob=0, tokens=tokens)
-        sequence = truncate_sequence(completion, request, print_warning=True)
-        completions.append(sequence)
+            completion = Sequence(text=response_text, logprob=0, tokens=tokens)
+            sequence = truncate_sequence(completion, request, print_warning=True)
+            completions.append(sequence)
 
         return RequestResult(
             success=True,


### PR DESCRIPTION
- Use a `MistralAIRequest` `TypedDict` for the MistralAIClient raw request
- Use Pydantic's `model_dump()` instead of `dict()` because `dict()` is deprecated
- Pass the model name as part of the `MistralAIRequest` to `_make_request()`, rather than having it be a separate parameter
- Delete `_model_aliases` and move the the model name to `model_deployments.yaml`
- Set `random_seed` properly for multiple completions
- Remove `completion_index` from the cache key since it is never sent to the API