### PR TITLE
Provide basic image support

### DIFF
--- a/helm-frontend/src/components/InstanceData.tsx
+++ b/helm-frontend/src/components/InstanceData.tsx
@@ -23,10 +23,9 @@ export default function InstanceData({
       </h3>
       <h3>Input</h3>
       <Preview value={instance.input.text} />
-      <h3>References</h3>
-      <span>
+      {instance.references && instance.references.length > 0 ? (
         <References references={instance.references} />
-      </span>
+      ) : null}
       {predictions && requests ? (
         <Predictions predictions={predictions} requests={requests} />
       ) : null}

--- a/helm-frontend/src/components/Predictions.tsx
+++ b/helm-frontend/src/components/Predictions.tsx
@@ -25,6 +25,69 @@ export default function Predictions({ predictions, requests }: Props) {
     return null;
   }
 
+  if (predictions && predictions[0] && predictions[0].base64_images) {
+    return (
+      <div>
+        <div className="flex flex-wrap justify-start items-start">
+          {predictions.map((prediction, idx) => (
+            <div className="w-full" key={idx}>
+              {predictions.length > 1 ? <h2>Trial {idx}</h2> : null}
+              <div className="mt-2 w-full">
+                <h3>
+                  <span className="mr-4">Prediction image</span>
+                </h3>
+                <div>
+                  {prediction &&
+                  prediction.base64_images &&
+                  prediction.base64_images[0] ? (
+                    <img
+                      src={"data:image;base64," + prediction.base64_images[0]}
+                      alt="Base64 Image"
+                    />
+                  ) : null}
+                </div>
+              </div>
+              <div className="accordion-wrapper">
+                <button
+                  className="accordion-title p-5 bg-gray-100 hover:bg-gray-200 w-full text-left"
+                  onClick={toggleAccordion}
+                >
+                  <h3 className="text-lg font-medium text-gray-900">
+                    Prompt Details
+                  </h3>
+                </button>
+
+                {isOpen && (
+                  <div className="accordion-content p-5 border shadow-lg rounded-md bg-white">
+                    <div className="mt-3 text-left">
+                      <div className="overflow-auto">
+                        <Request request={requests[idx]} />
+                      </div>
+                      <List>
+                        {Object.keys(prediction.stats).map((statKey, idx) => (
+                          <ListItem key={idx} className="mt-2">
+                            <span>{statKey}:</span>
+                            <span>
+                              {String(
+                                prediction.stats[
+                                  statKey as keyof typeof prediction.stats
+                                ],
+                              )}
+                            </span>
+                          </ListItem>
+                        ))}
+                      </List>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div>
       <div className="flex flex-wrap justify-start items-start">

--- a/helm-frontend/src/components/References.tsx
+++ b/helm-frontend/src/components/References.tsx
@@ -9,27 +9,30 @@ const CORRECT_TAG = "correct";
 
 export default function References({ references }: Props) {
   return (
-    <ul>
-      {references.map((reference, index) => {
-        return (
-          <li
-            key={index}
-            className="bg-base-200 p-2 block overflow-auto w-full max-h-72 mb-2 whitespace-pre-wrap"
-          >
-            {reference.output.text}
-            {reference.tags.map((tag) => {
-              return (
-                <Badge
-                  className="mx-2"
-                  color={tag === CORRECT_TAG ? "green" : undefined}
-                >
-                  {tag}
-                </Badge>
-              );
-            })}
-          </li>
-        );
-      })}
-    </ul>
+    <span>
+      <h3>References</h3>
+      <ul>
+        {references.map((reference, index) => {
+          return (
+            <li
+              key={index}
+              className="bg-base-200 p-2 block overflow-auto w-full max-h-72 mb-2 whitespace-pre-wrap"
+            >
+              {reference.output.text}
+              {reference.tags.map((tag) => {
+                return (
+                  <Badge
+                    className="mx-2"
+                    color={tag === CORRECT_TAG ? "green" : undefined}
+                  >
+                    {tag}
+                  </Badge>
+                );
+              })}
+            </li>
+          );
+        })}
+      </ul>
+    </span>
   );
 }

--- a/helm-frontend/src/types/DisplayPrediction.ts
+++ b/helm-frontend/src/types/DisplayPrediction.ts
@@ -11,4 +11,5 @@ export default interface DisplayPrediction {
     quasi_exact_match: number;
   };
   mapped_output: string | undefined;
+  base64_images?: string[] | undefined;
 }


### PR DESCRIPTION
Provides basic image support such that HEIM can use the new front-end. Existing HELM frontends should be unchanged as a result of this.

There could be a better logic switch/thing to check before triggering the image display versus the normal text display. We can discuss that here.

Try it [here](https://farzaank.github.io/heim/#/runs/common_syntactic_processes:phenomenon=ambiguity,model=AlephAlpha_m-vader,max_eval_instances=100)

Compare it to the existing [frontend](https://crfm.stanford.edu/heim/latest/?runs=1&runSpec=common_syntactic_processes%3Aphenomenon%3Dambiguity%2Cmodel%3DAlephAlpha_m-vader%2Cmax_eval_instances%3D100)

I will follow-up with some other changes that makes HEIM work generally. 