### PR TITLE
Fix bug that caused incorrect Hugging Face model ID to be used

### DIFF
--- a/src/helm/clients/huggingface_client.py
+++ b/src/helm/clients/huggingface_client.py
@@ -18,7 +18,7 @@ from helm.common.request import (
     Token,
 )
 from .client import CachingClient, truncate_sequence
-from helm.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer, WrappedPreTrainedTokenizer, resolve_alias
+from helm.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer, WrappedPreTrainedTokenizer
 from threading import Lock
 
 
@@ -236,13 +236,11 @@ class HuggingFaceClient(CachingClient):
             "stop_sequences": request.stop_sequences,
         }
 
-        pretrained_model_name_or_path: str
-        if self._pretrained_model_name_or_path:
-            pretrained_model_name_or_path = self._pretrained_model_name_or_path
-        else:
-            pretrained_model_name_or_path = resolve_alias(request.model_deployment)
+        pretrained_model_name_or_path = (
+            self._pretrained_model_name_or_path if self._pretrained_model_name_or_path else request.model
+        )
         huggingface_model: HuggingFaceServer = HuggingFaceServerFactory.get_server(
-            helm_model_name=request.model_deployment,
+            helm_model_name=request.model,
             pretrained_model_name_or_path=pretrained_model_name_or_path,
             **self._kwargs,
         )

--- a/src/helm/clients/test_huggingface_client.py
+++ b/src/helm/clients/test_huggingface_client.py
@@ -1,24 +1,17 @@
-import os
 import pytest
-import tempfile
 
-from helm.common.cache import SqliteCacheConfig
+from helm.common.cache import BlackHoleCacheConfig
 from helm.common.request import Request, RequestResult
-from .huggingface_client import HuggingFaceClient
+from helm.clients.huggingface_client import HuggingFaceClient
 
 
 class TestHuggingFaceClient:
-    def setup_method(self, method):
-        cache_file = tempfile.NamedTemporaryFile(delete=False)
-        self.cache_path: str = cache_file.name
-        self.client = HuggingFaceClient(cache_config=SqliteCacheConfig(self.cache_path))
-
-    def teardown_method(self, method):
-        os.remove(self.cache_path)
-
     def test_gpt2(self):
+        client = HuggingFaceClient(
+            cache_config=BlackHoleCacheConfig(), pretrained_model_name_or_path="openai-community/gpt2"
+        )
         prompt: str = "I am a computer scientist."
