### PR TITLE
Get helm-summarize to work on HELM-Instruct

### DIFF
--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -760,9 +760,6 @@ class Summarizer:
                             num_prompt_tokens.extend(get_all_stats_by_name(run.stats, "num_prompt_tokens"))
                             num_completion_tokens.extend(get_all_stats_by_name(run.stats, "num_completion_tokens"))
 
-                if len(num_instances) == 0:
-                    continue
-
                 rows.append(
                     [
                         Cell(group.display_name, href=get_benchmarking_url({"group": group.name})),

--- a/src/helm/benchmark/static/schema_instruction_following.yaml
+++ b/src/helm/benchmark/static/schema_instruction_following.yaml
@@ -1,5 +1,6 @@
 ---
 ############################################################
+perturbations: []
 adapter:
   - name: method
     description: The high-level strategy for converting instances into a prompt for the language model.
@@ -100,7 +101,6 @@ run_groups:
   - name: instruction_following
     display_name: Instruction Following
     description: Given an open-ended instruction in natural language, the goal is to produce a text response that is helpful, understandable, complete, concise and harmless.
-    category: Evaluations
     subgroups:
       - anthropic_hh_rlhf
       - grammar


### PR DESCRIPTION
- HELM-Instruct runs have no `num_instances` metric, therefore the check for `num_instances` in `helm-summarize` must be removed to allow it to work at all.
- `perturbations` is a required field in `Schema`, so it must be set to an empty list even if there are no perturbations.
- The `category` field doesn't seem to do anything in `Schema`, so it is deleted.