### PR TITLE
Fix AdapterSpec unhashable bug

### DIFF
--- a/src/helm/benchmark/adaptation/adapter_spec.py
+++ b/src/helm/benchmark/adaptation/adapter_spec.py
@@ -124,5 +124,5 @@ class AdapterSpec:
     # Parameters for image generation
     image_generation_parameters: Optional[ImageGenerationParameters] = None
 
-    # The splits from which evaluation instances will be drawn
-    eval_splits: Optional[List[str]] = None
+    # The splits from which evaluation instances will be drawn (set hash=False to make `AdapterSpec` hashable)
+    eval_splits: Optional[List[str]] = field(default=None, hash=False)


### PR DESCRIPTION
#2473 introduced a bug that makes `AdapterSpec` unhashable, because `eval_splits` is of type `List`, which is unhashable. Running `helm-summarize` with an `AdapterSpec` with a non-empty `eval_splits` will result in:

```
  File "/home/yifanmai/oss/helm/src/helm/benchmark/presentation/summarize.py", line 417, in group_runs
    self.group_adapter_to_runs[group_name][adapter_spec].append(run)
  File "<string>", line 3, in __hash__
TypeError: unhashable type: 'list'
```

We simply ignore this field for hashing (like we did for `stop_sequences`).