### PR TITLE
Render media object in front end

### DIFF
--- a/helm-frontend/src/components/MediaObjectDisplay.tsx
+++ b/helm-frontend/src/components/MediaObjectDisplay.tsx
@@ -1,19 +1,37 @@
 import MediaObject from "@/types/MediaObject";
+import getBenchmarkEndpoint from "@/utils/getBenchmarkEndpoint";
 
 interface Props {
-  mediaObject: MediaObject;
+	mediaObject: MediaObject;
 }
 
 export default function MediaObjectDisplay({ mediaObject }: Props) {
-  // TODO: Actually render the object.
-  // NOTE: If mediaObject.location has the prefix "benchmark_output/",
-  // this prefix should be stripped before appending the location to
-  // `window.BENCHMARK_OUTPUT_BASE_URL`.
-  return (
-    <div>
-      content_type: {mediaObject.content_type}, text:{" "}
-      {mediaObject.text || "undefined"}, location:{" "}
-      {mediaObject.location || "undefined"}
-    </div>
-  );
+	if (mediaObject.content_type.includes("image")) {
+		const url = getBenchmarkEndpoint(
+			String(mediaObject.location?.replace("benchmark_output/", ""))
+		);
+		return (
+			<div>
+				<img src={url}></img>
+				<br />
+			</div>
+		);
+	} else {
+		if (
+			mediaObject.text &&
+			mediaObject.content_type &&
+			mediaObject.content_type === "text/plain" &&
+			mediaObject.text.length > 1
+		) {
+			return (
+				<div>
+					{mediaObject.text}
+					<br />
+					<br />
+				</div>
+			);
+		} else {
+			return <div></div>;
+		}
+	}
 }

--- a/helm-frontend/src/components/MediaObjectDisplay.tsx
+++ b/helm-frontend/src/components/MediaObjectDisplay.tsx
@@ -2,36 +2,36 @@ import MediaObject from "@/types/MediaObject";
 import getBenchmarkEndpoint from "@/utils/getBenchmarkEndpoint";
 
 interface Props {
-	mediaObject: MediaObject;
+  mediaObject: MediaObject;
 }
 
 export default function MediaObjectDisplay({ mediaObject }: Props) {
-	if (mediaObject.content_type.includes("image")) {
-		const url = getBenchmarkEndpoint(
-			String(mediaObject.location?.replace("benchmark_output/", ""))
-		);
-		return (
-			<div>
-				<img src={url}></img>
-				<br />
-			</div>
-		);
-	} else {
-		if (
-			mediaObject.text &&
-			mediaObject.content_type &&
-			mediaObject.content_type === "text/plain" &&
-			mediaObject.text.length > 1
-		) {
-			return (
-				<div>
-					{mediaObject.text}
-					<br />
-					<br />
-				</div>
-			);
-		} else {
-			return <div></div>;
-		}
-	}
+  if (mediaObject.content_type.includes("image")) {
+    const url = getBenchmarkEndpoint(
+      String(mediaObject.location?.replace("benchmark_output/", "")),
+    );
+    return (
+      <div>
+        <img src={url}></img>
+        <br />
+      </div>
+    );
+  } else {
+    if (
+      mediaObject.text &&
+      mediaObject.content_type &&
+      mediaObject.content_type === "text/plain" &&
+      mediaObject.text.length > 1
+    ) {
+      return (
+        <div>
+          {mediaObject.text}
+          <br />
+          <br />
+        </div>
+      );
+    } else {
+      return <div></div>;
+    }
+  }
 }


### PR DESCRIPTION
Renders MediaObject in front end and removes extra labels for the object, like that text is of text type and images are of image type (I can add them back if desired).

Notably, the examples in VHELM seem to not work even after handling the deduplication of "benchmark_output/" but I may have missed something. The URLs look reasonable afterwards but don't seem to work. 

Here are some examples for reference (are these expected to be accessible?):
 
https://nlp.stanford.edu/helm/vhelm/benchmark_output/scenarios/a_okvqa/images/DPtUMrxDbLP2nQ9yUdmvkT.jpg

https://nlp.stanford.edu/helm/vhelm/benchmark_output/scenarios/a_okvqa/images/XkEu3gmYW23qTivgmHP3fN.jpg