### PR TITLE
Add references and mapped output to frontend

### DIFF
--- a/helm-frontend/src/components/InstanceData.tsx
+++ b/helm-frontend/src/components/InstanceData.tsx
@@ -2,6 +2,7 @@ import type Instance from "@/types/Instance";
 import type DisplayRequest from "@/types/DisplayRequest";
 import type DisplayPrediction from "@/types/DisplayPrediction";
 import Predictions from "@/components/Predictions";
+import References from "@/components/References";
 import Preview from "@/components/Preview";
 
 interface Props {
@@ -20,8 +21,12 @@ export default function InstanceData({
       <h3 className="text-xl mb-4">
         {`Instance id: ${instance.id} [split:  ${instance.split}]`}
       </h3>
-      <span className="text-gray-400">Input</span>
+      <h3>Input</h3>
       <Preview value={instance.input.text} />
+      <h3>References</h3>
+      <span>
+        <References references={instance.references} />
+      </span>
       {predictions && requests ? (
         <Predictions predictions={predictions} requests={requests} />
       ) : null}

--- a/helm-frontend/src/components/Predictions.tsx
+++ b/helm-frontend/src/components/Predictions.tsx
@@ -33,12 +33,19 @@ export default function Predictions({ predictions, requests }: Props) {
       <div className="flex flex-wrap justify-start items-start">
         {predictions.map((prediction, idx) => (
           <div className="w-full" key={idx}>
+            {predictions.length > 1 ? <h2>Trial {idx}</h2> : null}
             <div className="mt-2 w-full">
               <h3>
-                <span className="mr-4">{`Prediction [trial ${prediction.train_trial_index}]`}</span>
+                <span className="mr-4">Prediction raw text</span>
                 <Indicator stats={prediction.stats} />
               </h3>
               <Preview value={prediction.predicted_text} />
+              {prediction.mapped_output ? (
+                <>
+                  <h3>Prediction mapped output</h3>
+                  <Preview value={prediction.mapped_output} />
+                </>
+              ) : null}
             </div>
             <div className="my-4">
               <Tabs>

--- a/helm-frontend/src/components/References.tsx
+++ b/helm-frontend/src/components/References.tsx
@@ -1,0 +1,43 @@
+import type Reference from "@/types/Reference";
+import { Badge } from "@tremor/react";
+
+interface Props {
+  references: Reference[];
+}
+
+const CORRECT_TAG = "correct";
+
+export default function References({ references }: Props) {
+  return (
+    <ul>
+      {references.map((reference, index) => {
+        return (
+          <li
+            key={index}
+            className="bg-base-200 p-2 block overflow-auto w-full max-h-72 mb-2 whitespace-pre-wrap"
+          >
+            {reference.output.text}
+            {reference.tags.map((tag) => {
+              return (
+                <Badge
+                  className="mx-2"
+                  color={tag === CORRECT_TAG ? "green" : undefined}
+                >
+                  {tag}
+                </Badge>
+              );
+            })}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+// {metrics.map((metric) => {
+//     return (
+//       <li key={metric.name} className="ml-4">
+//         {metric.display_name}
+//       </li>
+//     );
+//   })}

--- a/helm-frontend/src/components/References.tsx
+++ b/helm-frontend/src/components/References.tsx
@@ -33,11 +33,3 @@ export default function References({ references }: Props) {
     </ul>
   );
 }
-
-// {metrics.map((metric) => {
-//     return (
-//       <li key={metric.name} className="ml-4">
-//         {metric.display_name}
-//       </li>
-//     );
-//   })}

--- a/helm-frontend/src/types/DisplayPrediction.ts
+++ b/helm-frontend/src/types/DisplayPrediction.ts
@@ -10,4 +10,5 @@ export default interface DisplayPrediction {
     prompt_truncated: number;
     quasi_exact_match: number;
   };
+  mapped_output: string | undefined;
 }

--- a/helm-frontend/src/types/Instance.ts
+++ b/helm-frontend/src/types/Instance.ts
@@ -1,9 +1,4 @@
-interface Reference {
-  output: {
-    text: string;
-  };
-  tags: string[];
-}
+import type Reference from "@/types/Reference";
 
 export default interface Instance {
   id: string;

--- a/helm-frontend/src/types/Reference.ts
+++ b/helm-frontend/src/types/Reference.ts
@@ -1,0 +1,6 @@
+export default interface Reference {
+  output: {
+    text: string;
+  };
+  tags: string[];
+}


### PR DESCRIPTION
The references and mapped output are useful for MCQA tasks.

Screenshot:
![Screenshot 2024-02-09 152907](https://github.com/stanford-crfm/helm/assets/185227/0289b87e-798e-4585-b538-a451c4914dce)
