### PR TITLE
Serve prod_env/cache/output on development servers

### DIFF
--- a/helm-frontend/vite.config.ts
+++ b/helm-frontend/vite.config.ts
@@ -11,7 +11,12 @@ const ServeBenchmarkOutputPlugin = {
       "/benchmark_output",
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call
       serveStatic("../benchmark_output", {fallthrough: false, index: false})
-    )
+    );
+    server.middlewares.use(
+      "/cache/output",
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call
+      serveStatic("../prod_env/cache/output", {fallthrough: false, index: false})
+    );
   }
 }
 

--- a/src/helm/benchmark/server.py
+++ b/src/helm/benchmark/server.py
@@ -70,6 +70,14 @@ def serve_benchmark_output(filename):
     return response
 
 
+@app.get("/cache/output/<filename:path>")
+def serve_cache_output(filename):
+    response = static_file(filename, root=app.config["helm.cacheoutputpath"])
+    response.set_header("Cache-Control", "no-cache, no-store, must-revalidate")
+    response.set_header("Expires", "0")
+    return response
+
+
 @app.get("/")
 @app.get("/<filename:path>")
 def serve_static(filename="index.html"):
@@ -86,6 +94,12 @@ def main():
         type=str,
         help="The location of the output path (filesystem path or URL)",
         default="benchmark_output",
+    )
+    parser.add_argument(
+        "--cache-output-path",
+        type=str,
+        help="The location of the filesystem cache output folder (filesystem path or URL)",
+        default="prod_env/cache/output",
     )
     parser.add_argument(
         "--suite",
@@ -112,7 +126,7 @@ def main():
     # Determine the location of the static directory.
     # This is a hack: it assumes that the static directory has a physical location,
     # which is not always the case (e.g. when using zipimport).
-    static_package_name = "helm.benchmark.static" if args.jquery else "helm.benchmark.static_build"
+    static_package_name = "helm.bencmark.static" if args.jquery else "helm.benchmark.static_build"
     resource_path = resources.files(static_package_name).joinpath("index.html")
     with resources.as_file(resource_path) as resource_filename:
         static_path = str(resource_filename.parent)
@@ -123,11 +137,13 @@ def main():
         # Output path is a URL, so set the output path base URL in the frontend to that URL
         # so that the frontend reads from that URL directly.
         app.config["helm.outputpath"] = None
+        # TODO: figure out helm.cacheoutputpath
         app.config["helm.outputurl"] = args.output_path
     else:
         # Output path is a location on disk, so set the output path base URL to /benchmark_output
         # and then serve files from the location on disk at that URL.
         app.config["helm.outputpath"] = path.abspath(args.output_path)
+        app.config["helm.cacheoutputpath"] = path.abspath(args.cache_output_path)
         app.config["helm.outputurl"] = "benchmark_output"
 
     app.config["helm.suite"] = args.suite or "latest"


### PR DESCRIPTION
Annotations contain paths of the form `prod_env/cache/output/latexcompiler/847f21a0dc444766a591d64ee00a6f13.png` but `prod_env` is not served by any web server.

This change makes `prod_env/cache/output/` accessible at `http://localhost:8000/cache/output/` for `helm-server` or `http://localhost:5173/cache/output/` for the Vite server so that these files are accessible. The frontend will need to translate the URLS e.g. `prod_env/cache/output/latexcompiler/847f21a0dc444766a591d64ee00a6f13.png` becomes `/cache/output/latexcompiler/847f21a0dc444766a591d64ee00a6f13.png`