### PR TITLE
Remove base64 encoded input from instances

### DIFF
--- a/src/helm/benchmark/presentation/run_display.py
+++ b/src/helm/benchmark/presentation/run_display.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict, defaultdict
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 import os
 from typing import Dict, Iterable, List, Optional, Set, Tuple, Any
 
@@ -15,7 +15,7 @@ from helm.benchmark.metrics.metric import PerInstanceStats
 from helm.common.multimodal_request_utils import gather_generated_image_locations
 from helm.benchmark.presentation.schema import Schema
 from helm.benchmark.run_spec import RunSpec
-from helm.benchmark.scenarios.scenario import Instance, Input
+from helm.benchmark.scenarios.scenario import Instance
 from helm.common.general import write
 from helm.common.hierarchical_logger import hlog, htrack
 from helm.common.images_utils import encode_base64
@@ -265,22 +265,6 @@ def write_run_display_json(run_path: str, run_spec: RunSpec, schema: Schema, ski
         instance_id_to_instance[
             (request_state.instance.id, request_state.instance.perturbation)
         ] = request_state.instance
-
-        # TODO: hacky way to display input images on the old frontend
-        if request_state.instance.input.multimedia_content is not None:
-            html_input: str = ""
-            for media_object in request_state.instance.input.multimedia_content.media_objects:
-                if media_object.is_type("image") and media_object.location is not None:
-                    html_input += f'<br><img src="data:image;base64,{encode_base64(media_object.location)}">'
-                elif media_object.is_type("text") and media_object.text is not None:
-                    html_input += f"<br>{media_object.text}"
-                else:
-                    raise ValueError(f"Unhandled media type: {media_object.type}")
-
-            instance_id_to_instance[(request_state.instance.id, request_state.instance.perturbation)] = replace(
-                request_state.instance,
-                input=Input(text=html_input),
-            )
 
         # Process images and include if they exist
         images: List[str] = [


### PR DESCRIPTION
Frontend support for linked images will be added in #2507, so we don't need to base64 encode those images.

Currently `instances.json` is extremely large (>50MB) which slows download time. This pull request greatly reduces the size of `instances.json`.