### PR TITLE
Fix dropdown bugs

### DIFF
--- a/helm-frontend/public/config.js
+++ b/helm-frontend/public/config.js
@@ -1,5 +1,5 @@
 window.SUITE = null;
-window.RELEASE = "v0.4.0";
+window.RELEASE = "v1.0.0";
 window.BENCHMARK_OUTPUT_BASE_URL =
-  "https://storage.googleapis.com/crfm-helm-public/benchmark_output/";
-window.RELEASE_INDEX_ID = "classic";
+  "https://storage.googleapis.com/crfm-helm-public/lite/benchmark_output/";
+window.RELEASE_INDEX_ID = "lite";

--- a/helm-frontend/public/config.js
+++ b/helm-frontend/public/config.js
@@ -1,5 +1,5 @@
 window.SUITE = null;
-window.RELEASE = "v1.0.0";
+window.RELEASE = "v0.4.0";
 window.BENCHMARK_OUTPUT_BASE_URL =
-	"https://storage.googleapis.com/crfm-helm-public/lite/benchmark_output/";
-window.RELEASE_INDEX_ID = "lite";
+  "https://storage.googleapis.com/crfm-helm-public/benchmark_output/";
+window.RELEASE_INDEX_ID = "classic";

--- a/helm-frontend/src/components/NavBar/NavBar.test.tsx
+++ b/helm-frontend/src/components/NavBar/NavBar.test.tsx
@@ -11,6 +11,6 @@ test("displays nav bar", () => {
   );
 
   expect(screen.getByRole("navigation")).toHaveTextContent(
-    "LeaderboardModelsScenariosPredictionsGitHubLite LeaderboardModelsScenariosPredictionsGitHubRelease unknown ()",
+    "LeaderboardModelsScenariosPredictionsGitHubLeaderboardModelsScenariosPredictionsGitHub",
   );
 });

--- a/helm-frontend/src/components/NavDropdown.tsx
+++ b/helm-frontend/src/components/NavDropdown.tsx
@@ -45,12 +45,16 @@ function NavDropdown() {
       <div
         tabIndex={0}
         role="button"
-        className="btn normal-case bg-white font-bold p-2 border-0 text-lg"
+        className="btn normal-case bg-white font-bold p-2 border-0 text-lg block whitespace-nowrap"
         aria-haspopup="true"
         aria-controls="menu"
       >
-        {currReleaseIndexEntry.title}
-        <ChevronDownIcon fill="black" color="black" className="text w-4 h-4" />
+        {currReleaseIndexEntry.title}&nbsp;
+        <ChevronDownIcon
+          fill="black"
+          color="black"
+          className="text w-4 h-4 inline"
+        />
       </div>
       <ul
         tabIndex={0}

--- a/helm-frontend/src/components/NavDropdown.tsx
+++ b/helm-frontend/src/components/NavDropdown.tsx
@@ -33,11 +33,11 @@ function NavDropdown() {
       });
   }, []);
 
-  function getCurrentSubsite(): string {
-    return currReleaseIndexEntry !== undefined &&
-      currReleaseIndexEntry.title !== undefined
-      ? currReleaseIndexEntry.title
-      : "Lite";
+  if (
+    currReleaseIndexEntry === undefined ||
+    currReleaseIndexEntry.title === undefined
+  ) {
+    return null;
   }
 
   return (
@@ -49,7 +49,7 @@ function NavDropdown() {
         aria-haspopup="true"
         aria-controls="menu"
       >
-        {getCurrentSubsite()}{" "}
+        {currReleaseIndexEntry.title}
         <ChevronDownIcon fill="black" color="black" className="text w-4 h-4" />
       </div>
       <ul
@@ -60,7 +60,7 @@ function NavDropdown() {
         {releaseIndex.map((item, index) => (
           <li key={index}>
             <a
-              href={getReleaseUrl(item.id, item)}
+              href={getReleaseUrl(undefined, item)}
               className="block"
               role="menuitem"
             >

--- a/helm-frontend/src/components/ReleaseDropdown.tsx
+++ b/helm-frontend/src/components/ReleaseDropdown.tsx
@@ -77,11 +77,11 @@ function ReleaseDropdown() {
       <div
         tabIndex={0}
         role="button"
-        className="normal-case bg-white border-0"
+        className="normal-case bg-white border-0 block whitespace-nowrap"
         aria-haspopup="true"
         aria-controls="menu"
       >
-        {releaseInfo}{" "}
+        {releaseInfo}&nbsp;
         <ChevronDownIcon
           fill="black"
           color="black"

--- a/helm-frontend/src/components/ReleaseDropdown.tsx
+++ b/helm-frontend/src/components/ReleaseDropdown.tsx
@@ -60,9 +60,13 @@ function ReleaseDropdown() {
 
   const releases = getReleases();
 
-  const releaseInfo = `Release ${
-    summary.release || summary.suite || "unknown"
-  } (${summary.date})`;
+  if (!summary.release && !summary.suite) {
+    return null;
+  }
+
+  const releaseInfo = `Release ${summary.release || summary.suite} (${
+    summary.date
+  })`;
 
   if (releases.length <= 1) {
     return <div>{releaseInfo}</div>;

--- a/helm-frontend/src/utils/getReleaseUrl.ts
+++ b/helm-frontend/src/utils/getReleaseUrl.ts
@@ -1,11 +1,14 @@
 import ReleaseIndexEntry from "@/types/ReleaseIndexEntry";
 
 export default function getReleaseUrl(
-  version: string,
+  version: string | undefined,
   currReleaseIndexEntry: ReleaseIndexEntry | undefined,
 ): string {
-  return currReleaseIndexEntry !== undefined &&
-    currReleaseIndexEntry.id !== undefined
-    ? `https://crfm.stanford.edu/helm/${currReleaseIndexEntry.id}/${version}/`
-    : `https://crfm.stanford.edu/helm/lite/${version}/`;
+  if (!currReleaseIndexEntry) {
+    return "#";
+  }
+  if (!version) {
+    return `https://crfm.stanford.edu/helm/${currReleaseIndexEntry.id}/`;
+  }
+  return `https://crfm.stanford.edu/helm/${currReleaseIndexEntry.id}/`;
 }


### PR DESCRIPTION
- Fix links in the project dropdown. Previously the URLs were incorrect because they contained the project name twice (e.g. https://crfm.stanford.edu/helm/lite/lite/ )
- Prevent the dropdown from briefly flashing "Lite" and "Version unknown" respectively before `summary.json` is loaded.
- Prevent dropdown arrow from wrapping to a newline