### PR TITLE
Change caching of MediaObject

### DIFF
--- a/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
+++ b/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
@@ -75,7 +75,8 @@ class ImageCompilerAnnotator(Annotator, ABC):
             cache_key: Dict[str, str] = {"completion": completion_text}
             raw_response, _ = self._cache.get(cache_key, do_it)
             response = {**raw_response}
-            response["media_object"] = MediaObject.from_dict(response["media_object"])
+            if "media_object" in response:
+                response["media_object"] = MediaObject.from_dict(response["media_object"])
 
             # Merge annotations
             annotations.append(response)

--- a/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
+++ b/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
@@ -62,7 +62,7 @@ class ImageCompilerAnnotator(Annotator, ABC):
                         infos = self.postprocess_infos(infos)
                         image_path: str = self._file_cache.store_image(lambda: image)
                         return {
-                            "media_object": MediaObject(location=image_path, content_type="image/png"),
+                            "media_object": MediaObject(location=image_path, content_type="image/png").to_dict(),
                             **infos,
                         }
                     except CompilationError as e:
@@ -73,7 +73,9 @@ class ImageCompilerAnnotator(Annotator, ABC):
                 return compile()
 
             cache_key: Dict[str, str] = {"completion": completion_text}
-            response, _ = self._cache.get(cache_key, do_it)
+            raw_response, _ = self._cache.get(cache_key, do_it)
+            response = {**raw_response}
+            response["media_object"] = MediaObject.from_dict(response["media_object"])
 
             # Merge annotations
             annotations.append(response)

--- a/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
+++ b/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Tuple, Callable
 
+from dacite import from_dict
+
 from helm.benchmark.annotation.annotator import Annotator
 from helm.benchmark.adaptation.request_state import RequestState
 from helm.common.cache import Cache, CacheConfig
@@ -76,7 +78,7 @@ class ImageCompilerAnnotator(Annotator, ABC):
             raw_response, _ = self._cache.get(cache_key, do_it)
             response = {**raw_response}
             if "media_object" in response:
-                response["media_object"] = MediaObject.from_dict(response["media_object"])
+                response["media_object"] = from_dict(MediaObject, response["media_object"])
 
             # Merge annotations
             annotations.append(response)

--- a/src/helm/common/media_object.py
+++ b/src/helm/common/media_object.py
@@ -31,11 +31,6 @@ class MediaObject:
         """Converts the media object to a dictionary."""
         return {key: value for key, value in self.__dict__.items() if value is not None}
 
-    @staticmethod
-    def from_dict(data: dict) -> "MediaObject":
-        """Creates a media object from a dictionary."""
-        return MediaObject(**data)
-
     @property
     def type(self) -> str:
         """The MIME type of the media object."""

--- a/src/helm/common/media_object.py
+++ b/src/helm/common/media_object.py
@@ -27,6 +27,15 @@ class MediaObject:
     location: Optional[str] = None
     """When the media object is a file, specify the location of the media object, which can be a local path or URL."""
 
+    def to_dict(self) -> dict:
+        """Converts the media object to a dictionary."""
+        return {key: value for key, value in self.__dict__.items() if value is not None}
+
+    @staticmethod
+    def from_dict(data: dict) -> "MediaObject":
+        """Creates a media object from a dictionary."""
+        return MediaObject(**data)
+
     @property
     def type(self) -> str:
         """The MIME type of the media object."""


### PR DESCRIPTION
`MediaObject`s are now converted to dicts before caching. This is the correct way to handle this, not like proposed in #2518. The bug illustrated in #2519 is also no longer relevant as `MediaObject` should not be cached directly.