### PR TITLE
Rename run_specs.py to classic_run_specs.py

### DIFF
--- a/src/helm/benchmark/adaptation/adapters/test_generation_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/test_generation_adapter.py
@@ -11,7 +11,7 @@ from helm.benchmark.scenarios.scenario import (
     Input,
     Output,
 )
-from helm.benchmark.run_specs import get_scenario_spec1, get_adapter_spec1
+from helm.benchmark.run_specs.classic_run_specs import get_scenario_spec1, get_adapter_spec1
 from helm.benchmark.adaptation.prompt import Prompt
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from .adapter_factory import AdapterFactory, ADAPT_GENERATION

--- a/src/helm/benchmark/heim_run_specs.py
+++ b/src/helm/benchmark/heim_run_specs.py
@@ -1,12 +1,12 @@
 from typing import List, Optional
 
 from helm.common.image_generation_parameters import ImageGenerationParameters
-from .adaptation.adapter_spec import AdapterSpec
-from .adaptation.adapters.adapter_factory import ADAPT_GENERATION
-from .metrics.metric import MetricSpec
-from .run_specs import run_spec_function, get_basic_metric_specs
-from .runner import RunSpec
-from .scenarios.scenario import ScenarioSpec
+from helm.benchmark.adaptation.adapter_spec import AdapterSpec
+from helm.benchmark.adaptation.adapters.adapter_factory import ADAPT_GENERATION
+from helm.benchmark.metrics.metric import MetricSpec
+from helm.benchmark.run_specs.classic_run_specs import run_spec_function, get_basic_metric_specs
+from helm.benchmark.runner import RunSpec
+from helm.benchmark.scenarios.scenario import ScenarioSpec
 
 
 ############################################################

--- a/src/helm/benchmark/presentation/test_run_entry.py
+++ b/src/helm/benchmark/presentation/test_run_entry.py
@@ -3,7 +3,7 @@ import pytest
 
 from helm.common.object_spec import parse_object_spec
 from helm.benchmark.presentation.run_entry import read_run_entries
-from helm.benchmark.run_specs import construct_run_specs
+from helm.benchmark.run_specs.classic_run_specs import construct_run_specs
 from helm.benchmark import heim_run_specs  # noqa
 from helm.benchmark import vlm_run_specs  # noqa
 

--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -22,7 +22,7 @@ from helm.benchmark import heim_run_specs  # noqa
 from helm.benchmark import vlm_run_specs  # noqa
 from .executor import ExecutionSpec
 from .runner import Runner, RunSpec, LATEST_SYMLINK, set_benchmark_output_path
