### PR TITLE
Add ThaiExam scenario

### DIFF
--- a/src/helm/benchmark/run_specs/classic_run_specs.py
+++ b/src/helm/benchmark/run_specs/classic_run_specs.py
@@ -1435,3 +1435,25 @@ def get_lm_entry_spec(task: str, method: str = ADAPT_GENERATION) -> RunSpec:
         metric_specs=metric_specs,
         groups=["lm_entry"],
     )
+
+@run_spec_function("thai_exam")
+def get_thai_exam_spec(exam: str = "onet", method: str = ADAPT_MULTIPLE_CHOICE_JOINT) -> RunSpec:
+    scenario_spec = ScenarioSpec(
+        class_name="helm.benchmark.scenarios.thai_exam_scenario.ThaiExamScenario", args={"exam": exam}
+    )
+
+    adapter_spec = get_multiple_choice_adapter_spec(
+        method=method,        
+        instructions=f"The following are multiple choice questions (with answers).",
+        input_noun="Question",
+        output_noun="Answer",
+        max_train_instances=5,
+    )
+
+    return RunSpec(
+        name=f"thai_exam:exam={exam},method={method}",
+        scenario_spec=scenario_spec,
+        adapter_spec=adapter_spec,
+        metric_specs=get_exact_match_metric_specs(),
+        groups=["thai_exam"],
+    )

--- a/src/helm/benchmark/run_specs/classic_run_specs.py
+++ b/src/helm/benchmark/run_specs/classic_run_specs.py
@@ -1436,6 +1436,7 @@ def get_lm_entry_spec(task: str, method: str = ADAPT_GENERATION) -> RunSpec:
         groups=["lm_entry"],
     )
 
