### PR TITLE
Remove support for schema.yaml in the React frontend

### DIFF
--- a/helm-frontend/package.json
+++ b/helm-frontend/package.json
@@ -25,7 +25,6 @@
     "react-spinners": "^0.13.8",
     "recharts": "^2.7.2",
     "serve-static": "^1.15.0",
-    "yaml": "^2.3.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.17.0",

--- a/helm-frontend/package.json
+++ b/helm-frontend/package.json
@@ -24,7 +24,7 @@
     "react-router-dom": "^6.14.2",
     "react-spinners": "^0.13.8",
     "recharts": "^2.7.2",
-    "serve-static": "^1.15.0",
+    "serve-static": "^1.15.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.17.0",

--- a/helm-frontend/src/services/getSchema.ts
+++ b/helm-frontend/src/services/getSchema.ts
@@ -1,8 +1,6 @@
-import { parse } from "yaml";
 import type Schema from "@/types/Schema";
 import getBenchmarkEndpoint from "@/utils/getBenchmarkEndpoint";
 import getVersionBaseUrl from "@/utils/getVersionBaseUrl";
-import getBenchmarkSuite from "@/utils/getBenchmarkSuite";
 
 export default async function getSchema(signal: AbortSignal): Promise<Schema> {
   try {
@@ -13,30 +11,14 @@ export default async function getSchema(signal: AbortSignal): Promise<Schema> {
 
     return (await resp.json()) as Schema;
   } catch (error) {
-    // Fallback to schema.yaml if schema.json is not found since some HELMets do not have schema.json
-    try {
-      let url = getBenchmarkEndpoint(`${getVersionBaseUrl()}/`) + `schema.yaml`;
-
-      // if suite appears before benchmark_output, we need to replace that part of the url (since it means suite appears twice)
-      const suite = getBenchmarkSuite();
-      if (suite && url.includes(suite + "/benchmark_output/runs/")) {
-        url = url.replace(suite + "/benchmark_output/runs/", "");
-      }
-
-      const resp = await fetch(url, { signal });
-      const data = await resp.text();
-      const schema = parse(data) as Schema;
-      return schema;
-    } catch (error) {
-      console.log(error);
-      return {
-        adapter: [],
-        metric_groups: [],
-        metrics: [],
-        models: [],
-        perturbations: [],
-        run_groups: [],
-      } as Schema;
-    }
+    console.log(error);
+    return {
+      adapter: [],
+      metric_groups: [],
+      metrics: [],
+      models: [],
+      perturbations: [],
+      run_groups: [],
+    } as Schema;
   }
 }

--- a/helm-frontend/yarn.lock
+++ b/helm-frontend/yarn.lock
@@ -5444,7 +5444,7 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@^2.1.1, yaml@^2.3.1:
+yaml@^2.1.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.2.tgz#f522db4313c671a0ca963a75670f1c12ea909144"
   integrity sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==


### PR DESCRIPTION
Everyone using the new frontend should be using `schema.json` instead.