### PR TITLE
Frontend patches for HEIM

### DIFF
--- a/helm-frontend/public/config.js
+++ b/helm-frontend/public/config.js
@@ -1,4 +1,4 @@
-window.BENCHMARK_OUTPUT_BASE_URL =
-  "https://storage.googleapis.com/crfm-helm-public/lite/benchmark_output/";
 window.SUITE = null;
 window.RELEASE = "v1.0.0";
+window.BENCHMARK_OUTPUT_BASE_URL =
+	"https://storage.googleapis.com/crfm-helm-public/lite/benchmark_output/";

--- a/helm-frontend/src/components/InstanceData.tsx
+++ b/helm-frontend/src/components/InstanceData.tsx
@@ -23,10 +23,9 @@ export default function InstanceData({
       </h3>
       <h3>Input</h3>
       <Preview value={instance.input.text} />
-      <h3>References</h3>
-      <span>
+      {instance.references && instance.references.length > 0 ? (
         <References references={instance.references} />
-      </span>
+      ) : null}
       {predictions && requests ? (
         <Predictions predictions={predictions} requests={requests} />
       ) : null}

--- a/helm-frontend/src/components/Predictions.tsx
+++ b/helm-frontend/src/components/Predictions.tsx
@@ -25,6 +25,69 @@ export default function Predictions({ predictions, requests }: Props) {
     return null;
   }
 
+  if (predictions && predictions[0] && predictions[0].base64_images) {
+    return (
+      <div>
+        <div className="flex flex-wrap justify-start items-start">
+          {predictions.map((prediction, idx) => (
+            <div className="w-full" key={idx}>
+              {predictions.length > 1 ? <h2>Trial {idx}</h2> : null}
+              <div className="mt-2 w-full">
+                <h3>
+                  <span className="mr-4">Prediction image</span>
+                </h3>
+                <div>
+                  {prediction &&
+                  prediction.base64_images &&
+                  prediction.base64_images[0] ? (
+                    <img
+                      src={"data:image;base64," + prediction.base64_images[0]}
+                      alt="Base64 Image"
+                    />
+                  ) : null}
+                </div>
+              </div>
+              <div className="accordion-wrapper">
+                <button
+                  className="accordion-title p-5 bg-gray-100 hover:bg-gray-200 w-full text-left"
+                  onClick={toggleAccordion}
+                >
+                  <h3 className="text-lg font-medium text-gray-900">
+                    Prompt Details
+                  </h3>
+                </button>
+
+                {isOpen && (
+                  <div className="accordion-content p-5 border shadow-lg rounded-md bg-white">
+                    <div className="mt-3 text-left">
+                      <div className="overflow-auto">
+                        <Request request={requests[idx]} />
+                      </div>
+                      <List>
+                        {Object.keys(prediction.stats).map((statKey, idx) => (
+                          <ListItem key={idx} className="mt-2">
+                            <span>{statKey}:</span>
+                            <span>
+                              {String(
+                                prediction.stats[
+                                  statKey as keyof typeof prediction.stats
+                                ],
+                              )}
+                            </span>
+                          </ListItem>
+                        ))}
+                      </List>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div>
       <div className="flex flex-wrap justify-start items-start">

--- a/helm-frontend/src/components/References.tsx
+++ b/helm-frontend/src/components/References.tsx
@@ -9,27 +9,30 @@ const CORRECT_TAG = "correct";
 
 export default function References({ references }: Props) {
   return (
-    <ul>
-      {references.map((reference, index) => {
-        return (
-          <li
-            key={index}
-            className="bg-base-200 p-2 block overflow-auto w-full max-h-72 mb-2 whitespace-pre-wrap"
-          >
-            {reference.output.text}
-            {reference.tags.map((tag) => {
-              return (
-                <Badge
-                  className="mx-2"
-                  color={tag === CORRECT_TAG ? "green" : undefined}
-                >
-                  {tag}
-                </Badge>
-              );
-            })}
-          </li>
-        );
-      })}
-    </ul>
+    <span>
+      <h3>References</h3>
+      <ul>
+        {references.map((reference, index) => {
+          return (
+            <li
+              key={index}
+              className="bg-base-200 p-2 block overflow-auto w-full max-h-72 mb-2 whitespace-pre-wrap"
+            >
+              {reference.output.text}
+              {reference.tags.map((tag) => {
+                return (
+                  <Badge
+                    className="mx-2"
+                    color={tag === CORRECT_TAG ? "green" : undefined}
+                  >
+                    {tag}
+                  </Badge>
+                );
+              })}
+            </li>
+          );
+        })}
+      </ul>
+    </span>
   );
 }

--- a/helm-frontend/src/components/ReleaseDropdown.tsx
+++ b/helm-frontend/src/components/ReleaseDropdown.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import getBenchmarkRelease from "@/utils/getBenchmarkRelease";
 import getReleaseSummary from "@/services/getReleaseSummary";
 import ReleaseSummary from "@/types/ReleaseSummary";
+import getBenchmarkSuite from "@/utils/getBenchmarkSuite";
 
 function ReleaseDropdown() {
   const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -11,7 +12,7 @@ function ReleaseDropdown() {
     date: "",
   });
   const release = getBenchmarkRelease();
-
+  const suite = getBenchmarkSuite();
   useEffect(() => {
     const controller = new AbortController();
     async function fetchData() {
@@ -33,7 +34,13 @@ function ReleaseDropdown() {
           onClick={() => setDropdownOpen(!dropdownOpen)}
           className="inline-flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75"
         >
-          <div> Release: {release + " : " + summary.date} </div>
+          <div>
+            {" "}
+            Release:{" "}
+            {(release == "null" || release == null ? suite : release) +
+              " : " +
+              summary.date}{" "}
+          </div>
           <svg
             xmlns="http://www.w3.org/2000/svg"
             className="h-4 w-4 ml-2"

--- a/helm-frontend/src/services/getSchema.ts
+++ b/helm-frontend/src/services/getSchema.ts
@@ -1,6 +1,8 @@
+import { parse } from "yaml";
 import type Schema from "@/types/Schema";
 import getBenchmarkEndpoint from "@/utils/getBenchmarkEndpoint";
 import getVersionBaseUrl from "@/utils/getVersionBaseUrl";
+import getBenchmarkSuite from "@/utils/getBenchmarkSuite";
 
 export default async function getSchema(signal: AbortSignal): Promise<Schema> {
   try {
@@ -11,14 +13,30 @@ export default async function getSchema(signal: AbortSignal): Promise<Schema> {
 
     return (await resp.json()) as Schema;
   } catch (error) {
-    console.log(error);
-    return {
-      adapter: [],
-      metric_groups: [],
-      metrics: [],
-      models: [],
-      perturbations: [],
-      run_groups: [],
-    } as Schema;
+    // Fallback to schema.yaml if schema.json is not found since some HELMets do not have schema.json
+    try {
+      let url = getBenchmarkEndpoint(`${getVersionBaseUrl()}/`) + `schema.yaml`;
+
+      // if suite appears before benchmark_output, we need to replace that part of the url (since it means suite appears twice)
+      const suite = getBenchmarkSuite();
+      if (suite && url.includes(suite + "/benchmark_output/runs/")) {
+        url = url.replace(suite + "/benchmark_output/runs/", "");
+      }
+
+      const resp = await fetch(url, { signal });
+      const data = await resp.text();
+      const schema = parse(data) as Schema;
+      return schema;
+    } catch (error) {
+      console.log(error);
+      return {
+        adapter: [],
+        metric_groups: [],
+        metrics: [],
+        models: [],
+        perturbations: [],
+        run_groups: [],
+      } as Schema;
+    }
   }
 }

--- a/helm-frontend/src/types/DisplayPrediction.ts
+++ b/helm-frontend/src/types/DisplayPrediction.ts
@@ -11,4 +11,5 @@ export default interface DisplayPrediction {
     quasi_exact_match: number;
   };
   mapped_output: string | undefined;
+  base64_images?: string[] | undefined;
 }


### PR DESCRIPTION
Implemented the following fixes for HEIM to start working. This allows you to run HEIM on the front-end on the same codebase by updating the expected 2 fields in config.js

Changes are live at https://farzaank.github.io/heim/

This only leaves us needing to design a new landing page for HEIM, like we did for HELM-instruct.

- Rearrange config.js such that benchmark_output is last
  - Intuitively it would seem we shouldn't have benchmark_output be dependent on suite or release, but this is the case for HEIM. And since this is at least theoretically possible to be replicated in other HELMlets, it's probably best to just build in support for this.
  - You can now do 
     `window.BENCHMARK_OUTPUT_BASE_URL ="https://nlp.stanford.edu/helm/${window.SUITE}/benchmark_output/"`
- Add suite fallback for Release dropdown, since HEIM uses suite.
- Add yaml fallback for HEIM, which doesn't have schema.json
- Adds image support (via pre-requisite PR #2371)
