### PR TITLE
Update releaseIndex.json

### DIFF
--- a/helm-frontend/public/releaseIndex.json
+++ b/helm-frontend/public/releaseIndex.json
@@ -1,13 +1,13 @@
 [
 	{
 		"title": "Lite",
-		"description": "Thorough language model evaluations based on the scenarios from the original HELM paper",
+		"description": "Lightweight, broad evaluation of the capabilities of language models using in-context learning",
 		"id": "lite",
-		"releases": ["v1.0.0"]
+		"releases": ["v1.1.0", "v1.0.0"]
 	},
 	{
 		"title": "Classic",
-		"description": "Lightweight, broad evaluation of the capabilities of language models using in-context learning",
+		"description": "Thorough language model evaluations based on the scenarios from the original HELM paper",
 		"id": "classic",
 		"releases": ["v0.4.0", "v0.3.0", "v0.2.4", "v0.2.3", "v0.2.2"]
 	},
@@ -21,6 +21,6 @@
 		"title": "Instruct",
 		"description": "Evaluations of instruction following models with absolute ratings",
 		"id": "instruct",
-		"releases": ["v1.1.0", "v1.0.0"]
+		"releases": ["v1.0.0"]
 	}
 ]


### PR DESCRIPTION
I was trying to write a script that downloads latest HELM results and I found some issues with the release index:
- Lite v1.1.0 is present on the website, but not in `releaseIndex.json`
- Instruct v1.1.0 is present in `releaseIndex.json`, but returns a 404 on the website
- The descriptions of Lite and Classic appear to be switched

This PR proposes a fix to the above.