### PR TITLE
Fixes for image2structure

### DIFF
--- a/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
+++ b/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
@@ -70,7 +70,7 @@ class ImageCompilerAnnotator(Annotator, ABC):
                         return {"error": str(e)}
 
                 try:
-                    cache_key: Dict[str, str] = {"completion": completion_text, "debug": str(1234567)}
+                    cache_key: Dict[str, str] = {"completion": completion_text}
                     raw_response, _ = self._cache.get(cache_key, do_it)
                     return raw_response
                 except Exception as e:

--- a/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
+++ b/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
@@ -17,12 +17,11 @@ except ModuleNotFoundError as e:
 
 def retry_if_compilation_failed(result: Dict[str, Any]) -> bool:
     """Retries when the compilation fails."""
-    print("Result:", result)
     return "unknown_error" in result
 
 
 retry: Callable = get_retry_decorator(
-    "Compilation", max_attempts=2, wait_exponential_multiplier_seconds=2, retry_on_result=retry_if_compilation_failed
+    "Compilation", max_attempts=5, wait_exponential_multiplier_seconds=2, retry_on_result=retry_if_compilation_failed
 )
 
 
@@ -63,7 +62,6 @@ class ImageCompilerAnnotator(Annotator, ABC):
                         image, infos = self.compile_completion_into_image(request_state, completion_text)
                         infos = self.postprocess_infos(infos)
                         image_path: str = self._file_cache.store_image(lambda: image)
-                        x = 1 / 0
                         return {
                             "media_object": MediaObject(location=image_path, content_type="image/png").to_dict(),
                             **infos,

--- a/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
+++ b/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
@@ -75,7 +75,8 @@ class ImageCompilerAnnotator(Annotator, ABC):
             cache_key: Dict[str, str] = {"completion": completion_text}
             raw_response, _ = self._cache.get(cache_key, do_it)
             response = {**raw_response}
-            response["media_object"] = MediaObject.from_dict(response["media_object"])
+            if "media_object" in response:
+                response["media_object"] = MediaObject.from_dict(response["media_object"])
 
             # Merge annotations
             annotations.append(response)

--- a/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
+++ b/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
@@ -73,7 +73,7 @@ class ImageCompilerAnnotator(Annotator, ABC):
 
                 return compile()
 
-            cache_key: Dict[str, str] = {"completion": completion_text}
+            cache_key: Dict[str, str] = {"completion": completion_text, "debug": str(1234)}
             raw_response, _ = self._cache.get(cache_key, do_it)
             response = {**raw_response}
             if "media_object" in response:

--- a/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
+++ b/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
@@ -69,8 +69,6 @@ class ImageCompilerAnnotator(Annotator, ABC):
                         }
                     except CompilationError as e:
                         return {"error": str(e)}
-                    except Exception as e:
-                        return {"unknown_error": e}
 
                 cache_key: Dict[str, str] = {"completion": completion_text, "debug": str(123456)}
                 raw_response, _ = self._cache.get(cache_key, do_it)

--- a/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
+++ b/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
@@ -62,7 +62,7 @@ class ImageCompilerAnnotator(Annotator, ABC):
                         infos = self.postprocess_infos(infos)
                         image_path: str = self._file_cache.store_image(lambda: image)
                         return {
-                            "media_object": MediaObject(location=image_path, content_type="image/png"),
+                            "media_object": MediaObject(location=image_path, content_type="image/png").to_dict(),
                             **infos,
                         }
                     except CompilationError as e:
@@ -73,7 +73,9 @@ class ImageCompilerAnnotator(Annotator, ABC):
                 return compile()
 
             cache_key: Dict[str, str] = {"completion": completion_text}
-            response, _ = self._cache.get(cache_key, do_it)
+            raw_response, _ = self._cache.get(cache_key, do_it)
+            response = {**raw_response}
+            response["media_object"] = MediaObject.from_dict(response["media_object"])
 
             # Merge annotations
             annotations.append(response)

--- a/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
+++ b/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
@@ -21,7 +21,7 @@ def retry_if_compilation_failed(result: Dict[str, Any]) -> bool:
 
 
 retry: Callable = get_retry_decorator(
-    "Compilation", max_attempts=5, wait_exponential_multiplier_seconds=2, retry_on_result=retry_if_compilation_failed
+    "Compilation", max_attempts=2, wait_exponential_multiplier_seconds=2, retry_on_result=retry_if_compilation_failed
 )
 
 
