### PR TITLE
Adding Phi2 and Qwen1.5

### DIFF
--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -575,6 +575,13 @@ model_deployments:
     client_spec:
       class_name: "helm.proxy.clients.vision_language.huggingface_vlm_client.HuggingFaceVLMClient"
 
+  - name: together/phi-2
+    model_name: microsoft/phi-2
+    tokenizer_name: microsoft/phi-2
+    max_sequence_length: 2047
+    client_spec:
+      class_name: "helm.proxy.clients.together_client.TogetherClient" 
+
   ## Mistral AI
   - name: huggingface/bakLlava-v1-hf
     model_name: mistralai/bakLlava-v1-hf
@@ -1646,3 +1653,41 @@ model_deployments:
     max_sequence_and_generated_tokens_length: 30048
     client_spec:
       class_name: "helm.proxy.clients.palmyra_client.PalmyraClient"
+
+  # Qwen
+
+  - name: together/qwen-7b
+    model_name: qwen/qwen-7b
+    tokenizer_name: qwen/qwen-7b
+    max_sequence_length: 8191
+    client_spec:
+      class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: togethercomputer/Qwen-7B
+
+  - name: together/qwen1.5-7b
+    model_name: qwen/qwen1.5-7b
+    tokenizer_name: qwen/qwen1.5-7b
+    max_sequence_length: 32767
+    client_spec:
+      class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: Qwen/Qwen1.5-7B
+
+  - name: together/qwen1.5-14b
+    model_name: qwen/qwen1.5-14b
+    tokenizer_name: qwen/qwen1.5-7b
+    max_sequence_length: 32767
+    client_spec:
+      class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: Qwen/Qwen1.5-14B
+
+  - name: together/qwen1.5-72b
+    model_name: qwen/qwen1.5-72b
+    tokenizer_name: qwen/qwen1.5-7b
+    max_sequence_length: 4095
+    client_spec:
+      class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: Qwen/Qwen1.5-72B

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -1585,9 +1585,33 @@ models:
 
   # Qwen
 
+  - name: qwen/qwen-7b
+    display_name: Qwen
+    description: 7B-parameter version of the large language model series, Qwen (abbr. Tongyi Qianwen), proposed by Aibaba Cloud. Qwen-7B is a Transformer-based large language model, which is pretrained on a large volume of data, including web texts, books, codes, etc. 
+    creator_organization_name: Qwen
+    access: open
+    release_date: 2024-02-05
+    tags: [TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG]
+
   - name: qwen/qwen1.5-7b
     display_name: Qwen1.5
     description: 7B-parameter version of the large language model series, Qwen 1.5 (abbr. Tongyi Qianwen), proposed by Aibaba Cloud. Qwen-7B is a Transformer-based large language model, which is pretrained on a large volume of data, including web texts, books, codes, etc. 
+    creator_organization_name: Qwen
+    access: open
+    release_date: 2024-02-05
+    tags: [TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG]
+
+  - name: qwen/qwen1.5-14b
+    display_name: Qwen1.5
+    description: 14B-parameter version of the large language model series, Qwen 1.5 (abbr. Tongyi Qianwen), proposed by Aibaba Cloud. Qwen-7B is a Transformer-based large language model, which is pretrained on a large volume of data, including web texts, books, codes, etc. 
+    creator_organization_name: Qwen
+    access: open
+    release_date: 2024-02-05
+    tags: [TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG]
+
+  - name: qwen/qwen1.5-72b
+    display_name: Qwen1.5
+    description: 72B-parameter version of the large language model series, Qwen 1.5 (abbr. Tongyi Qianwen), proposed by Aibaba Cloud. Qwen-7B is a Transformer-based large language model, which is pretrained on a large volume of data, including web texts, books, codes, etc. 
     creator_organization_name: Qwen
     access: open
     release_date: 2024-02-05

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -1676,49 +1676,6 @@ models:
     num_parameters: 20000000000
     release_date: 2023-03-08
     tags: [TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG, CHATML_MODEL_TAG]