-from .run_specs import construct_run_specs
+from .run_specs.classic_run_specs import construct_run_specs
 
 
 def run_entries_to_run_specs(

--- a/src/helm/benchmark/run_specs/classic_run_specs.py
+++ b/src/helm/benchmark/run_specs/classic_run_specs.py
@@ -24,8 +24,8 @@ from helm.benchmark.adaptation.adapters.adapter_factory import (
 )
 from helm.benchmark.adaptation.adapters.binary_ranking_adapter import BinaryRankingAdapter
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
-from .metrics.metric import MetricSpec
-from .run_expander import (
+from helm.benchmark.metrics.metric import MetricSpec
+from helm.benchmark.run_expander import (
     RUN_EXPANDERS,
     GlobalPrefixRunExpander,
     AnthropicRunExpander,
@@ -38,17 +38,17 @@ from .run_expander import (
     IncreaseTemperatureRunExpander,
     IncreaseMaxTokensRunExpander,
 )
-from .runner import RunSpec, get_benchmark_output_path
-from .scenarios.lex_glue_scenario import (
+from helm.benchmark.runner import RunSpec, get_benchmark_output_path
+from helm.benchmark.scenarios.lex_glue_scenario import (
     get_lex_glue_max_train_instances,
     get_lex_glue_instructions,
     get_lex_glue_max_tokens,
     get_lex_glue_task_type,
 )
-from .scenarios.scenario import ScenarioSpec, get_scenario_cache_path
-from .scenarios.msmarco_scenario import MSMARCOScenario
-from .scenarios.copyright_scenario import datatag2hash_code
-from .scenarios.lextreme_scenario import (
+from helm.benchmark.scenarios.scenario import ScenarioSpec, get_scenario_cache_path
+from helm.benchmark.scenarios.msmarco_scenario import MSMARCOScenario
+from helm.benchmark.scenarios.copyright_scenario import datatag2hash_code
+from helm.benchmark.scenarios.lextreme_scenario import (
     get_lextreme_instructions,
     get_lextreme_max_train_instances,
     get_lextreme_max_tokens,
@@ -1279,7 +1279,7 @@ def get_raft_spec(subset: str) -> RunSpec:
 def get_numeracy_spec(
     relation_type: str = "linear", mode: str = "function", seed: str = "0", run_solver: str = "False"
 ) -> RunSpec:
-    from .scenarios.numeracy_scenario import get_numeracy_adapter_spec, RELTYPE_INFO
+    from helm.benchmark.scenarios.numeracy_scenario import get_numeracy_adapter_spec, RELTYPE_INFO
 
     run_solver_bool: bool = True if run_solver == "True" else False
     del run_solver

--- a/src/helm/benchmark/scenarios/test_scenario.py
+++ b/src/helm/benchmark/scenarios/test_scenario.py
@@ -1,4 +1,4 @@
-from helm.benchmark.run_specs import get_scenario_spec_tiny
+from helm.benchmark.run_specs.classic_run_specs import get_scenario_spec_tiny
 from helm.benchmark.scenarios.scenario import create_scenario, Scenario, Input, PassageQuestionInput
 
 

--- a/src/helm/benchmark/test_data_preprocessor.py
+++ b/src/helm/benchmark/test_data_preprocessor.py
@@ -4,7 +4,7 @@ from typing import List
 from helm.benchmark.augmentations.data_augmenter import DataAugmenterSpec
 from helm.benchmark.augmentations.perturbation import PerturbationSpec
 from helm.benchmark.data_preprocessor import DataPreprocessor
-from helm.benchmark.run_specs import get_scenario_spec1
+from helm.benchmark.run_specs.classic_run_specs import get_scenario_spec1
 from helm.benchmark.scenarios.scenario import create_scenario, Instance, Scenario, with_instance_ids
 
 

--- a/src/helm/benchmark/vlm_run_specs.py
+++ b/src/helm/benchmark/vlm_run_specs.py
@@ -1,11 +1,11 @@
 from typing import List, Optional, Dict
 
-from .adaptation.adapter_spec import AdapterSpec
-from .adaptation.adapters.adapter_factory import ADAPT_GENERATION_MULTIMODAL, ADAPT_MULTIPLE_CHOICE_JOINT_MULTIMODAL
-from .metrics.metric import MetricSpec
-from .run_specs import run_spec_function, get_exact_match_metric_specs, get_open_ended_generation_metric_specs
-from .runner import RunSpec
-from .scenarios.scenario import ScenarioSpec
+from helm.benchmark.adaptation.adapter_spec import AdapterSpec
+from helm.benchmark.adaptation.adapters.adapter_factory import ADAPT_GENERATION_MULTIMODAL, ADAPT_MULTIPLE_CHOICE_JOINT_MULTIMODAL
+from helm.benchmark.metrics.metric import MetricSpec
+from helm.benchmark.run_specs.classic_run_specs import run_spec_function, get_exact_match_metric_specs, get_open_ended_generation_metric_specs
+from helm.benchmark.runner import RunSpec
+from helm.benchmark.scenarios.scenario import ScenarioSpec
 
 
 ############################################################

--- a/src/helm/benchmark/vlm_run_specs.py
+++ b/src/helm/benchmark/vlm_run_specs.py
@@ -1,9 +1,16 @@
 from typing import List, Optional, Dict
 
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
-from helm.benchmark.adaptation.adapters.adapter_factory import ADAPT_GENERATION_MULTIMODAL, ADAPT_MULTIPLE_CHOICE_JOINT_MULTIMODAL
+from helm.benchmark.adaptation.adapters.adapter_factory import (
+    ADAPT_GENERATION_MULTIMODAL,
+    ADAPT_MULTIPLE_CHOICE_JOINT_MULTIMODAL,
+)
 from helm.benchmark.metrics.metric import MetricSpec
-from helm.benchmark.run_specs.classic_run_specs import run_spec_function, get_exact_match_metric_specs, get_open_ended_generation_metric_specs
+from helm.benchmark.run_specs.classic_run_specs import (
+    run_spec_function,
+    get_exact_match_metric_specs,
+    get_open_ended_generation_metric_specs,
+)
 from helm.benchmark.runner import RunSpec
 from helm.benchmark.scenarios.scenario import ScenarioSpec
 

--- a/src/helm/proxy/critique/model_critique_client.py
+++ b/src/helm/proxy/critique/model_critique_client.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Union, Optional
 import string
 import dataclasses
 
-from helm.benchmark.run_specs import get_default_model_deployment_for_model
+from helm.benchmark.run_specs.classic_run_specs import get_default_model_deployment_for_model
 from helm.common.critique_request import (
     CritiqueRequest,
     CritiqueRequestResult,


### PR DESCRIPTION
This is a precursor to #2321 and must be landed first.

For some reason, git does not recognize the refactor in #2321 as a file rename of `run_specs.py`. Therefore, we should do the file rename in this isolated pull request, so that file history and blame history is preserved in git for debugging purposes.