### PR TITLE
Send intermediate certificate in crfm-models proxy server

### DIFF
--- a/src/helm/proxy/server.py
+++ b/src/helm/proxy/server.py
@@ -260,6 +260,7 @@ def main():
     parser.add_argument("-p", "--port", type=int, help="What port to listen on", default=1959)
     parser.add_argument("--ssl-key-file", type=str, help="Path to SSL key file")
     parser.add_argument("--ssl-cert-file", type=str, help="Path to SSL cert file")
+    parser.add_argument("--ssl-ca-certs", type=str, help="Path to SSL CA certs")
     parser.add_argument("-b", "--base-path", help="What directory has credentials, etc.", default="prod_env")
     parser.add_argument("-w", "--workers", type=int, help="Number of worker processes to handle requests", default=8)
     parser.add_argument("-t", "--timeout", type=int, help="Request timeout in seconds", default=5 * 60)
@@ -289,9 +290,12 @@ def main():
         "timeout": args.timeout,
         "limit_request_line": 0,  # Controls the maximum size of HTTP request line in bytes. 0 = unlimited.
     }
-    if args.ssl_key_file and args.ssl_cert_file:
+    if args.ssl_key_file:
         gunicorn_args["keyfile"] = args.ssl_key_file
+    if args.ssl_cert_file:
         gunicorn_args["certfile"] = args.ssl_cert_file
+    if args.ssl_ca_certs:
+        gunicorn_args["ca_certs"] = args.ssl_ca_certs
 
     # Clear arguments before running gunicorn as it also uses argparse
     sys.argv = [sys.argv[0]]


### PR DESCRIPTION
This is required to send the intermediate certificate as [recommended by Stanford University IT](https://uit.stanford.edu/service/ssl/chain).

Failing to do so will result in the following error when attempting to connect to the proxy using our Python library: `[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate`

I have already patched this on the server, and would like to merge it into main.