### PR TITLE
Deduplicate run_spec_names in helm-summarize

### DIFF
--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -853,7 +853,16 @@ class Summarizer:
         # Link the runs that this cell was aggregated from, if this is not a scenario table.
         # Scenario tables link to the runs in the model cells,
         # whereas non-scenario tables link to the runs in the metrics cells.
-        run_spec_names = None if is_scenario_table else aggregated_run_specs
+        run_spec_names: Optional[List] = None
+        if not is_scenario_table:
+            # Deduplicate run spec names becuase aggregated_run_specs may have duplicated
+            # run specs if a run spec belongs to multiple groups.
+            run_spec_names = []
+            run_spec_names_set = set()
+            for run_spec_name in aggregated_run_specs:
+                if run_spec_name not in run_spec_names_set:
+                    run_spec_names.append(run_spec_name)
+                    run_spec_names_set.add(run_spec_name)
 
         return Cell(
             value=value,


### PR DESCRIPTION
Workaround for #2541

Currently, the MMLU leaderboard has table cells that go to the run page with a single run, rather than going to the run directly. This is because `helm-summarize` produces `run_spec_names` in leaderboard table cells with duplicate run specs. This is a workaround that deduplicates the run specs so that the frontend can link to the run directly. A more principled fix would require a significant `helm-summarize` rewrite.