### PR TITLE
Add workflow for scenario tests

### DIFF
--- a/.github/workflows/test_scenarios.yml
+++ b/.github/workflows/test_scenarios.yml
@@ -1,0 +1,32 @@
+name: Scenario tests
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'src/helm/benchmark/scenarios/test_*_scenario.py'
+  pull_request:
+    paths:
+      - 'src/helm/benchmark/scenarios/test_*_scenario.py'
+
+jobs:
+  test:
+    name: Run scenario tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+      - name: Clear free space
+        run: |
+            sudo rm -rf /opt/ghc
+            df -h
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      # Installs dependencies and performs static code checks
+      - name: Install HELM 
+        run: ./install-dev.sh && ./pre-commit.sh
+      - name: Run scenario tests
+        run: python3 -m pytest -m scenarios

--- a/setup.cfg
+++ b/setup.cfg
@@ -192,7 +192,7 @@ image2structure =
 
 heim =
     # HEIM scenarios
-    gdown~=4.4.0
+    gdown~=5.1
 
     # HEIM models
     diffusers~=0.24.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -304,9 +304,20 @@ exclude = dalle_mini|mindalle|open_flamingo
 
 [tool:pytest]
 addopts =
-    # By default, we don't test models because doing so will
-    # make real requests and spend real money
-    -m 'not models'
+    # By default:
+    # - we don't test models because doing so will
+    #   make real requests and spend real money
+    # - we don't test scenarios because these will
+    #   download files, which is slow, consumes disk
+    #   space, and increases the chance of spurious
+    #   test failures due to failed downloads.
+    #
+    # For more documentation on pytest markers, see:
+    # - https://docs.pytest.org/en/latest/how-to/mark.html#mark
+    # - https://docs.pytest.org/en/latest/example/markers.html#mark-examples
+    -m 'not models and not scenarios'
 markers =
-    # Marker for tests that make real model requests
+    # Marker for model tests that make real model requests
     models
+    # Marker for scenario tests that download files
+    scenarios

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ human-evaluation =
     surge-api~=1.1.0
 
 scenarios =
-    gdown~=4.4.0  # For disinformation_scenario, med_mcqa_scenario, med_qa_scenario: used by ensure_file_downloaded()
+    gdown~=5.1  # For disinformation_scenario, med_mcqa_scenario, med_qa_scenario: used by ensure_file_downloaded()
     sympy~=1.11.1  # For numeracy_scenario
     xlrd~=2.0.1  # For ice_scenario: used by pandas.read_excel()
 

--- a/src/helm/benchmark/scenarios/test_commonsense_scenario.py
+++ b/src/helm/benchmark/scenarios/test_commonsense_scenario.py
@@ -1,0 +1,21 @@
+import pytest
+from tempfile import TemporaryDirectory
+
+from helm.benchmark.scenarios.commonsense_scenario import OpenBookQA
+from helm.benchmark.scenarios.scenario import CORRECT_TAG, Input, Output, Reference
+
+
+@pytest.mark.scenarios
+def test_openbookqa_scenario():
+    scenario = OpenBookQA()
+    with TemporaryDirectory() as tmpdir:
+        instances = scenario.get_instances(tmpdir)
+    assert len(instances) == 5457
+    assert instances[0].input == Input(text="The sun is responsible for")
+    assert instances[0].references == [
+        Reference(output=Output(text="puppies learning new tricks"), tags=[]),
+        Reference(output=Output(text="children growing up and getting old"), tags=[]),
+        Reference(output=Output(text="flowers wilting in a vase"), tags=[]),
+        Reference(output=Output(text="plants sprouting, blooming and wilting"), tags=[CORRECT_TAG]),
+    ]
+    assert instances[0].split == "train"

--- a/src/helm/benchmark/scenarios/test_gsm_scenario.py
+++ b/src/helm/benchmark/scenarios/test_gsm_scenario.py
@@ -1,0 +1,31 @@
+import pytest
+from tempfile import TemporaryDirectory
+
+from helm.benchmark.scenarios.gsm_scenario import GSM8KScenario
+from helm.benchmark.scenarios.scenario import Input, Output, Reference
+
+
+@pytest.mark.scenarios
+def test_gsm_scenario_get_instances():
+    math_scenario = GSM8KScenario()
+    with TemporaryDirectory() as tmpdir:
+        actual_instances = math_scenario.get_instances(tmpdir)
+    assert len(actual_instances) == 8792
+    assert actual_instances[0].input == Input(
+        text=(
+            "Natalia sold clips to 48 of her friends in April, and then she sold half as many clips in May. How many"
+            " clips did Natalia sell altogether in April and May?"
+        )
+    )
+    assert actual_instances[0].references == [
+        Reference(
+            output=Output(
+                text=(
+                    "Natalia sold 48/2 = <<48/2=24>>24 clips in May. Natalia sold 48+24 = <<48+24=72>>72 clips"
+                    " altogether in April and May. The answer is 72."
+                )
+            ),
+            tags=["correct"],
+        )
+    ]
+    assert actual_instances[0].split == "train"

