### PR TITLE
Fix caching and content block handling for Gemini

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -132,7 +132,7 @@ openai =
     tiktoken~=0.3.3
 
 google =
-    google-cloud-aiplatform~=1.38.1
+    google-cloud-aiplatform~=1.44
 
 tsinghua =
     icetk~=0.0.4

--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -90,6 +90,16 @@ class InstructionsRunExpander(RunExpander):
                 instructions="I am an expert AI assistant who is here to help you with the following. "
                 + adapter_spec.instructions,
             )
+        elif self.value == "prefix_1":
+            adapter_spec = replace(
+                adapter_spec,
+                instructions="Answer only with a single letter. " + adapter_spec.instructions,
+            )
+        elif self.value == "suffix_1":
+            adapter_spec = replace(
+                adapter_spec,
+                instructions=adapter_spec.instructions + " Answer only with a single letter.",
+            )
         else:
             raise Exception("Unknown value: {self.value}")
         return [

--- a/src/helm/clients/vertexai_client.py
+++ b/src/helm/clients/vertexai_client.py
@@ -145,7 +145,7 @@ class VertexAIChatClient(VertexAIClient):
         4,  # RECITATION
         6,  # BLOCKLIST
         7,  # PROHIBITED_CONTENT
-        8,  # SPII
+        8,  # SPII (Sensitive Personally Identifiable Information)
     ]
 
     @staticmethod

--- a/src/helm/clients/vertexai_client.py
+++ b/src/helm/clients/vertexai_client.py
@@ -214,7 +214,7 @@ class VertexAIChatClient(VertexAIClient):
                 try:
                     response_dict = {
                         "predictions": [{"text": completion.text} for completion in candidates],
-                    }
+                    }  # TODO: Extract more information from the response
                 except ValueError as e:
                     if "Content has no parts" in str(e):
                         # The prediction was either blocked due to safety settings or the model stopped and returned


### PR DESCRIPTION
- Don't cache responses blocked by the content filter, because the filter may be lifted in the future
- Detect some kinds of content filtering that were not detected before by checking the finish reason
- Fix a bug due to a misplaced brace that caused there to be a single completion even if there were multiple `candidates` in the raw response 