### PR TITLE
Fix frontend breakage

### DIFF
--- a/helm-frontend/src/services/getReleaseSummary.ts
+++ b/helm-frontend/src/services/getReleaseSummary.ts
@@ -14,6 +14,11 @@ export default async function getReleaseSummary(
     return (await summary.json()) as ReleaseSummary;
   } catch (error) {
     console.log(error);
-    return { release: undefined, suites: undefined, suite: undefined, date: "" };
+    return {
+      release: undefined,
+      suites: undefined,
+      suite: undefined,
+      date: "",
+    };
   }
 }

--- a/helm-frontend/src/services/getReleaseSummary.ts
+++ b/helm-frontend/src/services/getReleaseSummary.ts
@@ -14,6 +14,6 @@ export default async function getReleaseSummary(
     return (await summary.json()) as ReleaseSummary;
   } catch (error) {
     console.log(error);
-    return { release: "", suites: [], date: "" };
+    return { release: undefined, suites: undefined, suite: undefined, date: "" };
   }
 }


### PR DESCRIPTION
Fix a type error caused by #2410: `getReleaseSummary()` needs to follow the new `ReleaseSummary` schema.