--- a/src/helm/benchmark/scenarios/test_legalbench_scenario.py
+++ b/src/helm/benchmark/scenarios/test_legalbench_scenario.py
@@ -1,0 +1,30 @@
+import pytest
+from tempfile import TemporaryDirectory
+
+from helm.benchmark.scenarios.legalbench_scenario import LegalBenchScenario
+from helm.benchmark.scenarios.scenario import CORRECT_TAG, Input, Output, Reference
+
+
+@pytest.mark.scenarios
+def test_legalbench_scenario():
+    scenario = LegalBenchScenario(subset="abercrombie")
+    with TemporaryDirectory() as tmpdir:
+        instances = scenario.get_instances(tmpdir)
+    assert len(instances) == 100
+    assert instances[0].input == Input(text='Description: The mark "Ivory" for a product made of elephant tusks.')
+    assert instances[0].references == [
+        Reference(output=Output(text="generic"), tags=["correct"]),
+    ]
+    assert instances[0].split == "train"
+
+    scenario = LegalBenchScenario(subset="proa")
+    with TemporaryDirectory() as tmpdir:
+        instances = scenario.get_instances(tmpdir)
+    assert len(instances) == 100
+    assert instances[0].input == Input(
+        text="Statute: Amendments to pleadings must be filed within 15 days of the filing of the initial pleading."
+    )
+    assert instances[0].references == [
+        Reference(output=Output(text="No"), tags=[CORRECT_TAG]),
+    ]
+    assert instances[0].split == "train"

--- a/src/helm/benchmark/scenarios/test_math_scenario.py
+++ b/src/helm/benchmark/scenarios/test_math_scenario.py
@@ -5,18 +5,12 @@ from helm.benchmark.scenarios.math_scenario import MATHScenario
 from helm.benchmark.scenarios.scenario import Input, Output, Reference
 
 
-# TODO: Fix the test for newer versions of diffusers: https://github.com/stanford-crfm/helm/issues/2168
-@pytest.mark.skip(
-    reason="Incompatible with newer versions with diffusers>0.24.0. Fails with "
-    '"Loading a dataset cached in a LocalFileSystem is not supported"'
-)
+@pytest.mark.scenarios
 def test_math_scenario_get_instances():
     math_scenario = MATHScenario(subject="number_theory", level="1")
     with TemporaryDirectory() as tmpdir:
         actual_instances = math_scenario.get_instances(tmpdir)
     assert len(actual_instances) == 77
     assert actual_instances[0].input == Input(text="What is the remainder when (99)(101) is divided by 9?")
-    assert actual_instances[0].references == [
-        Reference(output=Output(text="0", multimedia_content=None), tags=["correct"])
-    ]
+    assert actual_instances[0].references == [Reference(output=Output(text="0"), tags=["correct"])]
     assert actual_instances[0].split == "train"

--- a/src/helm/benchmark/scenarios/test_med_qa_scenario.py
+++ b/src/helm/benchmark/scenarios/test_med_qa_scenario.py
@@ -1,0 +1,30 @@
+import pytest
+from tempfile import TemporaryDirectory
+
+from helm.benchmark.scenarios.med_qa_scenario import MedQAScenario
+from helm.benchmark.scenarios.scenario import CORRECT_TAG, Input, Output, Reference
+
+
+@pytest.mark.scenarios
+def test_med_qa_scenario():
+    scenario = MedQAScenario()
+    with TemporaryDirectory() as tmpdir:
+        instances = scenario.get_instances(tmpdir)
+    assert len(instances) == 12723
+    assert instances[0].input == Input(
+        text=(
+            "A 23-year-old pregnant woman at 22 weeks gestation presents with burning upon urination. She states it"
+            " started 1 day ago and has been worsening despite drinking more water and taking cranberry extract. She"
+            " otherwise feels well and is followed by a doctor for her pregnancy. Her temperature is 97.7°F (36.5°C),"
+            " blood pressure is 122/77 mmHg, pulse is 80/min, respirations are 19/min, and oxygen saturation is 98% on"
+            " room air. Physical exam is notable for an absence of costovertebral angle tenderness and a gravid uterus."
+            " Which of the following is the best treatment for this patient?"
+        )
+    )
+    assert instances[0].references == [
+        Reference(output=Output(text="Ampicillin"), tags=[]),
+        Reference(output=Output(text="Ceftriaxone"), tags=[]),
+        Reference(output=Output(text="Doxycycline"), tags=[]),
+        Reference(output=Output(text="Nitrofurantoin"), tags=[CORRECT_TAG]),
+    ]
+    assert instances[0].split == "train"

