### PR TITLE
Require Pydantic 2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -130,6 +130,7 @@ mistral =
 openai =
     openai~=1.0
     tiktoken~=0.3.3
+    pydantic~=2.0  # For model_dump(mode="json") - openai only requires pydantic>=1.9.0
 
 google =
     google-cloud-aiplatform~=1.44


### PR DESCRIPTION
OpenAI only requires `pydantic>=1.9.0`, but we call `model_dump(mode="json")` in `OpenAIClient`, which requires Pydantic 2. Therefore we need to add `pydantic~=2.0` to our own requirements. If Pydantic <2 is installed and an OpenAI model is used, this results in the error:

```
ValueError: mode is only supported in Pydantic v2
```