### PR TITLE
Remove Gemini's dependency on Vertex AI tokenize API

### DIFF
--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -394,7 +394,7 @@ model_deployments:
   # See: https://ai.google.dev/models/gemini#model_variations
   - name: google/gemini-pro
     model_name: google/gemini-pro
-    tokenizer_name: google/text-bison@001
+    tokenizer_name: google/gemma-2b  # Gemini has no tokenizer endpoint, so we approximate by using Gemma's tokenizer.
     max_sequence_length: 30720
     max_sequence_and_generated_tokens_length: 32768 # Officially max_sequence_length + 2048
     client_spec:
@@ -404,7 +404,7 @@ model_deployments:
 
   - name: google/gemini-pro-vision
     model_name: google/gemini-pro-vision
-    tokenizer_name: google/text-bison@001
+    tokenizer_name: google/gemma-2b  # Gemini has no tokenizer endpoint, so we approximate by using Gemma's tokenizer.
     max_sequence_length: 12288
     max_sequence_and_generated_tokens_length: 16384 # Officially max_sequence_length + 4096, in practice max_output_tokens <= 2048 for vision models
     client_spec:


### PR DESCRIPTION
Gemini is currently not working because it uses the Vertex AI API tokenize API for tokenization, and this API is currently returning errors with this stack trace:

```
  File "/.../src/helm/tokenizers/vertexai_tokenizer.py", line 43, in __init__
    creds.refresh(auth_req)
  File "/.../lib/python3.8/site-packages/google/oauth2/service_account.py", line 441, in refresh
    access_token, expiry, _ = _client.jwt_grant(
  File "/.../lib/python3.8/site-packages/google/oauth2/_client.py", line 308, in jwt_grant
    response_data = _token_endpoint_request(
  File "/.../lib/python3.8/site-packages/google/oauth2/_client.py", line 279, in _token_endpoint_request
    _handle_error_response(response_data, retryable_error)
  File "/.../lib/python3.8/site-packages/google/oauth2/_client.py", line 72, in _handle_error_response
    raise exceptions.RefreshError(
google.auth.exceptions.RefreshError: ('invalid_scope: Invalid OAuth scope or ID token audience provided.', {'error': 'invalid_scope', 'error_description': 'Invalid OAuth scope or ID token audience provided.'})
```

We fix this for Gemini in two ways:

1. Don't tokenize in the client. This is due to a more general policy change: if an API endpoint does not return tokens, previously, we would tokenize it within the client to get tokens, but going forward, we will return an empty tokens list instead.
1. Use use a local tokenizer (Gemma on Hugging Face) as a replacement for the remote tokenizer for the window service.