### PR TITLE
Fix KeyError bug in AnthropicClient

### DIFF
--- a/src/helm/clients/anthropic_client.py
+++ b/src/helm/clients/anthropic_client.py
@@ -207,7 +207,11 @@ class AnthropicClient(CachingClient):
 
 def _is_content_moderation_failure(response: Dict) -> bool:
     """Return whether a a response failed because of the content moderation filter."""
-    if response["error"]["message"] == "Output blocked by content filtering policy":
+    if (
+        "error" in response
+        and "message" in response["error"]
+        and ["message"] == "Output blocked by content filtering policy"
+    ):
         hlog(f"Anthropic - output blocked by content filtering policy: {response}")
         return True
     return False

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -1223,7 +1223,7 @@ models:
     release_date: 2024-02-01
     tags: [TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG]
 
-  - name: allenai/olmo-7b-twin-2t
+  - name: allenai/olmo-7b-instruct
     display_name: OLMo (7B Instruct)
     description: OLMo is a series of Open Language Models trained on the Dolma dataset. The instruct versions was trained on the Tulu SFT mixture and a cleaned version of the UltraFeedback dataset.
     creator_organization_name: Allen Institute for AI

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -1223,7 +1223,7 @@ models:
     release_date: 2024-02-01
     tags: [TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG]
 
-  - name: allenai/olmo-7b-instruct
+  - name: allenai/olmo-7b-twin-2t
     display_name: OLMo (7B Instruct)
     description: OLMo is a series of Open Language Models trained on the Dolma dataset. The instruct versions was trained on the Tulu SFT mixture and a cleaned version of the UltraFeedback dataset.
     creator_organization_name: Allen Institute for AI


### PR DESCRIPTION
#2471 introduces a bug where `AnthropicClient` traverses into the key "error" in the response without first checking if it exists, resulting in the error:

```
  File "/.../helm/clients/anthropic_client.py", line 210, in _is_content_moderation_failure
    if response["error"]["message"] == "Output blocked by content filtering policy":
KeyError: 'error'
```