### PR TITLE
Upgrade OpenAI SDK

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -125,7 +125,7 @@ mistral =
     mistralai~=0.0.11
 
 openai =
-    openai~=0.27.8
+    openai~=1.0
     tiktoken~=0.3.3
 
 google =

--- a/src/helm/benchmark/test_model_deployment_definition.py
+++ b/src/helm/benchmark/test_model_deployment_definition.py
@@ -31,7 +31,8 @@ class TestModelProperties:
     @pytest.mark.parametrize("deployment_name", [deployment.name for deployment in ALL_MODEL_DEPLOYMENTS])
     def test_models_has_window_service(self, deployment_name: str):
         with TemporaryDirectory() as tmpdir:
-            auto_client = AutoClient({}, tmpdir, BlackHoleCacheBackendConfig())
+            credentials = {"openaiApiKey": "test-openai-api-key"}
+            auto_client = AutoClient(credentials, tmpdir, BlackHoleCacheBackendConfig())
             auto_tokenizer = AutoTokenizer({}, BlackHoleCacheBackendConfig())
             tokenizer_service = get_tokenizer_service(tmpdir, BlackHoleCacheBackendConfig())
 

--- a/src/helm/proxy/clients/auto_client.py
+++ b/src/helm/proxy/clients/auto_client.py
@@ -13,6 +13,7 @@ from helm.common.hierarchical_logger import hlog
 from helm.common.object_spec import create_object, inject_object_spec_args
 from helm.common.request import Request, RequestResult
 from helm.proxy.clients.client import Client
+from helm.proxy.clients.moderation_api_client import ModerationAPIClient
 from helm.proxy.critique.critique_client import CritiqueClient
 from helm.proxy.clients.toxicity_classifier_client import ToxicityClassifierClient
 from helm.proxy.retry import NonRetriableException, retry_request
@@ -150,10 +151,8 @@ class AutoClient(Client):
         cache_config: CacheConfig = self.cache_backend_config.get_cache_config("perspectiveapi")
         return PerspectiveAPIClient(self.credentials.get("perspectiveApiKey", ""), cache_config)
 
-    def get_moderation_api_client(self):
+    def get_moderation_api_client(self) -> ModerationAPIClient:
         """Get the ModerationAPI client."""
-        from .moderation_api_client import ModerationAPIClient
-
         cache_config: CacheConfig = self.cache_backend_config.get_cache_config("ModerationAPI")
         return ModerationAPIClient(self.credentials.get("openaiApiKey", ""), cache_config)
 

--- a/src/helm/proxy/clients/image_generation/dalle3_client.py
+++ b/src/helm/proxy/clients/image_generation/dalle3_client.py
@@ -79,7 +79,7 @@ class DALLE3Client(DALLE2Client):
 
                 responses.append(response)
                 all_cached = all_cached and cached
-            except openai.error.OpenAIError as e:
+            except openai.OpenAIError as e:
                 return self.handle_openai_error(request, e)
 
         completions: List[Sequence] = []


### PR DESCRIPTION
Migrate to OpenAI SDK v1.0.0, using the guide and CLI tool [here](https://github.com/openai/openai-python/discussions/742).

I manually tested this by sending requests and checking that the `RequestResult` looked acceptable for the following models: `gpt-3.5-turbo-instruct` (completion), `gpt-3.5-turbo-0613` (chat), `text-embedding-ada-002` (embedding), and `dall-e-2` (image).

The only behavior change is that we now use "model" instead of "engine" in the request to completion and embedding models, because "engine" is deprecated. This means that new requests will not match existing cache keys for completion and embedding models. Chat models were already using "model" and are unaffected.

Also fixes an existing issue where `ModerationAPIClient` is instantiated eagerly instead of lazily in `ServerService`.

Also add a configurable `base_url`, which should allow the client to be used with vLLM.

Addresses #1997.