### PR TITLE
Remove Anthropic import from AnthropicClaude2RunExpander

### DIFF
--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -282,6 +282,9 @@ class AnthropicClaude2RunExpander(RunExpander):
 
     name = "anthropic"
 
+    # These strings must be added to the prompt in order to pass prompt validation,
+    # otherwise the Anthropic API will return an error.
+    # See: https://docs.anthropic.com/claude/reference/prompt-validation
     HUMAN_PROMPT = "\n\nHuman:"
     AI_PROMPT = "\n\nAssistant:"
 

--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -16,7 +16,6 @@ from helm.benchmark.model_metadata_registry import (
     VISION_LANGUAGE_MODEL_TAG,
 )
 from helm.benchmark.adaptation.adapters.adapter_factory import ADAPT_GENERATION
-from helm.common.general import handle_module_not_found_error
 from helm.benchmark.model_deployment_registry import get_model_names_with_tokenizer
 from .run_spec import RunSpec
 from helm.benchmark.adaptation.adapter_spec import ADAPT_MULTIPLE_CHOICE_JOINT, AdapterSpec, Substitution
@@ -283,25 +282,26 @@ class AnthropicClaude2RunExpander(RunExpander):
 
     name = "anthropic"
 
+    HUMAN_PROMPT = "\n\nHuman:"
+    AI_PROMPT = "\n\nAssistant:"
+
     def __init__(self):
         pass
 
     def expand(self, run_spec: RunSpec) -> List[RunSpec]:
-        try:
-            import anthropic
-        except ModuleNotFoundError as e:
-            handle_module_not_found_error(e, ["anthropic"])
-
         return [
             replace(
                 run_spec,
                 name=run_spec.name,
                 adapter_spec=replace(
                     run_spec.adapter_spec,
-                    global_prefix=anthropic.HUMAN_PROMPT + " " + IN_CONTEXT_LEARNING_INSTRUCTIONS_PREFIX + "\n\n",
+                    global_prefix=AnthropicClaude2RunExpander.HUMAN_PROMPT
+                    + " "
+                    + IN_CONTEXT_LEARNING_INSTRUCTIONS_PREFIX
+                    + "\n\n",
                     global_suffix="\n\n"
                     + IN_CONTEXT_LEARNING_INSTRUCTIONS_SUFFIX
-                    + anthropic.AI_PROMPT
+                    + AnthropicClaude2RunExpander.AI_PROMPT
                     + " "
                     + run_spec.adapter_spec.output_prefix.strip(),
                 ),


### PR DESCRIPTION
This fixes an issue when running a command that doesn't use an Anthropic model still requires installing the `anthropic` library. e.g. 

```
helm-run -c src/helm/benchmark/presentation/run_specs_dec2023.conf -m 5 --suite debug --models-to-run openai/gpt-3.5-turbo-0613
```

results in:

```
helm.common.optional_dependencies.OptionalDependencyNotInstalled: Optional dependency anthropic is not installed. Please run `pip install crfm-helm[anthropic]` or `pip install crfm-helm[all]` to install it.
```

even though the command does not use any Anthropic models. This is because `AnthropicClaude2RunExpander` runs _before_ the `--models-to-run` filer is applied.