### PR TITLE
Un-deprecate model field in schema

### DIFF
--- a/src/helm/benchmark/static/schema_classic.yaml
+++ b/src/helm/benchmark/static/schema_classic.yaml
@@ -45,7 +45,7 @@ adapter:
   - name: sample_train
     description: If true, randomly sample N training examples; if false, select N consecutive training examples
   - name: model
-    description: DEPRECATED. Name of the language model (<creator_organization>/<model name>) to send requests to.
+    description: Name of the language model (<creator_organization>/<model name>) to send requests to.
   - name: model_deployment
     description: Name of the language model (<host_organization>/<model name>) to send requests to.
   - name: temperature

--- a/src/helm/benchmark/static/schema_classic.yaml
+++ b/src/helm/benchmark/static/schema_classic.yaml
@@ -47,7 +47,7 @@ adapter:
   - name: model
     description: Name of the language model (<creator_organization>/<model name>) to send requests to.
   - name: model_deployment
-    description: Name of the language model (<host_organization>/<model name>) to send requests to.
+    description: Name of the language model deployment (<host_organization>/<model name>) to send requests to.
   - name: temperature
     description: Temperature parameter used in generation.
   - name: max_tokens

--- a/src/helm/benchmark/static/schema_instruction_following.yaml
+++ b/src/helm/benchmark/static/schema_instruction_following.yaml
@@ -40,7 +40,7 @@ adapter:
   - name: model
     description: Name of the language model (<creator_organization>/<model name>) to send requests to.
   - name: model_deployment
-    description: Name of the language model (<host_organization>/<model name>) to send requests to.
+    description: Name of the language model deployment (<host_organization>/<model name>) to send requests to.
   - name: temperature
     description: Temperature parameter used in generation.
   - name: max_tokens

--- a/src/helm/benchmark/static/schema_lite.yaml
+++ b/src/helm/benchmark/static/schema_lite.yaml
@@ -47,7 +47,7 @@ adapter:
   - name: sample_train
     description: If true, randomly sample N training examples; if false, select N consecutive training examples
   - name: model
-    description: DEPRECATED. Name of the language model (<creator_organization>/<model name>) to send requests to.
+    description: Name of the language model (<creator_organization>/<model name>) to send requests to.
   - name: model_deployment
     description: Name of the language model (<host_organization>/<model name>) to send requests to.
   - name: temperature

--- a/src/helm/benchmark/static/schema_lite.yaml
+++ b/src/helm/benchmark/static/schema_lite.yaml
@@ -49,7 +49,7 @@ adapter:
   - name: model
     description: Name of the language model (<creator_organization>/<model name>) to send requests to.
   - name: model_deployment
-    description: Name of the language model (<host_organization>/<model name>) to send requests to.
+    description: Name of the language model deployment (<host_organization>/<model name>) to send requests to.
   - name: temperature
     description: Temperature parameter used in generation.
   - name: max_tokens

--- a/src/helm/benchmark/static/schema_vlm.yaml
+++ b/src/helm/benchmark/static/schema_vlm.yaml
@@ -47,7 +47,7 @@ adapter:
   - name: sample_train
     description: If true, randomly sample N training examples; if false, select N consecutive training examples
   - name: model
-    description: DEPRECATED. Name of the language model (<creator_organization>/<model name>) to send requests to.
+    description: Name of the language model (<creator_organization>/<model name>) to send requests to.
   - name: model_deployment
     description: Name of the language model (<host_organization>/<model name>) to send requests to.
   - name: temperature

--- a/src/helm/benchmark/static/schema_vlm.yaml
+++ b/src/helm/benchmark/static/schema_vlm.yaml
@@ -49,7 +49,7 @@ adapter:
   - name: model
     description: Name of the language model (<creator_organization>/<model name>) to send requests to.
   - name: model_deployment
-    description: Name of the language model (<host_organization>/<model name>) to send requests to.
+    description: Name of the language model deployment (<host_organization>/<model name>) to send requests to.
   - name: temperature
     description: Temperature parameter used in generation.
   - name: max_tokens


### PR DESCRIPTION
The `model` field is not deprecated, and is semantically distinct from `model_deployments`.