@@ -55,6 +55,7 @@ class ImageCompilerAnnotator(Annotator, ABC):
 
             def do_it() -> Dict[str, Any]:
 
+                @retry
                 def compile() -> Dict[str, Any]:
                     try:
                         assert self._file_cache is not None
@@ -65,15 +66,15 @@ class ImageCompilerAnnotator(Annotator, ABC):
                             "media_object": MediaObject(location=image_path, content_type="image/png").to_dict(),
                             **infos,
                         }
+                        x = 3 / 0
                     except CompilationError as e:
                         return {"error": str(e)}
                     except Exception as e:
-                        raise e
-                        return {"unknown_error": str(e)}
+                        return {"unknown_error": e}
 
                 return compile()
 
-            cache_key: Dict[str, str] = {"completion": completion_text, "debug": str(1234)}
+            cache_key: Dict[str, str] = {"completion": completion_text, "debug": str(12345)}
             raw_response, _ = self._cache.get(cache_key, do_it)
             response = {**raw_response}
             if "media_object" in response:

--- a/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
+++ b/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Tuple, Callable
 
+from dacite import from_dict
+
 from helm.benchmark.annotation.annotator import Annotator
 from helm.benchmark.adaptation.request_state import RequestState
 from helm.common.cache import Cache, CacheConfig
@@ -79,7 +81,7 @@ class ImageCompilerAnnotator(Annotator, ABC):
             raw_response = compile()
             response = {**raw_response}
             if "media_object" in response:
-                response["media_object"] = MediaObject.from_dict(response["media_object"])
+                response["media_object"] = from_dict(MediaObject, response["media_object"])
 
             # Merge annotations
             annotations.append(response)

--- a/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
+++ b/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
@@ -68,6 +68,7 @@ class ImageCompilerAnnotator(Annotator, ABC):
                     except CompilationError as e:
                         return {"error": str(e)}
                     except Exception as e:
+                        raise e
                         return {"unknown_error": str(e)}
 
                 return compile()

--- a/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
+++ b/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
@@ -76,7 +76,7 @@ class ImageCompilerAnnotator(Annotator, ABC):
                     raw_response, _ = self._cache.get(cache_key, do_it)
                     return raw_response
                 except Exception as e:
-                    raw_response = {"unknown_error": str(e)}
+                    return {"unknown_error": str(e)}
 
             raw_response = compile()
             response = {**raw_response}

--- a/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
+++ b/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
@@ -70,7 +70,7 @@ class ImageCompilerAnnotator(Annotator, ABC):
                         return {"error": str(e)}
 
                 try:
-                    cache_key: Dict[str, str] = {"completion": completion_text, "debug": str(123456)}
+                    cache_key: Dict[str, str] = {"completion": completion_text, "debug": str(1234567)}
                     raw_response, _ = self._cache.get(cache_key, do_it)
                     return raw_response
                 except Exception as e:

--- a/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
+++ b/src/helm/benchmark/annotation/image2structure/image_compiler_annotator.py
@@ -54,7 +54,7 @@ class ImageCompilerAnnotator(Annotator, ABC):
             completion_text: str = completion.text.strip()
 
             def do_it() -> Dict[str, Any]:
-                @retry
+
                 def compile() -> Dict[str, Any]:
                     try:
                         assert self._file_cache is not None

--- a/src/helm/benchmark/annotation/image2structure/webpage_compiler_annotator.py
+++ b/src/helm/benchmark/annotation/image2structure/webpage_compiler_annotator.py
@@ -127,6 +127,6 @@ class WebpageCompilerAnnotator(ImageCompilerAnnotator):
         image: Image.Image = Image.open(destination_path)
 
         # Delete the repository
-        shutil.rmtree(repo_path)
+        shutil.rmtree(repo_path, ignore_errors=True)
 
         return image, infos