--- a/src/helm/benchmark/scenarios/test_mmlu_scenario.py
+++ b/src/helm/benchmark/scenarios/test_mmlu_scenario.py
@@ -1,0 +1,33 @@
+import pytest
+from tempfile import TemporaryDirectory
+
+from helm.benchmark.scenarios.mmlu_scenario import MMLUScenario
+from helm.benchmark.scenarios.scenario import CORRECT_TAG, Input, Output, Reference
+
+
+@pytest.mark.scenarios
+def test_mmlu_scenario():
+    with TemporaryDirectory() as tmpdir:
+        scenario = MMLUScenario(subject="abstract_algebra")
+        instances = scenario.get_instances(tmpdir)
+        assert len(instances) == 116
+        assert instances[0].input == Input(text="Find all c in Z_3 such that Z_3[x]/(x^2 + c) is a field.")
+        assert instances[0].references == [
+            Reference(output=Output(text="0"), tags=[]),
+            Reference(output=Output(text="1"), tags=[CORRECT_TAG]),
+            Reference(output=Output(text="2"), tags=[]),
+            Reference(output=Output(text="3"), tags=[]),
+        ]
+        assert instances[0].split == "train"
+
+        scenario = MMLUScenario(subject="anatomy")
+        instances = scenario.get_instances(tmpdir)
+        assert len(instances) == 154
+        assert instances[0].input == Input(text="What is the embryological origin of the hyoid bone?")
+        assert instances[0].references == [
+            Reference(output=Output(text="The first pharyngeal arch"), tags=[]),
+            Reference(output=Output(text="The first and second pharyngeal arches"), tags=[]),
+            Reference(output=Output(text="The second pharyngeal arch"), tags=[]),
+            Reference(output=Output(text="The second and third pharyngeal arches"), tags=[CORRECT_TAG]),
+        ]
+        assert instances[0].split == "train"