-        result: RequestResult = self.client.make_request(
+        result: RequestResult = client.make_request(
             Request(
                 model="openai/gpt2",
                 model_deployment="huggingface/gpt2",
@@ -36,7 +29,10 @@ class TestHuggingFaceClient:
 
     @pytest.mark.skip(reason="GPT-J 6B is 22 GB and extremely slow without a GPU.")
     def test_gptj_6b(self):
-        result: RequestResult = self.client.make_request(
+        client = HuggingFaceClient(
+            cache_config=BlackHoleCacheConfig(), pretrained_model_name_or_path="openai-community/gpt2"
+        )
+        result: RequestResult = client.make_request(
             Request(
                 model="eleutherai/gpt-j-6b",
                 model_deployment="huggingface/gpt-j-6b",
@@ -49,8 +45,11 @@ class TestHuggingFaceClient:
         assert len(result.completions) == 3
 
     def test_logprob(self):
+        client = HuggingFaceClient(
+            cache_config=BlackHoleCacheConfig(), pretrained_model_name_or_path="openai-community/gpt2"
+        )
         prompt: str = "I am a computer scientist."
-        result: RequestResult = self.client.make_request(
+        result: RequestResult = client.make_request(
             Request(
                 model="openai/gpt2",
                 model_deployment="huggingface/gpt2",

--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -747,6 +747,8 @@ model_deployments:
     max_request_length: 1025
     client_spec:
       class_name: "helm.clients.huggingface_client.HuggingFaceClient"
+      args:
+        pretrained_model_name_or_path: openai-community/gpt2
 
   ## StabilityAI
   - name: huggingface/stablelm-base-alpha-3b

--- a/src/helm/config/tokenizer_configs.yaml
+++ b/src/helm/config/tokenizer_configs.yaml
@@ -188,7 +188,8 @@ tokenizer_configs:
   - name: huggingface/gpt2
     tokenizer_spec:
       class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
-      # openai-community/gpt2
+      args:
+        pretrained_model_name_or_path: openai-community/gpt2
     end_of_text_token: "<|endoftext|>"
     prefix_token: "<|endoftext|>"
 

--- a/src/helm/config/tokenizer_configs.yaml
+++ b/src/helm/config/tokenizer_configs.yaml
@@ -106,6 +106,8 @@ tokenizer_configs:
   - name: google/t5-11b
     tokenizer_spec:
       class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
+      args:
+        pretrained_model_name_or_path: google-t5/t5-11b
     end_of_text_token: "</s>"
     prefix_token: ""
   - name: google/flan-t5-xxl
@@ -186,6 +188,7 @@ tokenizer_configs:
   - name: huggingface/gpt2
     tokenizer_spec:
       class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
+      # openai-community/gpt2
     end_of_text_token: "<|endoftext|>"
     prefix_token: "<|endoftext|>"
 
@@ -324,6 +327,8 @@ tokenizer_configs:
   - name: writer/gpt2
     tokenizer_spec:
       class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
+      args:
+        pretrained_model_name_or_path: openai-community/gpt2
     end_of_text_token: ""
     prefix_token: ""
 

--- a/src/helm/tokenizers/huggingface_tokenizer.py
+++ b/src/helm/tokenizers/huggingface_tokenizer.py
@@ -11,26 +11,6 @@ from .caching_tokenizer import CachingTokenizer
 from .tokenizer import cleanup_tokens
 
 
-# TODO: Delete this.
-_MODEL_NAME_ALIASES: Dict[str, str] = {
-    "google/t5-11b": "t5-11b",
-    "huggingface/gpt2": "gpt2",
-    "huggingface/santacoder": "bigcode/santacoder",
-    "huggingface/starcoder": "bigcode/starcoder",
-    "writer/gpt2": "gpt2",  # Palmyra models do not support echo
-    # So they have a different TokenizerConfig called "writer/gpt2"
-    # when in reality they use the same tokenizer as "huggingface/gpt2"
-    "microsoft/gpt2": "gpt2",  # Same as above
-}
-"""Mapping of some HELM model names to Hugging Face pretrained model name."""
-
-
-# TODO: Delete this.
-def resolve_alias(model_name: str) -> str:
-    """Resolve some HELM model names to Hugging Face pretrained model name."""
-    return _MODEL_NAME_ALIASES.get(model_name, model_name)
-
-
 WrappedPreTrainedTokenizer = ThreadSafeWrapper[PreTrainedTokenizerBase]
 """Thread safe wrapper around Hugging Face PreTrainedTokenizerBase.
 
@@ -106,11 +86,9 @@ class HuggingFaceTokenizer(CachingTokenizer):
 
     def _get_tokenizer_for_request(self, request: Dict[str, Any]) -> WrappedPreTrainedTokenizer:
         """Method used in both _tokenize_do_it and _decode_do_it to get the tokenizer."""
-        pretrained_model_name_or_path: str
-        if self._pretrained_model_name_or_path:
-            pretrained_model_name_or_path = self._pretrained_model_name_or_path
-        else:
-            pretrained_model_name_or_path = resolve_alias(request["tokenizer"])
+        pretrained_model_name_or_path = (
+            self._pretrained_model_name_or_path if self._pretrained_model_name_or_path else request["tokenizer"]
+        )
         return HuggingFaceTokenizer.get_tokenizer(
             helm_tokenizer_name=request["tokenizer"],
             pretrained_model_name_or_path=pretrained_model_name_or_path,


### PR DESCRIPTION
Currently `HuggingFaceClient` doesn't work for all models where the model deployment name and model names are different, and `pretrained_model_name_or_path` is unset. This fixes the bug.

This also does some cleanup by deleting `resolve_alias()`, which has been replaced by `pretrained_model_name_or_path`.