### PR TITLE
Add simple scenarios for tutorials

### DIFF
--- a/src/helm/benchmark/adaptation/adapters/test_generation_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/test_generation_adapter.py
@@ -11,7 +11,7 @@ from helm.benchmark.scenarios.scenario import (
     Input,
     Output,
 )
-from helm.benchmark.run_specs.classic_run_specs import get_simple1_spec
+from helm.benchmark.run_specs.simple_run_specs import get_simple1_spec
 from helm.benchmark.adaptation.prompt import Prompt
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from .adapter_factory import AdapterFactory, ADAPT_GENERATION

--- a/src/helm/benchmark/run_specs/classic_run_specs.py
+++ b/src/helm/benchmark/run_specs/classic_run_specs.py
@@ -48,34 +48,6 @@ from helm.benchmark.scenarios.scenario import ScenarioSpec, get_scenario_cache_p
 from helm.common.hierarchical_logger import hlog, htrack
 
 
-@run_spec_function("simple1")
-def get_simple1_spec() -> RunSpec:
-    """A run spec for debugging."""
-    scenario_spec = ScenarioSpec(
-        class_name="helm.benchmark.scenarios.simple_scenarios.Simple1Scenario",
-        args={"num_input_tokens": 5, "vocab_size": 20, "num_train_instances": 10, "num_test_instances": 10},
-    )
-    adapter_spec = AdapterSpec(
-        method=ADAPT_GENERATION,
-        instructions="Please solve the following problem.\n",
-        max_train_instances=5,
-        max_eval_instances=10,
-        num_outputs=3,
-        num_train_trials=3,
-        model="simple/model1",
-        model_deployment="simple/model1",
-        temperature=1,
-        stop_sequences=["."],
-    )
-    return RunSpec(
-        name="simple1",
-        scenario_spec=scenario_spec,
-        adapter_spec=adapter_spec,
-        metric_specs=get_basic_generation_metric_specs([]) + get_generic_metric_specs(),
-        groups=[],
-    )
-
-
 @run_spec_function("bbq")
 def get_bbq_spec(subject: str, method: str = ADAPT_MULTIPLE_CHOICE_JOINT) -> RunSpec:
     scenario_spec = ScenarioSpec(

--- a/src/helm/benchmark/run_specs/simple_run_specs.py
+++ b/src/helm/benchmark/run_specs/simple_run_specs.py
@@ -1,0 +1,100 @@
+"""Run spec functions for tutorials and for debugging."""
+
+from helm.benchmark.adaptation.adapter_spec import (
+    ADAPT_GENERATION,
+    AdapterSpec,
+)
+from helm.benchmark.adaptation.common_adapter_specs import get_multiple_choice_joint_adapter_spec
+from helm.benchmark.metrics.common_metric_specs import (
+    get_basic_generation_metric_specs,
+    get_exact_match_metric_specs,
+    get_generic_metric_specs,
+    get_open_ended_generation_metric_specs,
+)
+from helm.benchmark.run_spec import RunSpec, run_spec_function
+from helm.benchmark.scenarios.scenario import ScenarioSpec
+
+
+@run_spec_function("simple_mcqa")
+def get_simple_mcqa_run_spec() -> RunSpec:
+    scenario_spec = ScenarioSpec(class_name="helm.benchmark.scenarios.simple_scenarios.SimpleMCQAScenario")
+    adapter_spec = get_multiple_choice_joint_adapter_spec(
+        instructions="Answer the following questions with a single letter only.",
+        input_noun="Question",
+        output_noun="Answer",
+    )
+    metric_specs = get_exact_match_metric_specs()
+    return RunSpec(
+        name="simple_mcqa",
+        scenario_spec=scenario_spec,
+        adapter_spec=adapter_spec,
+        metric_specs=metric_specs,
+        groups=["simple_mcqa"],
+    )
+
+
+@run_spec_function("simple_short_answer_qa")
+def get_simple_short_answer_qa_run_spec() -> RunSpec:
+    scenario_spec = ScenarioSpec(class_name="helm.benchmark.scenarios.simple_scenarios.SimpleShortAnswerQAScenario")
+    adapter_spec = get_multiple_choice_joint_adapter_spec(
+        instructions="Answer the following questions with a single word only.",
+        input_noun="Question",
+        output_noun="Answer",
+    )
+    # NOTE: Open ended generation metrics measure the amount of overlap
+    # (e.g. ROUGE, BLEU, F1 word overlap) between the generated output
+    # and the correct reference outputs.
+    metric_specs = get_open_ended_generation_metric_specs()
+    return RunSpec(
+        name="simple_short_answer_qa",
+        scenario_spec=scenario_spec,
+        adapter_spec=adapter_spec,
+        metric_specs=metric_specs,
+        groups=["simple_short_answer_qa"],
+    )
+
+
+@run_spec_function("simple_classification")
+def get_simple_classification_run_spec() -> RunSpec:
+    scenario_spec = ScenarioSpec(class_name="helm.benchmark.scenarios.simple_scenarios.SimpleClassificationScenario")
+    adapter_spec = get_multiple_choice_joint_adapter_spec(
+        instructions="Answer the following questions with a single word only.",
+        input_noun="Question",
+        output_noun="Answer",
+    )
+    metric_specs = get_exact_match_metric_specs()
+    return RunSpec(
+        name="simple_classification",
+        scenario_spec=scenario_spec,
+        adapter_spec=adapter_spec,
+        metric_specs=metric_specs,
+        groups=["simple_classification"],
+    )
+
+
+@run_spec_function("simple1")
+def get_simple1_spec() -> RunSpec:
+    """A run spec for debugging."""
+    scenario_spec = ScenarioSpec(
+        class_name="helm.benchmark.scenarios.simple_scenarios.Simple1Scenario",
+        args={"num_input_tokens": 5, "vocab_size": 20, "num_train_instances": 10, "num_test_instances": 10},
+    )
+    adapter_spec = AdapterSpec(
+        method=ADAPT_GENERATION,
+        instructions="Please solve the following problem.\n",
+        max_train_instances=5,
+        max_eval_instances=10,
+        num_outputs=3,
+        num_train_trials=3,
+        model="simple/model1",
+        model_deployment="simple/model1",
+        temperature=1,
+        stop_sequences=["."],
+    )
+    return RunSpec(
+        name="simple1",
+        scenario_spec=scenario_spec,
+        adapter_spec=adapter_spec,
+        metric_specs=get_basic_generation_metric_specs([]) + get_generic_metric_specs(),
+        groups=[],
+    )

--- a/src/helm/benchmark/run_specs/simple_run_specs.py
+++ b/src/helm/benchmark/run_specs/simple_run_specs.py
@@ -4,9 +4,13 @@ from helm.benchmark.adaptation.adapter_spec import (
     ADAPT_GENERATION,
     AdapterSpec,
 )
-from helm.benchmark.adaptation.common_adapter_specs import get_multiple_choice_joint_adapter_spec
+from helm.benchmark.adaptation.common_adapter_specs import (
+    get_generation_adapter_spec,
+    get_multiple_choice_joint_adapter_spec,
+)
 from helm.benchmark.metrics.common_metric_specs import (
     get_basic_generation_metric_specs,
+    get_classification_metric_specs,
     get_exact_match_metric_specs,
     get_generic_metric_specs,
     get_open_ended_generation_metric_specs,
@@ -36,7 +40,7 @@ def get_simple_mcqa_run_spec() -> RunSpec:
 @run_spec_function("simple_short_answer_qa")
 def get_simple_short_answer_qa_run_spec() -> RunSpec:
     scenario_spec = ScenarioSpec(class_name="helm.benchmark.scenarios.simple_scenarios.SimpleShortAnswerQAScenario")
-    adapter_spec = get_multiple_choice_joint_adapter_spec(
+    adapter_spec = get_generation_adapter_spec(
         instructions="Answer the following questions with a single word only.",
         input_noun="Question",
         output_noun="Answer",
@@ -57,12 +61,12 @@ def get_simple_short_answer_qa_run_spec() -> RunSpec:
 @run_spec_function("simple_classification")
 def get_simple_classification_run_spec() -> RunSpec:
     scenario_spec = ScenarioSpec(class_name="helm.benchmark.scenarios.simple_scenarios.SimpleClassificationScenario")
-    adapter_spec = get_multiple_choice_joint_adapter_spec(
-        instructions="Answer the following questions with a single word only.",
-        input_noun="Question",
-        output_noun="Answer",
+    adapter_spec = get_generation_adapter_spec(
+        instructions='Classify the following numbers by their parity. The classes are "Even" and "Odd".',
+        input_noun="Number",
+        output_noun="Parity",
     )
-    metric_specs = get_exact_match_metric_specs()
+    metric_specs = get_exact_match_metric_specs() + get_classification_metric_specs()
     return RunSpec(
         name="simple_classification",
         scenario_spec=scenario_spec,

--- a/src/helm/benchmark/scenarios/simple_scenarios.py
+++ b/src/helm/benchmark/scenarios/simple_scenarios.py
@@ -1,7 +1,128 @@
+"""Simple scenarios for debugging and for tutorials.
+
+NOTE: Typically, each scenario should be in its own file,
+but these scenarios are placed in the same module for
+tutorial purposes."""
+
 import random
 from typing import List
 
-from .scenario import Scenario, Instance, Reference, TRAIN_SPLIT, TEST_SPLIT, CORRECT_TAG, Input, Output
+from helm.benchmark.scenarios.scenario import (
+    Scenario,
+    Instance,
+    Reference,
+    TRAIN_SPLIT,
+    TEST_SPLIT,
+    CORRECT_TAG,
+    Input,
+    Output,
+)
+
+
+class SimpleMCQAScenario(Scenario):
+    """Simple multiple-choice question answering scenario for tutorials and debugging.
+
+    The task is to answer questions about whether two-digit numbers are even or odd.
+
+    Example:
+
+        Answer the following questions with a single letter only.
+
+        Question: Is 24 even or odd?
+        A. Even
+        B. Odd
+        Answer: A"""
+
+    name = "simple_mcqa"
+    description = "Answer if two-digit numbers are even or odd."
+    tags = ["question answering"]
+
+    def get_instances(self, output_path: str) -> List[Instance]:
+        instances: List[Instance] = []
+        for i in range(10, 100):
+            # NOTE: For simplicity, the input text and reference output text
+            # is the same for all instances.
+            # However, for most question answering scenarios, the input text
+            # and reference output text can vary between questions.
+            input = Input(text=f"Is {i} even or odd?")
+            references = [
+                Reference(Output(text="Even"), tags=[CORRECT_TAG] if i % 2 == 0 else []),
+                Reference(Output(text="Odd"), tags=[CORRECT_TAG] if i % 2 == 1 else []),
+            ]
+            split = TRAIN_SPLIT if i <= 20 else TEST_SPLIT
+            instance = Instance(input=input, references=references, split=split)
+            instances.append(instance)
+        return instances
+
+
+class SimpleShortAnswerQAScenario(Scenario):
+    """Simple short answer question answering scenario for tutorials and debugging.
+
+    The task is to answer questions about whether two-digit numbers are even or odd.
+
+    Example:
+
+        Answer the following questions with a single word only.
+
+        Question: Is 24 even or odd?
+        Answer: Even"""
+
+    name = "simple_mcqa"
+    description = "Answer if two-digit numbers are even or odd."
+    tags = ["question answering"]
+
+    def get_instances(self, output_path: str) -> List[Instance]:
+        instances: List[Instance] = []
+        for i in range(10, 100):
+            # NOTE: For simplicity, the input text and reference output text
+            # is the same for all instances.
+            # However, for most question answering scenarios, the input text
+            # and reference output text can vary between questions.
+            input = Input(text=f"Is {i} even or odd?")
+            correct_answer = "Even" if i % 2 == 0 else "Odd"
+            # NOTE: Unlike multiple-choice question answering, only the correct
+            # references are needed for short-answer question answering.
+            references = [
+                Reference(Output(text=correct_answer), tags=[CORRECT_TAG]),
+            ]
+            split = TRAIN_SPLIT if i <= 20 else TEST_SPLIT
+            instance = Instance(input=input, references=references, split=split)
+            instances.append(instance)
+        return instances
+
+
+class SimpleClassificationScenario(Scenario):
+    """Simple multiple-choice question answering scenario for tutorials and debugging.
+
+    The task is to classify two-digit numbers as even or odd.
+
+    Example:
+
+        Classify the following numbers by their pairity. The classes are "Even" and "Odd".
+
+        Number: 24
+        Pairity: Even"""
+
+    name = "simple_classification"
+    description = "Classify numbers by pairity."
+    tags = ["classification"]
+
+    def get_instances(self, output_path: str) -> List[Instance]:
+        instances: List[Instance] = []
+        for i in range(10, 100):
+            input = Input(text=str(i))
+            # NOTE: For classification scenarios, the reference outputs should be the same
+            # for all instances, and should include both correct and incorrect classes.
+            # HELM only supports single-label classification. Exactly one reference
+            # should have the CORRECT_TAG tag.
+            references = [
+                Reference(Output(text="Even"), tags=[CORRECT_TAG] if i % 2 == 0 else []),
+                Reference(Output(text="Odd"), tags=[CORRECT_TAG] if i % 2 == 1 else []),
+            ]
+            split = TRAIN_SPLIT if i <= 20 else TEST_SPLIT
+            instance = Instance(input=input, references=references, split=split)
+            instances.append(instance)
+        return instances
 
 
 class Simple1Scenario(Scenario):

--- a/src/helm/benchmark/scenarios/test_simple_scenarios.py
+++ b/src/helm/benchmark/scenarios/test_simple_scenarios.py
@@ -1,0 +1,50 @@
+import pytest
+from tempfile import TemporaryDirectory
+
+from helm.benchmark.scenarios.simple_scenarios import (
+    SimpleMCQAScenario,
+    SimpleShortAnswerQAScenario,
+    SimpleClassificationScenario,
+)
+from helm.benchmark.scenarios.scenario import CORRECT_TAG, Input, Output, Reference
+
+
+@pytest.mark.scenarios
+def test_simple_mcqa_scenario():
+    scenario = SimpleMCQAScenario()
+    with TemporaryDirectory() as tmpdir:
+        instances = scenario.get_instances(tmpdir)
+    assert len(instances) == 90
+    assert instances[0].input == Input(text="Is 10 even or odd?")
+    assert instances[0].references == [
+        Reference(output=Output(text="Even"), tags=[CORRECT_TAG]),
+        Reference(output=Output(text="Odd"), tags=[]),
+    ]
+    assert instances[0].split == "train"
+
+
+@pytest.mark.scenarios
+def test_simple_short_answer_qa_scenario():
+    scenario = SimpleShortAnswerQAScenario()
+    with TemporaryDirectory() as tmpdir:
+        instances = scenario.get_instances(tmpdir)
+    assert len(instances) == 90
+    assert instances[0].input == Input(text="Is 10 even or odd?")
+    assert instances[0].references == [
+        Reference(output=Output(text="Even"), tags=[CORRECT_TAG]),
+    ]
+    assert instances[0].split == "train"
+
+
+@pytest.mark.scenarios
+def test_simple_classification_scenario():
+    scenario = SimpleClassificationScenario()
+    with TemporaryDirectory() as tmpdir:
+        instances = scenario.get_instances(tmpdir)
+    assert len(instances) == 90
+    assert instances[0].input == Input(text="10")
+    assert instances[0].references == [
+        Reference(output=Output(text="Even"), tags=[CORRECT_TAG]),
+        Reference(output=Output(text="Odd"), tags=[]),
+    ]
+    assert instances[0].split == "train"

--- a/src/helm/benchmark/test_data_preprocessor.py
+++ b/src/helm/benchmark/test_data_preprocessor.py
@@ -4,7 +4,7 @@ from typing import List
 from helm.benchmark.augmentations.data_augmenter import DataAugmenterSpec
 from helm.benchmark.augmentations.perturbation import PerturbationSpec
 from helm.benchmark.data_preprocessor import DataPreprocessor
-from helm.benchmark.run_specs.classic_run_specs import get_simple1_spec
+from helm.benchmark.run_specs.simple_run_specs import get_simple1_spec
 from helm.benchmark.scenarios.scenario import create_scenario, Instance, Scenario, with_instance_ids
 
 


### PR DESCRIPTION
The existing `Simple1Scenario` is not actually that simple, and it is hard to use it in a tutorial.

This adds even simpler scenarios, one for each common NLP task: multiple-choice QA, short answer QA, and classification. These scenarios are more appropriate for tutorials. Additionally, these scenarios are accompanied by scenario tests, which will be required for all future scenarios added to HELM.