### PR TITLE
Improve MMLU landing page

### DIFF
--- a/helm-frontend/src/components/Landing/MMLULanding.tsx
+++ b/helm-frontend/src/components/Landing/MMLULanding.tsx
@@ -1,24 +1,38 @@
+import MiniLeaderboard from "@/components/MiniLeaderboard";
+
 export default function MMLULanding() {
   return (
     <div className="container mx-auto px-16">
       <h1 className="text-3xl mt-16 my-8 font-bold text-center">
         Massive Multitask Language Understanding (MMLU) on HELM
       </h1>
-      <p>
-        <strong>Massive Multitask Language Understanding (MMLU)</strong>{" "}
-        <a href="https://arxiv.org/pdf/2009.03300.pdf" className="link">
-          (Hendrycks et al, 2020)
-        </a>{" "}
-        is a multiple-choice question answering test that covers 57 tasks
-        including elementary mathematics, US history, computer science, law, and
-        more. We publish evaluation results from evaluating various models on
-        MMLU using HELM. Our evaluation results include the following:
-      </p>
-      <ul className="my-2 list-disc list-inside">
-        <li>Standarized prompting templates for comparability</li>
-        <li>Break down of accuracy results for each of 57 subjects</li>
-        <li>Full transparency of all raw prompts and predictions</li>
-      </ul>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <div>
+          <p>
+            <strong>Massive Multitask Language Understanding (MMLU)</strong>{" "}
+            <a href="https://arxiv.org/pdf/2009.03300.pdf" className="link">
+              (Hendrycks et al, 2020)
+            </a>{" "}
+            is a multiple-choice question answering test that covers 57 tasks
+            including elementary mathematics, US history, computer science, law,
+            and more. We publish evaluation results from evaluating various
+            models on MMLU using HELM. Our evaluation results include the
+            following:
+          </p>
+          <ul className="my-2 list-disc list-inside">
+            <li>Simple, standardized prompts</li>
+            <li>Accuracy breakdown for each of the 57 subjects</li>
+            <li>Full transparency of all raw prompts and predictions</li>
+          </ul>
+          <div className="flex flex-row justify-center mt-8">
+            <a className="px-10 btn rounded-md" href="#/leaderboard">
+              Full Leaderboard
+            </a>
+          </div>
+        </div>
+        <MiniLeaderboard />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
New landing page:

![Screenshot 2024-04-01 173714](https://github.com/stanford-crfm/helm/assets/185227/1f0137c0-415f-4402-8e4f-e0b81ba36d30)

Also changes the `MiniLeaderboard` to use the first table, rather than using `core_scenarios`. This is the same change as in #2366.