### PR TITLE
Add vLLM client

### DIFF
--- a/src/helm/proxy/clients/openai_client.py
+++ b/src/helm/proxy/clients/openai_client.py
@@ -221,7 +221,7 @@ class OpenAIClient(CachingClient):
             embedding=[],
         )
 
-    def _make_completion_request(self, request: Request) -> RequestResult:
+    def _to_raw_completion_request(self, request: Request) -> Dict[str, Any]:
         raw_request: Dict[str, Any] = {
             # Note: In older deprecated versions of the OpenAI API, "model" used to be "engine".
             "model": self._get_model_for_request(request),
@@ -242,6 +242,11 @@ class OpenAIClient(CachingClient):
         # per-token candidates.
         raw_request["best_of"] = max(raw_request["best_of"], raw_request["n"])
         raw_request["logprobs"] = max(raw_request["logprobs"], raw_request["n"])
+
+        return raw_request
+
+    def _make_completion_request(self, request: Request) -> RequestResult:
+        raw_request = self._to_raw_completion_request(request)
 
         def do_it() -> Dict[str, Any]:
             return self.client.completions.create(**raw_request).model_dump(mode="json")

--- a/src/helm/proxy/clients/vllm_client.py
+++ b/src/helm/proxy/clients/vllm_client.py
@@ -1,0 +1,35 @@
+from typing import Optional
+
+from helm.common.cache import CacheConfig
+from helm.common.request import Request
+from helm.proxy.clients.openai_client import OpenAIClient
+from helm.proxy.tokenizers.tokenizer import Tokenizer
+
+
+class VLLMClient(OpenAIClient):
+    def __init__(
+        self,
+        tokenizer: Tokenizer,
+        tokenizer_name: str,
+        cache_config: CacheConfig,
+        base_url: Optional[str] = None,
+    ):
+        super().__init__(
+            tokenizer=tokenizer,
+            tokenizer_name=tokenizer_name,
+            cache_config=cache_config,
+            api_key="EMPTY",
+            org_id=None,
+            base_url=base_url,
+        )
+        self.tokenizer = tokenizer
+        self.tokenizer_name = tokenizer_name
+
+    def _is_chat_model_engine(self, model_engine: str) -> bool:
+        # Only support completion models for now.
+        return False
+
+    def _get_model_for_request(self, request: Request) -> str:
+        # The `model` parameter for vLLM should be the whole model name including the creator organization,
+        # unlike OpenAI which only uses the model engine.
+        return request.model


### PR DESCRIPTION
`VLLMClient` is a lightly customized version of `OpenAIClient` that allows sending requests to a vLLM server using the [OpenAI-compatible API](https://docs.vllm.ai/en/latest/getting_started/quickstart.html#openai-compatible-serve).

This closes a request from Shah Lab.

Fixes #1997