--- a/src/helm/benchmark/metrics/vision_language/emd_utils.py
+++ b/src/helm/benchmark/metrics/vision_language/emd_utils.py
@@ -111,7 +111,7 @@ def img_to_sig_patches(
     # Compute the weight of each patch
     # The weight of each point is 1 if the color is not the most frequent color, weight_most_frequent_color otherwise
     flattened_patches = patches.reshape(patches.shape[0], -1)
-    gray_most_frequent_color: float = to_gray(rgb_most_frequent_color).squeeze() / 255.0
+    gray_most_frequent_color: float = float(to_gray(rgb_most_frequent_color).squeeze() / 255.0)
     weight = weight_most_frequent_color + (1 - weight_most_frequent_color) * np.any(
         flattened_patches != gray_most_frequent_color, axis=1, keepdims=True
     ).astype(np.float32)
@@ -307,7 +307,7 @@ def compute_emd_recursive(
     # - index 1 - 1 + patch_size[0] * patch_size[1]: color values of the patch
     # - index -2, -1: position of the patch
     (rgb_most_frequent_color, frequency) = get_most_frequent_color(img2_np)
-    gray_most_frequent_color = to_gray(rgb_most_frequent_color).squeeze() / 255.0
+    gray_most_frequent_color = float(to_gray(rgb_most_frequent_color).squeeze() / 255.0)
     sig1 = img_to_sig_patches(img1_np, rgb_most_frequent_color, patch_size, weight_most_frequent_color)
     sig2 = img_to_sig_patches(img2_np, rgb_most_frequent_color, patch_size, weight_most_frequent_color)
 

--- a/src/helm/benchmark/metrics/vision_language/emd_utils.py
+++ b/src/helm/benchmark/metrics/vision_language/emd_utils.py
@@ -13,6 +13,10 @@ except ModuleNotFoundError as e:
     handle_module_not_found_error(e, suggestions=["images"])
 
 
+def to_gray(img: np.ndarray) -> np.ndarray:
+    return np.matmul(img, np.array([[0.299], [0.587], [0.114]]))
+
+
 def get_most_frequent_color(img: np.ndarray) -> Tuple[np.ndarray, float]:
     """Get the most frequent color in the image and its frequency.
 
@@ -85,7 +89,7 @@ def img_to_sig_patches(
     img /= 255.0  # Normalize colors to [0, 1]
 
     # Collapse color dimensions to grayscale
-    img = np.mean(img, axis=2, keepdims=True)
+    img = to_gray(img)
 
     # Reshape image into patches and flatten the color dimensions within each patch
     patches = (
@@ -107,7 +111,7 @@ def img_to_sig_patches(
     # Compute the weight of each patch
     # The weight of each point is 1 if the color is not the most frequent color, weight_most_frequent_color otherwise
     flattened_patches = patches.reshape(patches.shape[0], -1)
-    gray_most_frequent_color: float = np.mean(rgb_most_frequent_color) / 255.0
+    gray_most_frequent_color: float = to_gray(rgb_most_frequent_color).squeeze() / 255.0
     weight = weight_most_frequent_color + (1 - weight_most_frequent_color) * np.any(
         flattened_patches != gray_most_frequent_color, axis=1, keepdims=True
     ).astype(np.float32)
@@ -303,7 +307,7 @@ def compute_emd_recursive(
     # - index 1 - 1 + patch_size[0] * patch_size[1]: color values of the patch
     # - index -2, -1: position of the patch
     (rgb_most_frequent_color, frequency) = get_most_frequent_color(img2_np)
-    gray_most_frequent_color = np.mean(rgb_most_frequent_color) / 255.0
+    gray_most_frequent_color = to_gray(rgb_most_frequent_color).squeeze() / 255.0
     sig1 = img_to_sig_patches(img1_np, rgb_most_frequent_color, patch_size, weight_most_frequent_color)
     sig2 = img_to_sig_patches(img2_np, rgb_most_frequent_color, patch_size, weight_most_frequent_color)
 

--- a/src/helm/benchmark/metrics/vision_language/image_metrics.py
+++ b/src/helm/benchmark/metrics/vision_language/image_metrics.py
@@ -279,7 +279,7 @@ class AnnotatedImageMetrics(Metric):
                     if not isinstance(pred, str):
                         assert hash_dict is not None
                         cache_key = {"metric_name": metric_name, **hash_dict}
-                    response_metric, _ = self._cache.get({**cache_key, "debug": "1234"}, do_it)
+                    response_metric, _ = self._cache.get(cache_key, do_it)
                     value = response_metric["value"]
                 except Exception as e:
                     hlog(f"Error in metric {metric_name}: {str(e)}")

--- a/src/helm/benchmark/metrics/vision_language/image_metrics.py
+++ b/src/helm/benchmark/metrics/vision_language/image_metrics.py
@@ -240,6 +240,7 @@ class AnnotatedImageMetrics(Metric):
             annotation: Dict[str, Any] = request_state.annotations[compiler_name][completion_index]
 
             # Handle errors in annotation
+            print("Annotation: ", annotation)
             if "error" in annotation:
                 stats_dict[self.COMPILE_METRIC].add(0)  # Did not compile
                 # For all other metrics, we set the value to zero

--- a/src/helm/benchmark/metrics/vision_language/image_metrics.py
+++ b/src/helm/benchmark/metrics/vision_language/image_metrics.py
@@ -26,10 +26,7 @@ from helm.benchmark.metrics.vision_language.image_utils import (
     pixel_similarity,
     sift_similarity,
 )
-from helm.benchmark.metrics.vision_language.emd_utils import (  # noqa: F401
-    compute_emd_recursive,
-    get_most_frequent_color,
-)
+from helm.benchmark.metrics.vision_language.emd_utils import compute_emd_recursive
 
 try:
     from torchmetrics.image.lpip import LearnedPerceptualImagePatchSimilarity
@@ -418,8 +415,6 @@ class AnnotatedImageMetrics(Metric):
         )
 
         def do_it():
-            # color: np.ndarray = get_most_frequent_color(np.array(ref_image))[0]
-            # constant_image = Image.new("RGB", ref_image.size, tuple(color))  # type: ignore
             constant_image = Image.new("RGB", ref_image.size, (255, 255, 255))  # default color is white
             value = compute_emd_recursive(
                 constant_image,

--- a/src/helm/benchmark/metrics/vision_language/image_metrics.py
+++ b/src/helm/benchmark/metrics/vision_language/image_metrics.py
@@ -240,8 +240,12 @@ class AnnotatedImageMetrics(Metric):
             annotation: Dict[str, Any] = request_state.annotations[compiler_name][completion_index]
 
             # Handle errors in annotation
-            print("Annotation: ", annotation)
-            if "error" in annotation:
+            if "unknown_error" in annotation:
+                hlog(
+                    f"Unknown error in annotation: {annotation['unknown_error']}\n"
+                    f"Scores of zero will be returned for all metrics."
+                )
+            if "error" in annotation or "unknown_error" in annotation:
                 stats_dict[self.COMPILE_METRIC].add(0)  # Did not compile
                 # For all other metrics, we set the value to zero
                 for metric_name in self._metric_names:

--- a/src/helm/benchmark/metrics/vision_language/image_metrics.py
+++ b/src/helm/benchmark/metrics/vision_language/image_metrics.py
@@ -279,7 +279,7 @@ class AnnotatedImageMetrics(Metric):
                     if not isinstance(pred, str):
                         assert hash_dict is not None
                         cache_key = {"metric_name": metric_name, **hash_dict}
-                    response_metric, _ = self._cache.get(cache_key, do_it)
+                    response_metric, _ = self._cache.get({**cache_key, "debug": "1234"}, do_it)
                     value = response_metric["value"]
                 except Exception as e:
                     hlog(f"Error in metric {metric_name}: {str(e)}")

--- a/src/helm/common/media_object.py
+++ b/src/helm/common/media_object.py
@@ -31,11 +31,6 @@ class MediaObject:
         """Converts the media object to a dictionary."""
         return {key: value for key, value in self.__dict__.items() if value is not None}
 
-    @staticmethod
-    def from_dict(data: dict) -> "MediaObject":
-        """Creates a media object from a dictionary."""
-        return MediaObject(**data)
-
     @property
     def type(self) -> str:
         """The MIME type of the media object."""

--- a/src/helm/common/media_object.py
+++ b/src/helm/common/media_object.py
@@ -27,6 +27,15 @@ class MediaObject:
     location: Optional[str] = None
     """When the media object is a file, specify the location of the media object, which can be a local path or URL."""
 
+    def to_dict(self) -> dict:
+        """Converts the media object to a dictionary."""
+        return {key: value for key, value in self.__dict__.items() if value is not None}
+
+    @staticmethod
+    def from_dict(data: dict) -> "MediaObject":
+        """Creates a media object from a dictionary."""
+        return MediaObject(**data)
+
     @property
     def type(self) -> str:
         """The MIME type of the media object."""


### PR DESCRIPTION
This PR fixes/introduces the following changes:
* `WebpageCompiler`: the error `directory not empty` on the cluster is fixed.
* `unknown_error` after compilation is no longer cached.
* `error` in image metrics is no longer cached
* Change caching of `MediaObject` (introduced by #2525 but not merged yet)
* Conversion to grayscale now uses weights instead of a mean
* Handle `PermissionError` when trying to load `transformers` model from the cache.