### PR TITLE
Frontend dropdown menu improvements

### DIFF
--- a/helm-frontend/src/components/NavBar/NavBar.test.tsx
+++ b/helm-frontend/src/components/NavBar/NavBar.test.tsx
@@ -11,6 +11,6 @@ test("displays nav bar", () => {
   );
 
   expect(screen.getByRole("navigation")).toHaveTextContent(
-    "LeaderboardModelsScenariosPredictionsGitHub LeaderboardModelsScenariosPredictionsGitHub Release: undefined",
+    "LeaderboardModelsScenariosPredictionsGitHubLite Lite: Lightweight, broad evaluation of the capabilities of language models using in-context learningClassic: Thorough language model evaluations based on the scenarios from the original HELM paperHEIM: Holistic evaluation of text-to-image modelsInstruct: Evaluations of instruction following models with absolute ratingsLeaderboardModelsScenariosPredictionsGitHubRelease unknown () v1.1.0v1.0.0",
   );
 });

--- a/helm-frontend/src/components/NavBar/NavBar.tsx
+++ b/helm-frontend/src/components/NavBar/NavBar.tsx
@@ -18,7 +18,7 @@ export default function NavBar() {
           </label>
           <ul
             tabIndex={0}
-            className="menu menu-lg dropdown-content mt-3 z-[1] p-2 bg-base-100 shadow-lg text-base"
+            className="menu menu-lg dropdown-content mt-3 z-[1] p-2 bg-base-100 shadow"
           >
             <li>
               <Link to="leaderboard">Leaderboard</Link>

--- a/helm-frontend/src/components/NavBar/NavBar.tsx
+++ b/helm-frontend/src/components/NavBar/NavBar.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 import { Bars3Icon } from "@heroicons/react/24/outline";
 import crfmLogo from "@/assets/crfm-logo.png";
-//import helmLogo from "@/assets/helm-logo-simple.png";
+import helmLogo from "@/assets/helm-logo-simple.png";
 import NavDropdown from "@/components/NavDropdown";
 import ReleaseDropdown from "../ReleaseDropdown";
 
@@ -43,6 +43,9 @@ export default function NavBar() {
       <div className="flex-1 items-center">
         <Link to="https://crfm.stanford.edu/" className="w-24">
           <img src={crfmLogo} className="object-contain" />
+        </Link>
+        <Link to="https://crfm.stanford.edu/helm/" className="mx-2 w-32">
+          <img src={helmLogo} className="object-contain" />
         </Link>
         <NavDropdown></NavDropdown>
       </div>

--- a/helm-frontend/src/components/NavBar/NavBar.tsx
+++ b/helm-frontend/src/components/NavBar/NavBar.tsx
@@ -18,7 +18,7 @@ export default function NavBar() {
           </label>
           <ul
             tabIndex={0}
-            className="menu menu-lg dropdown-content mt-3 z-[1] p-2 bg-base-100 shadow"
+            className="menu menu-lg dropdown-content mt-3 z-[1] p-2 bg-base-100 shadow-lg text-base"
           >
             <li>
               <Link to="leaderboard">Leaderboard</Link>
@@ -44,7 +44,7 @@ export default function NavBar() {
         <Link to="https://crfm.stanford.edu/" className="w-24">
           <img src={crfmLogo} className="object-contain" />
         </Link>
-        <Link to="https://crfm.stanford.edu/helm/" className="mx-2 w-32">
+        <Link to="/" className="mx-2 w-32">
           <img src={helmLogo} className="object-contain" />
         </Link>
         <NavDropdown></NavDropdown>

--- a/helm-frontend/src/components/NavDropdown.tsx
+++ b/helm-frontend/src/components/NavDropdown.tsx
@@ -1,58 +1,75 @@
 import { ChevronDownIcon } from "@heroicons/react/24/solid";
 
-function NavDropdown() {
-  let currentSubsite = "";
+function getCurrentSubsite(): string {
+  // TODO: Fetch this from a configuration file.
   if (window.HELM_TYPE === "LITE") {
-    currentSubsite = "Lite";
+    return "Lite";
   } else if (window.HELM_TYPE === "CLASSIC") {
-    currentSubsite = "Classic";
+    return "Classic";
   } else if (window.HELM_TYPE === "HEIM") {
-    currentSubsite = "HEIM";
+    return "HEIM";
   } else if (window.HELM_TYPE === "INSTRUCT") {
-    currentSubsite = "Instruct";
+    return "Instruct";
   }
+  return "Lite";
+}
 
+function NavDropdown() {
   return (
     <div className="dropdown">
       <div
         tabIndex={0}
         role="button"
         className="btn normal-case bg-white font-bold p-2 border-0 text-lg"
+        aria-haspopup="true"
+        aria-controls="menu"
       >
-        {currentSubsite}{" "}
+        {getCurrentSubsite()}{" "}
         <ChevronDownIcon fill="black" color="black" className="text w-4 h-4" />
       </div>
       <ul
         tabIndex={0}
-        className="dropdown-content z-[1] menu p-1 shadow-lg bg-base-100 rounded-box width-100 block"
+        className="-translate-x-36 dropdown-content z-[1] menu p-1 shadow-lg bg-base-100 rounded-box w-max text-base"
+        role="menu"
       >
         <li>
-          <a href="https://crfm.stanford.edu/helm/lite/">
-            <strong>Lite:</strong>{" "}
-            <span>Lightweight, broad evaluation of recent language models</span>
+          <a
+            href="https://crfm.stanford.edu/helm/lite/"
+            className="block"
+            role="menuitem"
+          >
+            <strong className="inline">Lite:</strong> Lightweight, broad
+            evaluation of the capabilities of language models using in-context
+            learning
           </a>
         </li>
         <li>
-          <a href="https://crfm.stanford.edu/helm/classic/">
-            <strong>Classic:</strong>{" "}
-            <span>
-              Thorough language model evaluations based on the scenarios from
-              the original HELM paper
-            </span>
+          <a
+            href="https://crfm.stanford.edu/helm/classic/"
+            className="block"
+            role="menuitem"
+          >
+            <strong>Classic:</strong> Thorough language model evaluations based
+            on the scenarios from the original HELM paper
           </a>
         </li>
         <li>
-          <a href="https://crfm.stanford.edu/heim/">
-            <strong>HEIM:</strong>{" "}
-            <span>Holistic evaluation of text-to-image models</span>
+          <a
+            href="https://crfm.stanford.edu/heim/"
+            className="block"
+            role="menuitem"
+          >
+            <strong>HEIM:</strong> Holistic evaluation of text-to-image models
           </a>
         </li>
         <li>
-          <a href="https://crfm.stanford.edu/helm/instruct/">
-            <strong>Instruct:</strong>{" "}
-            <span>
-              Evaluations of instruction following models with absolute ratings
-            </span>
+          <a
+            href="https://crfm.stanford.edu/helm/instruct/"
+            className="block"
+            role="menuitem"
+          >
+            <strong>Instruct:</strong> Evaluations of instruction following
+            models with absolute ratings
           </a>
         </li>
       </ul>

--- a/helm-frontend/src/components/NavDropdown.tsx
+++ b/helm-frontend/src/components/NavDropdown.tsx
@@ -1,106 +1,61 @@
-import { useState } from "react";
-import { Link } from "react-router-dom";
+import { ChevronDownIcon } from "@heroicons/react/24/solid";
 
 function NavDropdown() {
-  const [dropdownOpen, setDropdownOpen] = useState(false);
+  let currentSubsite = "";
+  if (window.HELM_TYPE === "LITE") {
+    currentSubsite = "Lite";
+  } else if (window.HELM_TYPE === "CLASSIC") {
+    currentSubsite = "Classic";
+  } else if (window.HELM_TYPE === "HEIM") {
+    currentSubsite = "HEIM";
+  } else if (window.HELM_TYPE === "INSTRUCT") {
+    currentSubsite = "Instruct";
+  }
 
   return (
-    <div className="relative inline-block text-left p-2">
-      <div className="inline-flex items-center p-2">
-        <Link to="/">
-          <div className="flex items-center">
-            <img
-              src="https://crfm.stanford.edu/helm/v0.3.0/images/helm-logo-simple.png"
-              alt="Image 1"
-              className="h-10 object-cover"
-            />
-            {/* Manually set whether Classic or Not via config, otherwise don't show this */}
-            {window.HELM_TYPE ? (
-              <div className="hidden lg:flex pl-3">
-                {" "}
-                <strong>{window.HELM_TYPE}</strong>{" "}
-              </div>
-            ) : (
-              <> </>
-            )}
-          </div>
-        </Link>
-
-        {/* Chevron Button */}
-        <button
-          onClick={() => setDropdownOpen(!dropdownOpen)}
-          className="inline-flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            className="h-4 w-4 ml-2"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M19 9l-7 7-7-7"
-            />
-          </svg>
-        </button>
+    <div className="dropdown">
+      <div
+        tabIndex={0}
+        role="button"
+        className="btn normal-case bg-white font-bold p-2 border-0 text-lg"
+      >
+        {currentSubsite}{" "}
+        <ChevronDownIcon fill="black" color="black" className="text w-4 h-4" />
       </div>
-
-      {dropdownOpen && (
-        <div className="absolute mt-2 w-max translate-x-4 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5">
-          <div
-            className="py-1"
-            role="menu"
-            aria-orientation="vertical"
-            aria-labelledby="options-menu"
-          >
-            <div
-              className="block px-4 py-2 text-md text-gray-700 hover:bg-gray-100 hover:text-gray-900"
-              role="menuitem"
-            >
-              <a href="https://crfm.stanford.edu/helm/classic/latest/">
-                <div className="flex items-center">
-                  <span>
-                    <strong>HELM Classic: </strong>Thorough language model
-                    evaluations based on the scenarios from the original HELM
-                    paper
-                  </span>
-                </div>
-              </a>
-            </div>
-
-            <div
-              className="block px-4 py-2 text-md text-gray-700 hover:bg-gray-100 hover:text-gray-900"
-              role="menuitem"
-            >
-              <a href="https://crfm.stanford.edu/helm/lite/latest/">
-                <div className="flex items-center">
-                  <span>
-                    <strong>HELM Lite: </strong>Lightweight, broad evaluation of
-                    the capabilities of language models using in-context
-                    learning
-                  </span>
-                </div>
-              </a>
-            </div>
-            <div
-              className="block px-4 py-2 text-md text-gray-700 hover:bg-gray-100 hover:text-gray-900"
-              role="menuitem"
-            >
-              <a href="https://crfm.stanford.edu/heim/latest/">
-                <div className="flex items-center">
-                  <span>
-                    <strong>HEIM: </strong>Holistic evaluation of text-to-image
-                    models
-                  </span>
-                </div>
-              </a>
-            </div>
-          </div>
-        </div>
-      )}
+      <ul
+        tabIndex={0}
+        className="dropdown-content z-[1] menu p-1 shadow-lg bg-base-100 rounded-box width-100 block"
+      >
+        <li>
+          <a href="https://crfm.stanford.edu/helm/lite/">
+            <strong>Lite:</strong>{" "}
+            <span>Lightweight, broad evaluation of recent language models</span>
+          </a>
+        </li>
+        <li>
+          <a href="https://crfm.stanford.edu/helm/classic/">
+            <strong>Classic:</strong>{" "}
+            <span>
+              Thorough language model evaluations based on the scenarios from
+              the original HELM paper
+            </span>
+          </a>
+        </li>
+        <li>
+          <a href="https://crfm.stanford.edu/heim/">
+            <strong>HEIM:</strong>{" "}
+            <span>Holistic evaluation of text-to-image models</span>
+          </a>
+        </li>
+        <li>
+          <a href="https://crfm.stanford.edu/helm/instruct/">
+            <strong>Instruct:</strong>{" "}
+            <span>
+              Evaluations of instruction following models with absolute ratings
+            </span>
+          </a>
+        </li>
+      </ul>
     </div>
   );
 }

--- a/helm-frontend/src/components/ReleaseDropdown.tsx
+++ b/helm-frontend/src/components/ReleaseDropdown.tsx
@@ -1,18 +1,43 @@
 import { useEffect, useState } from "react";
-import getBenchmarkRelease from "@/utils/getBenchmarkRelease";
 import getReleaseSummary from "@/services/getReleaseSummary";
 import ReleaseSummary from "@/types/ReleaseSummary";
-import getBenchmarkSuite from "@/utils/getBenchmarkSuite";
+import { ChevronDownIcon } from "@heroicons/react/24/solid";
+
+function getReleases(): string[] {
+  // TODO: Fetch this from a configuration file.
+  if (window.HELM_TYPE === "LITE") {
+    return ["v1.1.0", "v1.0.0"];
+  } else if (window.HELM_TYPE === "CLASSIC") {
+    return ["v0.4.0", "v0.3.0", "v0.2.4", "v0.2.3", "v0.2.2"];
+  } else if (window.HELM_TYPE === "HEIM") {
+    return ["v1.1.0", "v1.0.0"];
+  } else if (window.HELM_TYPE === "INSTRUCT") {
+    return ["v1.0.0"];
+  }
+  return [];
+}
+
+function getReleaseUrl(version: string): string {
+  // TODO: Fetch this from a configuration file.
+  if (window.HELM_TYPE === "LITE") {
+    return `https://crfm.stanford.edu/helm/lite/${version}/`;
+  } else if (window.HELM_TYPE === "CLASSIC") {
+    return `https://crfm.stanford.edu/helm/classic/${version}/`;
+  } else if (window.HELM_TYPE === "HEIM") {
+    return `https://crfm.stanford.edu/heim/${version}/`;
+  } else if (window.HELM_TYPE === "INSTRUCT") {
+    return `https://crfm.stanford.edu/helm/instruct/${version}/`;
+  }
+  return `https://crfm.stanford.edu/helm/lite/${version}/`;
+}
 
 function ReleaseDropdown() {
-  const [dropdownOpen, setDropdownOpen] = useState(false);
   const [summary, setSummary] = useState<ReleaseSummary>({
-    release: "",
-    suites: [],
+    release: undefined,
+    suites: undefined,
+    suite: undefined,
     date: "",
   });
-  const release = getBenchmarkRelease();
-  const suite = getBenchmarkSuite();
   useEffect(() => {
     const controller = new AbortController();
     async function fetchData() {
@@ -24,63 +49,45 @@ function ReleaseDropdown() {
     return () => controller.abort();
   }, []);
 
-  const accessibleReleases = ["v0.4.0", "v0.3.0", "v0.2.2"]; // this could also read from a config file in the future
+  const releases = getReleases();
+
+  const releaseInfo = `Release ${
+    summary.release || summary.suite || "unknown"
+  } (${summary.date})`;
+
+  if (releases.length <= 1) {
+    return <div>{releaseInfo}</div>;
+  }
 
   return (
-    <div>
-      <div className="inline-flex items-center">
-        {/* Chevron Button */}
-        <button
-          onClick={() => setDropdownOpen(!dropdownOpen)}
-          className="inline-flex items-center justify-center focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75"
-        >
-          <div>
-            {" "}
-            Release:{" "}
-            {(release == "null" || release == null ? suite : release) +
-              " : " +
-              summary.date}{" "}
-          </div>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            className="h-4 w-4 ml-2"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M19 9l-7 7-7-7"
-            />
-          </svg>
-        </button>
+    <div className="dropdown">
+      <div
+        tabIndex={0}
+        role="button"
+        className="normal-case bg-white border-0"
+        aria-haspopup="true"
+        aria-controls="menu"
+      >
+        {releaseInfo}{" "}
+        <ChevronDownIcon
+          fill="black"
+          color="black"
+          className="inline text w-4 h-4"
+        />
       </div>
-
-      {dropdownOpen && (
-        <div className="absolute mt-2 w-max translate-x-4 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5">
-          <div
-            className="py-1"
-            role="menu"
-            aria-orientation="vertical"
-            aria-labelledby="options-menu"
-          >
-            {accessibleReleases.map((currRelease) => (
-              <div
-                className="block px-4 py-2 text-md text-gray-700 hover:bg-gray-100 hover:text-gray-900"
-                role="menuitem"
-              >
-                <a href={"https://crfm.stanford.edu/helm/" + currRelease}>
-                  <div className="flex items-center">
-                    <span>{currRelease}</span>
-                  </div>
-                </a>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
+      <ul
+        tabIndex={0}
+        className="dropdown-content z-[1] menu p-1 shadow-lg bg-base-100 rounded-box w-max"
+        role="menu"
+      >
+        {releases.map((release) => (
+          <li>
+            <a href={getReleaseUrl(release)} className="block" role="menuitem">
+              {release}
+            </a>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/helm-frontend/src/components/ReleaseDropdown.tsx
+++ b/helm-frontend/src/components/ReleaseDropdown.tsx
@@ -14,7 +14,7 @@ function getReleases(): string[] {
   } else if (window.HELM_TYPE === "INSTRUCT") {
     return ["v1.0.0"];
   }
-  return [];
+  return ["v1.1.0", "v1.0.0"];
 }
 
 function getReleaseUrl(version: string): string {
@@ -77,7 +77,7 @@ function ReleaseDropdown() {
       </div>
       <ul
         tabIndex={0}
-        className="dropdown-content z-[1] menu p-1 shadow-lg bg-base-100 rounded-box w-max"
+        className="dropdown-content z-[1] menu p-1 shadow-lg bg-base-100 rounded-box w-max text-base"
         role="menu"
       >
         {releases.map((release) => (

--- a/helm-frontend/src/types/ReleaseSummary.ts
+++ b/helm-frontend/src/types/ReleaseSummary.ts
@@ -1,5 +1,6 @@
 export default interface ReleaseSummary {
-  release: string;
-  suites: string[];
+  release: string | undefined;
+  suites: string[] | undefined;
+  suite: string | undefined;
   date: string;
 }


### PR DESCRIPTION
- Switched to using DaisyUI's dropdown menu
- Improved accessibility by enabling keyboard tab navigation of dropdown menus
- Added closing of the menu by clicking outside the menu
- Moved HELM logo out of the dropdown component
- Used HELM logo in asset bundle rather than an external logo
- Fixed schema for `summary.json`
- Added HELM Instruct to dropdown
- Made version dropdown reflect versions of the current HELMet, rather than always displaying the Lite versions
- Only a render a dropdown menu if there are at least two versions i.e. don't render the menu for HELM Instruct
- Added previously missing HELM Classic versions
- Added new versions for HEIM and Lite

Fixes #2136

![Screenshot 2024-02-27 215914](https://github.com/stanford-crfm/helm/assets/185227/3ef7b771-27d5-4200-b34f-9dda63e182bb)
![Screenshot 2024-02-27 215921](https://github.com/stanford-crfm/helm/assets/185227/6e3b7298-3987-4bc3-a2f5-700c9da62c68)