### PR TITLE
Add src/helm/benchmark/static_build/ to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@ recursive-include src/helm/ py.typed
 recursive-include src/helm/tokenizers/ *.sp
 recursive-include src/helm/benchmark/ *.json
 recursive-include src/helm/benchmark/static/ *.css *.html *.js *.png *.yaml
+recursive-include src/helm/benchmark/static_build/ *.css *.html *.js *.png *.yaml
 recursive-include src/helm/config/ *.yaml


### PR DESCRIPTION
This is required for `helm-server` to serve the new React frontend when the `crfm-helm` package is installed from PyPI.