### PR TITLE
Fix SimpleTokenizer

### DIFF
--- a/src/helm/clients/simple_client.py
+++ b/src/helm/clients/simple_client.py
@@ -59,6 +59,25 @@ class SimpleClient(CachingClient):
         - 4
         - 2
         """
+<<<<<<< HEAD
         prompt_words: List[str] = raw_request["prompt"].split()
         completions = list(itertools.islice(itertools.cycle(reversed(prompt_words)), raw_request["num_completions"]))
         return {"completions": completions}
+=======
+        prompt_tokens: List[str] = raw_request["prompt"].split(" ")
+        choices = reversed(prompt_tokens[-raw_request["n"] :])
+        response = {"completions": dict((text, -i) for i, text in enumerate(choices))}
+        return response
+
+    def invoke_model_tutorial(self, raw_request: Dict) -> Dict:
+        """Always returns: 'The model is generating some text. Hooray, the tutorial works! (Completion {i})'.
+        This supports multiple completions.
+        """
+        response = {
+            "completions": dict(
+                (f"The model is generating some text. Hooray, the tutorial works! (Completion {i})", -i)
+                for i in range(raw_request["n"])
+            )
+        }
+        return response
+>>>>>>> Fix SimpleTokenizer

--- a/src/helm/clients/simple_client.py
+++ b/src/helm/clients/simple_client.py
@@ -59,25 +59,6 @@ class SimpleClient(CachingClient):
         - 4
         - 2
         """
-<<<<<<< HEAD
         prompt_words: List[str] = raw_request["prompt"].split()
         completions = list(itertools.islice(itertools.cycle(reversed(prompt_words)), raw_request["num_completions"]))
         return {"completions": completions}
-=======
-        prompt_tokens: List[str] = raw_request["prompt"].split(" ")
-        choices = reversed(prompt_tokens[-raw_request["n"] :])
-        response = {"completions": dict((text, -i) for i, text in enumerate(choices))}
-        return response
-
-    def invoke_model_tutorial(self, raw_request: Dict) -> Dict:
-        """Always returns: 'The model is generating some text. Hooray, the tutorial works! (Completion {i})'.
-        This supports multiple completions.
-        """
-        response = {
-            "completions": dict(
-                (f"The model is generating some text. Hooray, the tutorial works! (Completion {i})", -i)
-                for i in range(raw_request["n"])
-            )
-        }
-        return response
->>>>>>> Fix SimpleTokenizer

--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -11,7 +11,7 @@
 model_deployments:
   - name: simple/model1
     model_name: simple/model1
-    tokenizer_name: simple/model1
+    tokenizer_name: simple/tokenizer1
     max_sequence_length: 2048
     client_spec:
       class_name: "helm.clients.simple_client.SimpleClient"

--- a/src/helm/config/tokenizer_configs.yaml
+++ b/src/helm/config/tokenizer_configs.yaml
@@ -10,7 +10,7 @@
 
 tokenizer_configs:
 
-  - name: simple/model1
+  - name: simple/tokenizer1
     tokenizer_spec:
       class_name: "helm.tokenizers.simple_tokenizer.SimpleTokenizer"
     end_of_text_token: "</s>"

--- a/src/helm/proxy/services/test_remote_service.py
+++ b/src/helm/proxy/services/test_remote_service.py
@@ -127,9 +127,9 @@ class TestRemoteServerService:
         assert response.success
 
     def test_tokenize(self):
-        request = TokenizationRequest(text="1 2 3", tokenizer="simple/model1")
+        request = TokenizationRequest(text="1 2 3", tokenizer="simple/tokenizer1")
         response: TokenizationRequestResult = self.service.tokenize(self.auth, request)
-        assert [token.value for token in response.tokens] == ["1", "2", "3"]
+        assert [token.value for token in response.tokens] == ["1", " ", "2", " ", "3"]
 
     def test_make_request_plus_sign(self):
         # Ensure + in prompt doesn't get replaced by a blank space

--- a/src/helm/tokenizers/simple_tokenizer.py
+++ b/src/helm/tokenizers/simple_tokenizer.py
@@ -9,7 +9,7 @@ from helm.tokenizers.tokenizer import Tokenizer
 
 
 class SimpleTokenizer(Tokenizer):
