### PR TITLE
Return token top_logprobs in crfm-models server

### DIFF
--- a/src/helm/proxy/server.py
+++ b/src/helm/proxy/server.py
@@ -195,7 +195,16 @@ def handle_request():
         if not request.model_deployment:
             request = dataclasses.replace(request, model_deployment=request.model)
 
-        return dataclasses.asdict(service.make_request(auth, request))
+        raw_response = dataclasses.asdict(service.make_request(auth, request))
+
+        # Hack to maintain reverse compatibility with clients with version <= 1.0.0.
+        # Clients with version <= 1.0.0 expect each token to contain a `top_logprobs`
+        # field of type dict.
+        for completion in raw_response["completions"]:
+            for token in completion["tokens"]:
+                token["top_logprobs"] = {}
+
+        return raw_response
 
     return safe_call(perform)
 


### PR DESCRIPTION
This maintains reverse compatibility with clients with version <= 1.0.0. Clients with version <= 1.0.0 expect each token to contain a `top_logprobs` field of type dict, which was removed by #2323.

Requested by @q-hwang 