### PR TITLE
Remove bias and robustness metrics in VLM schema

### DIFF
--- a/src/helm/benchmark/static/schema_vlm.yaml
+++ b/src/helm/benchmark/static/schema_vlm.yaml
@@ -388,7 +388,6 @@ run_groups:
     description: Safety Evaluation Benchmark for Evaluating on Out-of-Distribution and Sketch Images
     metric_groups:
       - accuracy
-      - robustness
       - general_information
     environment:
       main_name: exact_match
@@ -405,8 +404,6 @@ run_groups:
     description: Open-ended questions about biased images
     metric_groups:
       - accuracy
-      - bias
-      - robustness
     environment:
       main_name: f1_score
       main_split: test


### PR DESCRIPTION
It seems like having `robustness` and `bias` present for some scenarios but no other cause scenarios that do not have it (like i2s) to fail on summarization. This was introduced by #2456 but seems to be a bug in `summarize` more than something caused by #2456. @yifanmai what do you think?