-  
-  - name: together/phi-2
-    model_name: microsoft/phi-2
-    tokenizer_name: microsoft/phi-2
-    max_sequence_length: 2047
-    client_spec:
-      class_name: "helm.proxy.clients.together_client.TogetherClient" 
-
-  - name: together/qwen-7b
-    model_name: qwen/qwen-7b
-    tokenizer_name: qwen/qwen-7b
-    max_sequence_length: 8191
-    client_spec:
-      class_name: "helm.proxy.clients.together_client.TogetherClient"
-      args:
-        together_model: togethercomputer/Qwen-7B
-
-  - name: together/qwen1.5-7b
-    model_name: qwen/qwen1.5-7b
-    tokenizer_name: qwen/qwen1.5-7b
-    max_sequence_length: 32767
-    client_spec:
-      class_name: "helm.proxy.clients.together_client.TogetherClient"
-      args:
-        together_model: Qwen/Qwen1.5-7B
-
-  - name: together/qwen1.5-14b
-    model_name: qwen/qwen1.5-14b
-    tokenizer_name: qwen/qwen1.5-7b
-    max_sequence_length: 32767
-    client_spec:
-      class_name: "helm.proxy.clients.together_client.TogetherClient"
-      args:
-        together_model: Qwen/Qwen1.5-14B
-
-  - name: together/qwen1.5-72b
-    model_name: qwen/qwen1.5-72b
-    tokenizer_name: qwen/qwen1.5-7b
-    max_sequence_length: 4095
-    client_spec:
-      class_name: "helm.proxy.clients.together_client.TogetherClient"
-      args:
-        together_model: Qwen/Qwen1.5-72B
 
   - name: together/redpajama-incite-base-3b-v1
     display_name: RedPajama-INCITE-Base-v1 (3B)

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -1081,6 +1081,15 @@ models:
     release_date: 2023-10-05
     tags: [VISION_LANGUAGE_MODEL_TAG, LLAVA_MODEL_TAG]
 
+  - name: microsoft/phi-2
+    display_name: Phi-2
+    description: Phi-2 is a Transformer with 2.7 billion parameters. It was trained using the same data sources as Phi-1.5, augmented with a new data source that consists of various NLP synthetic texts and filtered websites (for safety and educational value)
+    creator_organization_name: Microsoft
+    access: open
+    num_parameters: 13000000000
+    release_date: 2023-10-05
+    tags: [VISION_LANGUAGE_MODEL_TAG, LLAVA_MODEL_TAG]
+
 
 
   # 01.AI

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -1088,7 +1088,7 @@ models:
     access: open
     num_parameters: 13000000000
     release_date: 2023-10-05
-    tags: [VISION_LANGUAGE_MODEL_TAG, LLAVA_MODEL_TAG]
+    tags: [TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG]
 
 
 
@@ -1591,7 +1591,7 @@ models:
     creator_organization_name: Qwen
     access: open
     release_date: 2024-02-05
-    tags: [TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG]
+    tags: [TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG]
 
   - name: qwen/qwen1.5-7b
     display_name: Qwen1.5
@@ -1599,7 +1599,7 @@ models:
     creator_organization_name: Qwen
     access: open
     release_date: 2024-02-05
-    tags: [TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG]
+    tags: [TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG]
 
   - name: qwen/qwen1.5-14b
     display_name: Qwen1.5
@@ -1607,7 +1607,7 @@ models:
     creator_organization_name: Qwen
     access: open
     release_date: 2024-02-05
-    tags: [TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG]
+    tags: [TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG]
 
   - name: qwen/qwen1.5-72b
     display_name: Qwen1.5
@@ -1615,7 +1615,7 @@ models:
     creator_organization_name: Qwen
     access: open
     release_date: 2024-02-05
-    tags: [TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG]
+    tags: [TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG]
 
   # Salesforce
   - name: salesforce/codegen # NOT SUPPORTED

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -1676,6 +1676,49 @@ models:
     num_parameters: 20000000000
     release_date: 2023-03-08
     tags: [TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG, CHATML_MODEL_TAG]
