### PR TITLE
Move yaml to its own Vite bundle

### DIFF
--- a/helm-frontend/vite.config.ts
+++ b/helm-frontend/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
           react: ["react", "react-dom", "react-markdown", "react-router-dom", "react-spinners"],
           tremor: ["@tremor/react"],
           recharts: ["recharts"],
+          yaml: ["yaml"],
         }
       }
     }


### PR DESCRIPTION
#2372 added the yaml library to the Vite build. This caused the build frontend diffs to go up from 8 lines in #2367 to 141 lines in #2398. Moving the yaml library to its own Vite bundle will reduce the diffs back to 8 lines.