### PR TITLE
Better handling for VertexAI response content with no parts

### DIFF
--- a/src/helm/clients/vertexai_client.py
+++ b/src/helm/clients/vertexai_client.py
@@ -206,14 +206,12 @@ class VertexAIChatClient(VertexAIClient):
                 # content blocking can show up in many ways, so this defensively handles most of these ways
                 if not candidates:
                     raise VertexAIContentBlockedError("No candidates in response due to content blocking")
-                for candidate in candidates:
-                    if candidate.finish_reason in VertexAIChatClient.CONTENT_BLOCKED_FINISH_REASONS:
-                        raise VertexAIContentBlockedError(
-                            f"Content blocked with finish reason {candidate.finish_reason}"
-                        )
                 predictions: List[Dict[str, Any]] = []
                 for candidate in candidates:
-                    if not candidate.content.parts:
+                    if (
+                        candidate.finish_reason in VertexAIChatClient.CONTENT_BLOCKED_FINISH_REASONS
+                        or not candidate.content.parts
+                    ):
                         # The prediction was either blocked due to safety settings or the model stopped and returned
                         # nothing (which also happens when the model is blocked).
                         # For now, we don't cache blocked requests, because we are trying to get the

--- a/src/helm/clients/vertexai_client.py
+++ b/src/helm/clients/vertexai_client.py
@@ -204,22 +204,22 @@ class VertexAIChatClient(VertexAIClient):
 
                 # Depending on the version of the Vertex AI library and the type of content blocking,
                 # content blocking can show up in many ways, so this defensively handles most of these ways
-                if not response.candidates:
+                if not candidates:
                     raise VertexAIContentBlockedError("No candidates in response due to content blocking")
-                for candidate in response.candidates:
+                for candidate in candidates:
                     if candidate.finish_reason in VertexAIChatClient.CONTENT_BLOCKED_FINISH_REASONS:
                         raise VertexAIContentBlockedError(
                             f"Content blocked with finish reason {candidate.finish_reason}"
                         )
                 predictions: List[Dict[str, Any]] = []
-                for completion in candidates:
-                    if not completion.content.parts:
+                for candidate in candidates:
+                    if not candidate.content.parts:
                         # The prediction was either blocked due to safety settings or the model stopped and returned
                         # nothing (which also happens when the model is blocked).
                         # For now, we don't cache blocked requests, because we are trying to get the
                         # content blocking removed.
                         raise VertexAIContentBlockedError("Content has no parts due to content blocking")
-                    predictions.append({"text": completion.text})
+                    predictions.append({"text": candidate.content.text})
                     # TODO: Extract more information from the response
                 return {"predictions": predictions}
 

--- a/src/helm/clients/vertexai_client.py
+++ b/src/helm/clients/vertexai_client.py
@@ -211,18 +211,17 @@ class VertexAIChatClient(VertexAIClient):
                         raise VertexAIContentBlockedError(
                             f"Content blocked with finish reason {candidate.finish_reason}"
                         )
-                try:
-                    response_dict = {
-                        "predictions": [{"text": completion.text} for completion in candidates],
-                    }  # TODO: Extract more information from the response
-                except ValueError as e:
-                    if "Content has no parts" in str(e):
+                predictions: List[Dict[str, Any]] = []
+                for completion in candidates:
+                    if not completion.content.parts:
                         # The prediction was either blocked due to safety settings or the model stopped and returned
                         # nothing (which also happens when the model is blocked).
                         # For now, we don't cache blocked requests, because we are trying to get the
                         # content blocking removed.
                         raise VertexAIContentBlockedError("Content has no parts due to content blocking")
-                return response_dict
+                    predictions.append({"text": completion.text})
+                    # TODO: Extract more information from the response
+                return {"predictions": predictions}
 
             # We need to include the engine's name to differentiate among requests made for different model
             # engines since the engine name is not included in the request itself.


### PR DESCRIPTION
Detecting a `ValueError` no longer works because this [Google library change](https://github.com/googleapis/python-aiplatform/commit/b91edf52e2b993c3301a419ad89b473c31c60cc3) changes it from `ValueError` to `AttributeError`. In any case, relying on internal implementation details is brittle. 

Instead, we just check that `content.parts` is non-empty.

This also fixed a couple of bugs:

- Other `ValueErrors` are silently swallowed
- There was a nested double loop through `candidates` where only only a single loop was required