+  
+  - name: together/phi-2
+    model_name: microsoft/phi-2
+    tokenizer_name: microsoft/phi-2
+    max_sequence_length: 2047
+    client_spec:
+      class_name: "helm.proxy.clients.together_client.TogetherClient" 
+
+  - name: together/qwen-7b
+    model_name: qwen/qwen-7b
+    tokenizer_name: qwen/qwen-7b
+    max_sequence_length: 8191
+    client_spec:
+      class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: togethercomputer/Qwen-7B
+
+  - name: together/qwen1.5-7b
+    model_name: qwen/qwen1.5-7b
+    tokenizer_name: qwen/qwen1.5-7b
+    max_sequence_length: 32767
+    client_spec:
+      class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: Qwen/Qwen1.5-7B
+
+  - name: together/qwen1.5-14b
+    model_name: qwen/qwen1.5-14b
+    tokenizer_name: qwen/qwen1.5-7b
+    max_sequence_length: 32767
+    client_spec:
+      class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: Qwen/Qwen1.5-14B
+
+  - name: together/qwen1.5-72b
+    model_name: qwen/qwen1.5-72b
+    tokenizer_name: qwen/qwen1.5-7b
+    max_sequence_length: 4095
+    client_spec:
+      class_name: "helm.proxy.clients.together_client.TogetherClient"
+      args:
+        together_model: Qwen/Qwen1.5-72B
 
   - name: together/redpajama-incite-base-3b-v1
     display_name: RedPajama-INCITE-Base-v1 (3B)

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -1583,6 +1583,16 @@ models:
     release_date: 2023-11-06
     tags: [TEXT_TO_IMAGE_MODEL_TAG]
 
+  # Qwen
+
+  - name: qwen/qwen1.5-7b
+    display_name: Qwen1.5
+    description: 7B-parameter version of the large language model series, Qwen 1.5 (abbr. Tongyi Qianwen), proposed by Aibaba Cloud. Qwen-7B is a Transformer-based large language model, which is pretrained on a large volume of data, including web texts, books, codes, etc. 
+    creator_organization_name: Qwen
+    access: open
+    release_date: 2024-02-05
+    tags: [TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG]
+
   # Salesforce
   - name: salesforce/codegen # NOT SUPPORTED
     display_name: CodeGen (16B)

--- a/src/helm/config/tokenizer_configs.yaml
+++ b/src/helm/config/tokenizer_configs.yaml
@@ -213,6 +213,12 @@ tokenizer_configs:
     end_of_text_token: "<|endoftext|>"
     prefix_token: "<<"
 
+  - name: microsoft/phi-2  
+    tokenizer_spec:  
+      class_name: "helm.proxy.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"  
+    end_of_text_token: "<|endoftext|>"  
+    prefix_token: "<|endoftext|>"
+
   # Mistralai
   - name: mistralai/Mistral-7B-v0.1
     tokenizer_spec:

--- a/src/helm/config/tokenizer_configs.yaml
+++ b/src/helm/config/tokenizer_configs.yaml
@@ -240,6 +240,23 @@ tokenizer_configs:
     end_of_text_token: ""
     prefix_token: ""
 
+  - name: qwen/qwen-7b
+    tokenizer_spec:
+      class_name: "helm.proxy.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
+      args:
+        pretrained_model_name_or_path: Qwen/Qwen-7B
+        trust_remote_code: true
+    end_of_text_token: "<|endoftext|>"
+    prefix_token: ""
+
+  - name: qwen/qwen1.5-7b
+    tokenizer_spec:
+      class_name: "helm.proxy.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
+      args:
+        pretrained_model_name_or_path: Qwen/Qwen1.5-7B
+    end_of_text_token: "<|endoftext|>"
+    prefix_token: ""
+
   # Tiiuae
   - name: tiiuae/falcon-7b
     tokenizer_spec:


### PR DESCRIPTION
Adds Phi2 and Qwen1.5 (along with Qwen) to config yamls.

Myself and Yifan have tested separately and are filling out the model checklist. 