--- a/src/helm/benchmark/scenarios/test_narrativeqa_scenario.py
+++ b/src/helm/benchmark/scenarios/test_narrativeqa_scenario.py
@@ -1,0 +1,73 @@
+import pytest
+from tempfile import TemporaryDirectory
+
+from helm.benchmark.scenarios.narrativeqa_scenario import NarrativeQAScenario
+from helm.benchmark.scenarios.scenario import CORRECT_TAG, Output, Reference
+
+
+@pytest.mark.scenarios
+def test_narrativeqa_scenario():
+    scenario = NarrativeQAScenario()
+    with TemporaryDirectory() as tmpdir:
+        instances = scenario.get_instances(tmpdir)
+    assert len(instances) == 1572
+    assert (
+        instances[0].input.text
+        == "At Madeline Hall, an old mansion-house near Southampton belonging to the wealthy de Versely family, lives"
+        " an elderly spinster Miss Delmar, the aunt of the earl de Versely and Captain Delmar. Miss Delmar invites"
+        " Arabella Mason, the daughter of a deceased, well-liked steward to stay with her as a lower-class guest in"
+        " the house. Captain Delmar is known to visit his aunt at Madeline Hall frequently, accompanied by his"
+        " valet Ben Keene, who is also a private marine. Captain Delmar eventually suggests that Ben should propose"
+        " to Arabella, and the two marry in secret, to the frustration of Miss Delmar and Arabella's mother. The"
+        " captain is able to smooth over the situation with his aunt, even after it is discovered that Arabella was"
+        " six months pregnant at the time of the marriage. She later gives birth to a boy, who takes the Captain's"
+        " Christian name and Ben's surname--the titular Percival Keene.\nThe family moves to Chatham, after Ben is"
+        " ordered back with his detachment. Arabella opens up a successful shop and circulating library below her"
+        " house, enlisting the help of her mother and sister, Amelia. Percival becomes well known in town from his"
+        " mischievous pranks on officers and other strangers, often encouraged by his aunt Amelia. However,"
+        " Percival's mother and grandmother are less fond of his disregard for manners, and insist on sending him"
+        " to school after an episode in which he bites his grandmother. Percival reports to the school house of Mr."
+        " O'Gallagher, a poor Irish scholar, who rules his class with a system of severe corporal punishment. Mr."
+        " O'Gallagher routinely bullies Percival by stealing his lunch, leading Percival to seek revenge by"
+        " poisoning his sandwiches with calomel. On Guy Fawkes Day the schoolteacher confiscates all the"
+        " schoolboys' fireworks, for which Percival retaliates by setting off the collected fireworks while the"
+        " teacher sits above them, leading to the total destruction of the schoolhouse and near death of the"
+        " schoolmaster.\nWhen Percival is a young teenager, Captain Delmar reappears and offers him a position"
+        " aboard his new navy ship, the H.M. Calliope. While preparing to enter service, Percival overhears gossip"
+        " of his illegitimate birth, introducing the idea that Captain Delmar may be his father. He confronts his"
+        " mother about his parentage, which she at first harshly denies but later tearfully explains the truth of"
+        " her affair. Early in his service in the navy, Percival is captured during a pirate raid along with"
+        " others. The pirate crew is entirely black, and the captain explains that they are primarily escaped"
+        " slaves from the Americas. Percival is taken in as a cabin boy, and later dyes his skin tan in the"
+        " appearance of a mulatto to please the captain who doesn't approve of white skin. The pirates often seek"
+        " to take over slave trading vessels, killing every white person on board. During the taking of one such"
+        " vessel, Percival is able is convince the captain to spare the lives of a wealthy Dutch merchant and his"
+        " young daughter, Minnie. Eventually the H.M. Calliope takes the pirate ship, and Percival--unrecognizable"
+        " with his dyed skin--is taken as a prisoner, later to convince his fellow shipman of his true"
+        " identity.\nAfter his reappearance aboard the ship, Percival gains esteem among the crew and is welcomed"
+        " back by the emotional Captain Delmar. His reputation continues to grow over the course of his service in"
+        " conflicts with Dutch and French vessels around the island of Curacao. He also stands in for an ill"
+        " Captain Delmar in a duel with a French officer, effectively saving the captain's life. At this point, the"
+        " captain receives news that his older brother has died, making him the new Lord de Versely, and before"
+        " returning to England he grants Perceval command of his own schooner. After another intense but successful"
+        " battle with a French war ship, Percival is promoted to captain. During his service in the Navy, Percival"
+        " still partakes in the merry pranks of his youth, and at one point teams up with a mulatto hotel owner in"
+        " Curaรงao to convince his fellow officers they've been poisoned. He also keeps correspondence with Minnie,"
+        " developing a romance with the beautiful heiress.\nNear the end of the story, Percival guides his crew"
+        " through a terrible storm in which many of the crew are killed and the ship is heavily damaged. After"
+        " being saved by another English vessel, he receives a letter informing him of Lord de Versely's sudden"
+        " death from heart complications and learns that he has been left all of his personal property. Percival is"
+        " still disappointed that he can not take his father's name. He later journey's with his friend Bob Cross"
+        " to Hamburg to reunite with Minnie, but is captured by French troops on the road and sentenced to"
+        " execution for spying. During a skirmish between the French and the Cossacks, Percival and Cross are able"
+        " to escape and continue on the road. At the end of the novel, Percival proposes to Minnie, and stands to"
+        " inherit a great fortune through her father. He also receives a letter from the de Versely attorney"
+        " letting him know he has been granted the arms and name of Delmar.\nQuestion: Who did Percival reunited"
+        " with?"
+    )
+
+    assert instances[0].references == [
+        Reference(output=Output(text="Minnie"), tags=[CORRECT_TAG]),
+        Reference(output=Output(text="minnie"), tags=[CORRECT_TAG]),
+    ]
+    assert instances[0].split == "train"


### PR DESCRIPTION
Changes:

- Added a new pytest mark for scenario tests
- Excluded scenario tests from the default test workflow
- Add new scenario test workflow to run scenario tests when a scenario test is added or modified
- Added scenario tests for most HELM Lite scenarios
- Upgrade gdown to fix MedQA scenario breakage

Proposed new policy: Any new text-completion-only scenario _must_ be accompanied with a unit test.