-    """Implements some "models" that just generate silly things quickly just to debug the infrastructure."""
+    """Simple tokenizer for tutorials and for debugging."""
 
     def tokenize(self, request: TokenizationRequest) -> TokenizationRequestResult:
         if request.encode:

--- a/src/helm/tokenizers/simple_tokenizer.py
+++ b/src/helm/tokenizers/simple_tokenizer.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from helm.common.tokenization_request import (
     DecodeRequest,
     DecodeRequestResult,
@@ -7,26 +5,29 @@ from helm.common.tokenization_request import (
     TokenizationRequestResult,
     TokenizationToken,
 )
-from .tokenizer import Tokenizer
+from helm.tokenizers.tokenizer import Tokenizer
 
 
 class SimpleTokenizer(Tokenizer):
     """Implements some "models" that just generate silly things quickly just to debug the infrastructure."""
 
-    @staticmethod
-    def tokenize_by_space(text: str) -> List[str]:
-        """Simply tokenizes by a single white space."""
-        return text.split(" ")
-
     def tokenize(self, request: TokenizationRequest) -> TokenizationRequestResult:
-        # TODO: Does not support encoding
-        if request.tokenizer == "simple/model1":
-            raw_tokens: List[str] = SimpleTokenizer.tokenize_by_space(request.text)
+        if request.encode:
             return TokenizationRequestResult(
-                success=True, cached=False, tokens=[TokenizationToken(text) for text in raw_tokens], text=request.text
+                success=True,
+                cached=False,
+                tokens=[TokenizationToken(ord(character)) for character in request.text],
+                text=request.text,
             )
         else:
-            raise ValueError("Unknown model")
+            return TokenizationRequestResult(
+                success=True,
+                cached=False,
+                tokens=[TokenizationToken(character) for character in request.text],
+                text=request.text,
+            )
 
     def decode(self, request: DecodeRequest) -> DecodeRequestResult:
-        raise NotImplementedError
+        return DecodeRequestResult(
+            success=True, cached=False, text="".join([chr(code_point) for code_point in request.tokens])
+        )

--- a/src/helm/tokenizers/test_simple_tokenizer.py
+++ b/src/helm/tokenizers/test_simple_tokenizer.py
@@ -1,0 +1,33 @@
+from helm.common.tokenization_request import (
+    DecodeRequest,
+    TokenizationRequest,
+    TokenizationToken,
+)
+from helm.tokenizers.simple_tokenizer import SimpleTokenizer
+
+
+def test_simple_tokenizer_tokenize():
+    tokenizer = SimpleTokenizer()
+    request = TokenizationRequest(tokenizer="simple/tokenizer1", text="otter 🦦")
+    result = tokenizer.tokenize(request)
+    assert result.success
+    assert not result.cached
+    assert result.tokens == [TokenizationToken(token) for token in ["o", "t", "t", "e", "r", " ", "🦦"]]
+
+
+def test_simple_tokenizer_encode():
+    tokenizer = SimpleTokenizer()
+    request = TokenizationRequest(tokenizer="simple/tokenizer1", text="otter 🦦", encode=True)
+    result = tokenizer.tokenize(request)
+    assert result.success
+    assert not result.cached
+    assert result.tokens == [TokenizationToken(token) for token in [111, 116, 116, 101, 114, 32, 129446]]
+
+
+def test_simple_tokenizer_decode():
+    tokenizer = SimpleTokenizer()
+    request = DecodeRequest(tokenizer="simple/tokenizer1", tokens=[111, 116, 116, 101, 114, 32, 129446])
+    result = tokenizer.decode(request)
+    assert result.success
+    assert not result.cached
+    assert result.text == "otter 🦦"


### PR DESCRIPTION
This fixes `SimpleTokenizer` so that it is in a state that can be used for tutorials.

Previously, `SimpleTokenizer` was missing encoding and decoding, which means that it could not be used for various window services. This pull request adds encoding and decoding.

This also adds a unit test, which will be required for future tokenizers submitted to HELM.