### PR TITLE
Add GitHub Actions workflow for viewing and purging the Python cache

### DIFF
--- a/.github/workflows/manage-python-cache.yml
+++ b/.github/workflows/manage-python-cache.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/manage-python-cache.yml
+++ b/.github/workflows/manage-python-cache.yml
@@ -1,0 +1,52 @@
+# Workflows for manually managing the Python cache.
+#
+# HELM's dependencies (e.g. PyTorch, transformers) can be very large,
+# and the cache may contain multiple versions of these dependencies,
+# so we may have to purge the cache from time to time.
+
+name: Manage Python Cache
+
+on: workflow_dispatch
+
+jobs:
+  info:
+    name: Show pip cache info and package list
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Get pip cache info
+        run: pip cache info && pip cache list
+
+  purge:
+    name: Purge and rebuild pip cache
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Get pip cache info before purging
+        run: pip cache info && pip cache list
+      - name: Purge pip cache
+        run: pip cache purge
+      - name: Get pip cache info after purging
+        run: pip cache info && pip cache list
+      - name: Install HELM
+        run: pip install -e .[all]
+      - name: Get pip cache info after installing HELM
+        run: pip cache info && pip cache list


### PR DESCRIPTION
Add GitHub Actions Workflows for manually managing the Python cache.

HELM's dependencies (e.g. PyTorch, transformers) can be very large, and the cache may contain multiple versions of these dependencies, so we may have to purge the cache from time to time.