+
 @run_spec_function("thai_exam")
 def get_thai_exam_spec(exam: str = "onet", method: str = ADAPT_MULTIPLE_CHOICE_JOINT) -> RunSpec:
     scenario_spec = ScenarioSpec(
@@ -1443,8 +1444,8 @@ def get_thai_exam_spec(exam: str = "onet", method: str = ADAPT_MULTIPLE_CHOICE_J
     )
 
     adapter_spec = get_multiple_choice_adapter_spec(
-        method=method,        
-        instructions=f"The following are multiple choice questions (with answers).",
+        method=method,
+        instructions="The following are multiple choice questions (with answers).",
         input_noun="Question",
         output_noun="Answer",
         max_train_instances=5,

--- a/src/helm/benchmark/scenarios/thai_exam_scenario.py
+++ b/src/helm/benchmark/scenarios/thai_exam_scenario.py
@@ -10,6 +10,20 @@ from .scenario import Scenario, Instance, Reference, TRAIN_SPLIT, TEST_SPLIT, CO
 
 class ThaiExamScenario(Scenario):
     """
+    ThaiExam, a benchmark comprising Thai multiple-choice examinations as follows:
+
+    ∙ ONET: The Ordinary National Educational Test (ONET) is an examination for students in Thailand. We select the grade-12 ONET exam, which comprises 5 subjects and each question has 5 choices. These subjects are Thai, English, Mathematics, Social Studies, and Science. We extracted these questions from the official 2021 ONET example, amounting to a total of 170 questions and options.
+
+    ∙ IC: The Investment Consultant (IC) examination, a licensing test for investment professionals in Thailand developed by the Stock Exchange of Thailand (SET), features 4 choices per question. We extracted questions for levels 1, 2, and 3 from the official SET website, resulting in a total of 95 questions and options.
+
+    ∙ TGAT: The Thai General Aptitude Test (TGAT), a national high school examination in Thailand, focuses on critical and logical thinking skills, as well as proficiency in the English language. We collected a total of 90 questions and answers. The TGAT consists of four choices per question.
+
+    ∙ TPAT-1: The Thai Professional Aptitude Test 1 (TPAT-1) is a national high school examination in Thailand that assesses students’ professional skills requirement in medical schools. This subset contains reasoning and medical ethics. We collected a total of 116 questions and answers. The TPAT-1 consists of 5 choices per question.
+
+    ∙ A-Level: An academic knowledge assessment examination (Applied Knowledge Level) that covers general foundational subjects taught in schools. The content assessed in this examination aligns with the curriculum guidelines and emphasizes the practical application of knowledge in daily life. We collected a total of 175 questions and answers.
+
+    We created and used these exams to evaluate the performance of the Typhoon models(https://arxiv.org/abs/2312.13951).
+
     Prompt models using the following format
 
         <input>                  # train
@@ -52,7 +66,7 @@ class ThaiExamScenario(Scenario):
     """
 
     name = "thai_exam"
-    description = "Thai Exam dataset from ONET, TGAT, TPAT1, A-Level"
+    description = "ThaiExam benchmark comprising Thai multiple-choice examinations."
     tags = ["knowledge", "multiple_choice"]
 
     def __init__(self, exam: str):
@@ -61,20 +75,21 @@ class ThaiExamScenario(Scenario):
 
     def download_thai_exam(self, path: str):
         ensure_file_downloaded(
-            "https://storage.googleapis.com/helm-benchmark/thai_exam.tar.gz",
+            "https://storage.googleapis.com/thai_dataset/thai_exam.tar.gz",
             target_path=path,
             unpack=True,
         )
-    
+
     def process_jsonl(self, jsonl_path: str, split: str) -> List[Instance]:
         instances: List[Instance] = []
         hlog(f"Reading {jsonl_path}")
-        with open(jsonl_path, 'r') as f:
+        with open(jsonl_path, "r") as f:
             for line in f:
                 data = json.loads(line)
                 # for handle missing key incase of some subject doesn't have all 5 choices
-                answers = [data.get(key, None) for key in ["a", "b", "c", "d", "e"] if data.get(key, None) != ""] 
-                answers_dict = dict(zip(["A", "B", "C", "D", "E"], answers))                
+                answers = [data[key] for key in ["a", "b", "c", "d", "e"] if key in data and data[key] != ""]
+                answers_dict = dict(zip(["A", "B", "C", "D", "E"], answers))
+
                 question, correct_answer = data["question"], answers_dict[data["answer"].upper()]
 
                 def answer_to_reference(answer: str) -> Reference:
@@ -89,18 +104,16 @@ class ThaiExamScenario(Scenario):
         return instances
 
     def get_instances(self, output_path) -> List[Instance]:
-        # Download the raw data
         data_path: str = os.path.join(output_path, "data")
         self.download_thai_exam(data_path)
 
-        # Read all the instances
         instances: List[Instance] = []
-        splits: Dict[str, str] = {            
+        splits: Dict[str, str] = {
             "train": TRAIN_SPLIT,
             "test": TEST_SPLIT,
         }
         for split in splits:
-            jsonl_path: str = os.path.join(data_path, {self.exam}, f"{self.exam}_{split}.jsonl")
+            jsonl_path: str = os.path.join(data_path, self.exam, f"{self.exam}_{split}.jsonl")
             if not os.path.exists(jsonl_path):
                 hlog(f"{jsonl_path} doesn't exist, skipping")
                 continue

--- a/src/helm/benchmark/scenarios/thai_exam_scenario.py
+++ b/src/helm/benchmark/scenarios/thai_exam_scenario.py
@@ -1,4 +1,3 @@
-import csv
 import os
 from typing import Dict, List
 import json
@@ -12,15 +11,29 @@ class ThaiExamScenario(Scenario):
     """
     ThaiExam, a benchmark comprising Thai multiple-choice examinations as follows:
 
-    ∙ ONET: The Ordinary National Educational Test (ONET) is an examination for students in Thailand. We select the grade-12 ONET exam, which comprises 5 subjects and each question has 5 choices. These subjects are Thai, English, Mathematics, Social Studies, and Science. We extracted these questions from the official 2021 ONET example, amounting to a total of 170 questions and options.
+    ∙ ONET: The Ordinary National Educational Test (ONET) is an examination for students in Thailand.
+    We select the grade-12 ONET exam, which comprises 5 subjects and each question has 5 choices.
+    These subjects are Thai, English, Mathematics, Social Studies, and Science.
+    Amounting to a total of 170 questions and options.
 
-    ∙ IC: The Investment Consultant (IC) examination, a licensing test for investment professionals in Thailand developed by the Stock Exchange of Thailand (SET), features 4 choices per question. We extracted questions for levels 1, 2, and 3 from the official SET website, resulting in a total of 95 questions and options.
+    ∙ IC: The Investment Consultant (IC) examination, a licensing test for investment professionals in Thailand.
+    Developed by the Stock Exchange of Thailand (SET), features 4 choices per question.
+    We extracted questions for levels 1, 2, and 3 resulting in a total of 95 questions and options.
 
-    ∙ TGAT: The Thai General Aptitude Test (TGAT), a national high school examination in Thailand, focuses on critical and logical thinking skills, as well as proficiency in the English language. We collected a total of 90 questions and answers. The TGAT consists of four choices per question.
+    ∙ TGAT: The Thai General Aptitude Test (TGAT), a national high school examination in Thailand.
+    Focuses on critical and logical thinking skills.
+    We collected a total of 90 questions and answers. The TGAT consists of four choices per question.
 
-    ∙ TPAT-1: The Thai Professional Aptitude Test 1 (TPAT-1) is a national high school examination in Thailand that assesses students’ professional skills requirement in medical schools. This subset contains reasoning and medical ethics. We collected a total of 116 questions and answers. The TPAT-1 consists of 5 choices per question.
+    ∙ TPAT-1: The Thai Professional Aptitude Test 1 (TPAT-1) is a national high school examination in Thailand.
+    The Exam assesses students’ professional skills requirement in medical schools.
+    This subset contains reasoning and medical ethics. We collected a total of 116 questions and answers.
+    The TPAT-1 consists of 5 choices per question.
 
-    ∙ A-Level: An academic knowledge assessment examination (Applied Knowledge Level) that covers general foundational subjects taught in schools. The content assessed in this examination aligns with the curriculum guidelines and emphasizes the practical application of knowledge in daily life. We collected a total of 175 questions and answers.
+    ∙ A-Level: An academic knowledge assessment examination (Applied Knowledge Level)
+    that covers general foundational subjects taught in schools.
+    The content assessed in this examination aligns with the curriculum guidelines
+    and emphasizes the practical application of knowledge in daily life.
+    We collected a total of 175 questions and answers.
 
     We created and used these exams to evaluate the performance of the Typhoon models(https://arxiv.org/abs/2312.13951).
 

--- a/src/helm/benchmark/scenarios/thai_exam_scenario.py
+++ b/src/helm/benchmark/scenarios/thai_exam_scenario.py
@@ -1,0 +1,109 @@
+import csv
+import os
+from typing import Dict, List
+import json
+
+from helm.common.general import ensure_file_downloaded
+from helm.common.hierarchical_logger import hlog
+from .scenario import Scenario, Instance, Reference, TRAIN_SPLIT, TEST_SPLIT, CORRECT_TAG, Input, Output
+
+
+class ThaiExamScenario(Scenario):
+    """
+    Prompt models using the following format
+
+        <input>                  # train
+        A. <reference>
+        B. <reference>
+        C. <reference>
+        D. <reference>
+        E. <reference>
+        Answer: <A/B/C/D/E>
+
+        x N (N-shot)
+
+        <input>                  # test
+        A. <reference1>
+        B. <reference2>
+        C. <reference3>
+        D. <reference4>
+        E. <reference5>
+        Answer:
+
+    For example:
+
+        ในระบบย่อยอาหารของมนุษย์ การดูดซึมสารอาหารส่วนใหญ่เกิดขึ้นที่อวัยวะใด?
+        A. ลำไส้เล็ก
+        B. ตับอ่อน
+        C. ลำไส้ใหญ่
+        D. กระเพาะอาหาร
+        E. หัวใจ
+        Answer: A
+
+        ข้อใดอธิบายเกี่ยวกับแรงไฟฟ้าได้ถูกต้อง?
+        A. เกิดได้โดยที่วัตถุไม่ต้องสัมผัสกัน
+        B. เป็นได้เฉพาะแรงผลักเท่านั้น
+        C. เป็นได้เฉพาะแรงดูดเท่านั้น
+        D. เป็นแรงต้านระหว่างวัตถุเท่านั้น
+        E. ถูกทุกข้อ
+        Answer:
+
+    Target: A
+    """
+
+    name = "thai_exam"
+    description = "Thai Exam dataset from ONET, TGAT, TPAT1, A-Level"
+    tags = ["knowledge", "multiple_choice"]
+
+    def __init__(self, exam: str):
+        super().__init__()
+        self.exam = exam
+
+    def download_thai_exam(self, path: str):
+        ensure_file_downloaded(
+            "https://storage.googleapis.com/helm-benchmark/thai_exam.tar.gz",
+            target_path=path,
+            unpack=True,
+        )
+    
+    def process_jsonl(self, jsonl_path: str, split: str) -> List[Instance]:
+        instances: List[Instance] = []
+        hlog(f"Reading {jsonl_path}")
+        with open(jsonl_path, 'r') as f:
+            for line in f:
+                data = json.loads(line)
+                # for handle missing key incase of some subject doesn't have all 5 choices
+                answers = [data.get(key, None) for key in ["a", "b", "c", "d", "e"] if data.get(key, None) != ""] 
+                answers_dict = dict(zip(["A", "B", "C", "D", "E"], answers))                
+                question, correct_answer = data["question"], answers_dict[data["answer"].upper()]
+
+                def answer_to_reference(answer: str) -> Reference:
+                    return Reference(Output(text=answer), tags=[CORRECT_TAG] if answer == correct_answer else [])
+
+                instance = Instance(
+                    input=Input(text=question),
+                    references=list(map(answer_to_reference, answers)),
+                    split=split,
+                )
+                instances.append(instance)
+        return instances
+
+    def get_instances(self, output_path) -> List[Instance]:
+        # Download the raw data
+        data_path: str = os.path.join(output_path, "data")
+        self.download_thai_exam(data_path)
+
+        # Read all the instances
+        instances: List[Instance] = []
+        splits: Dict[str, str] = {            
+            "train": TRAIN_SPLIT,
+            "test": TEST_SPLIT,
+        }
+        for split in splits:
+            jsonl_path: str = os.path.join(data_path, {self.exam}, f"{self.exam}_{split}.jsonl")
+            if not os.path.exists(jsonl_path):
+                hlog(f"{jsonl_path} doesn't exist, skipping")
+                continue
+            instances.extend(self.process_jsonl(jsonl_path, splits[split]))
+
+        return instances

--- a/src/helm/benchmark/static/schema_classic.yaml
+++ b/src/helm/benchmark/static/schema_classic.yaml
@@ -3048,3 +3048,20 @@ run_groups:
       who: n/a
       when: n/a
       language: synthetic
+
+  - name: thai_exam
+    display_name: Thai Exam
+    short_display_name: ThaiExam
+    description: A benchmark comprising Thai multiple-choice examinations.
+    metric_groups:
+      - accuracy
+      - general_information
+    environment:
+      main_name: exact_match
+      main_split: test
+    taxonomy:
+      task: question answering
+      what: "?"
+      who: "?"
+      when: "?"
+      language: Thai


### PR DESCRIPTION
This PR is to add ThaiExam scenario, 

**ThaiExam** is a benchmark comprising Thai multiple-choice examinations as follows:

**ONET:** The Ordinary National Educational Test (ONET) is an examination for students in Thailand. We select the grade-12 ONET exam, which comprises 5 subjects and each question has 5 choices. These subjects are Thai, English, Mathematics, Social Studies, and Science. We extracted these questions from the official 2021 ONET example, amounting to a total of 170 questions and options.

**IC:** The Investment Consultant (IC) examination, a licensing test for investment professionals in Thailand developed by the Stock Exchange of Thailand (SET), features 4 choices per question. We extracted questions for levels 1, 2, and 3 from the official SET website, resulting in a total of 95 questions and options.

**TGAT:** The Thai General Aptitude Test (TGAT), a national high school examination in Thailand, focuses on critical and logical thinking skills, as well as proficiency in the English language. We collected a total of 90 questions and answers. The TGAT consists of four choices per question.

**TPAT-1:** The Thai Professional Aptitude Test 1 (TPAT-1) is a national high school examination in Thailand that assesses students’ professional skills requirement in medical schools. This subset contains reasoning and medical ethics. We collected a total of 116 questions and answers. The TPAT-1 consists of 5 choices per question.

**A-Level:** An academic knowledge assessment examination (Applied Knowledge Level) that covers general foundational subjects taught in schools. The content assessed in this examination aligns with the curriculum guidelines and emphasizes the practical application of knowledge in daily life. We collected a total of 175 questions and answers.

We created and used these exams to evaluate the performance of the [Typhoon model](https://arxiv.org/abs/2312.13951).

Here are the example of runspecs.conf.

```sh
entries: [
  {description: "thai_exam:exam=onet,model=openai/gpt-3.5-turbo-0613", priority: 1}
  {description: "thai_exam:exam=tgat,model=openai/gpt-3.5-turbo-0613", priority: 1}
  {description: "thai_exam:exam=tpat1,model=openai/gpt-3.5-turbo-0613", priority: 1}
  {description: "thai_exam:exam=a_level,model=openai/gpt-3.5-turbo-0613", priority: 1}
  {description: "thai_exam:exam=ic,model=openai/gpt-3.5-turbo-0613", priority: 1}
]
```


Please let me know if you have any comment.

Thanks.
