### PR TITLE
Fix version dropdown links

### DIFF
--- a/helm-frontend/src/utils/getReleaseUrl.ts
+++ b/helm-frontend/src/utils/getReleaseUrl.ts
@@ -8,7 +8,7 @@ export default function getReleaseUrl(
     return "#";
   }
   if (!version) {
-    return `https://crfm.stanford.edu/helm/${currProjectMetadata.id}/`;
+    return `https://crfm.stanford.edu/helm/${currProjectMetadata.id}/latest/`;
   }
-  return `https://crfm.stanford.edu/helm/${currProjectMetadata.id}/`;
+  return `https://crfm.stanford.edu/helm/${currProjectMetadata.id}/${version}/`;
 }


### PR DESCRIPTION
Bugfix: currently every version in the version dropdown goes to the latest version.