### PR TITLE
Remove yaml bundle from Vite build

### DIFF
--- a/helm-frontend/vite.config.ts
+++ b/helm-frontend/vite.config.ts
@@ -41,7 +41,6 @@ export default defineConfig({
           react: ["react", "react-dom", "react-markdown", "react-router-dom", "react-spinners"],
           tremor: ["@tremor/react"],
           recharts: ["recharts"],
-          yaml: ["yaml"],
         }
       }
     }


### PR DESCRIPTION
Currently the yaml bundle is an empty file, so we can delete it.