### PR TITLE
Remove custom prompts from Google, Claude 3, OpenAI and Mistral models

### DIFF
--- a/src/helm/benchmark/run_spec_factory.py
+++ b/src/helm/benchmark/run_spec_factory.py
@@ -17,9 +17,7 @@ from helm.benchmark.model_metadata_registry import (
     ANTHROPIC_CLAUDE_3_MODEL_TAG,
     BUGGY_TEMP_0_TAG,
     CHATML_MODEL_TAG,
-    GOOGLE_GEMMA_INSTRUCT_MODEL_TAG,
     GOOGLE_GEMINI_MODEL_TAG,
-    GOOGLE_PALM_2_MODEL_TAG,
     IDEFICS_INSTRUCT_MODEL_TAG,
     IDEFICS_MODEL_TAG,
     LLAVA_MODEL_TAG,
@@ -27,8 +25,6 @@ from helm.benchmark.model_metadata_registry import (
     VISION_LANGUAGE_MODEL_TAG,
     NLG_PREFIX_TAG,
     NO_NEWLINES_TAG,
-    OPENAI_CHATGPT_MODEL_TAG,
-    MISTRAL_MODEL_TAG,
     ModelMetadata,
     get_model_metadata,
 )
@@ -38,14 +34,11 @@ from helm.benchmark.run_expander import (
     AnthropicClaude3RunExpander,
     ChatMLRunExpander,
     GlobalPrefixRunExpander,
-    GoogleRunExpander,
     IDEFICSInstructRunExpander,
     IncreaseTemperatureRunExpander,
     IncreaseMaxTokensRunExpander,
     LlavaRunExpander,
     OpenFlamingoRunExpander,
-    OpenAIRunExpander,
-    MistralRunExpander,
     StopRunExpander,
 )
 from helm.benchmark.run_spec import RunSpec, get_run_spec_function
@@ -130,29 +123,13 @@ def construct_run_specs(spec: ObjectSpec) -> List[RunSpec]:
             chatml_expander = ChatMLRunExpander()
             run_spec = singleton(chatml_expander.expand(run_spec))
 
-        # Anthropic prompts
+        # Anthropic Claude 1 and 2 prompts
         if ANTHROPIC_CLAUDE_1_MODEL_TAG in model.tags or ANTHROPIC_CLAUDE_2_MODEL_TAG in model.tags:
             run_spec = singleton(AnthropicClaude2RunExpander().expand(run_spec))
 
-        # Anthropic prompts
+        # Anthropic Claude 3 prompts
         if ANTHROPIC_CLAUDE_3_MODEL_TAG in model.tags:
             run_spec = singleton(AnthropicClaude3RunExpander().expand(run_spec))
-
-        # OpenAI prompts
-        if OPENAI_CHATGPT_MODEL_TAG in model.tags:
-            run_spec = singleton(OpenAIRunExpander().expand(run_spec))
-
-        # Google prompts
-        if (
-            GOOGLE_PALM_2_MODEL_TAG in model.tags
-            or GOOGLE_GEMINI_MODEL_TAG in model.tags
-            or GOOGLE_GEMMA_INSTRUCT_MODEL_TAG in model.tags
-        ):
-            run_spec = singleton(GoogleRunExpander().expand(run_spec))
-
-        # Mistral prompts
-        if MISTRAL_MODEL_TAG in model.tags:
-            run_spec = singleton(MistralRunExpander().expand(run_spec))
 
         # Google Gemini Vision returns an empty completion or throws an error if max_tokens is 1
         if (

--- a/src/helm/benchmark/run_spec_factory.py
+++ b/src/helm/benchmark/run_spec_factory.py
@@ -14,7 +14,6 @@ from helm.benchmark.model_deployment_registry import (
 from helm.benchmark.model_metadata_registry import (
     ANTHROPIC_CLAUDE_1_MODEL_TAG,
     ANTHROPIC_CLAUDE_2_MODEL_TAG,
-    ANTHROPIC_CLAUDE_3_MODEL_TAG,
     BUGGY_TEMP_0_TAG,
     CHATML_MODEL_TAG,
     GOOGLE_GEMINI_MODEL_TAG,
@@ -31,7 +30,6 @@ from helm.benchmark.model_metadata_registry import (
 from helm.benchmark.run_expander import (
     RUN_EXPANDERS,
     AnthropicClaude2RunExpander,
-    AnthropicClaude3RunExpander,
     ChatMLRunExpander,
     GlobalPrefixRunExpander,
     IDEFICSInstructRunExpander,
@@ -126,10 +124,6 @@ def construct_run_specs(spec: ObjectSpec) -> List[RunSpec]:
         # Anthropic Claude 1 and 2 prompts
         if ANTHROPIC_CLAUDE_1_MODEL_TAG in model.tags or ANTHROPIC_CLAUDE_2_MODEL_TAG in model.tags:
             run_spec = singleton(AnthropicClaude2RunExpander().expand(run_spec))
-
-        # Anthropic Claude 3 prompts
-        if ANTHROPIC_CLAUDE_3_MODEL_TAG in model.tags:
-            run_spec = singleton(AnthropicClaude3RunExpander().expand(run_spec))
 
         # Google Gemini Vision returns an empty completion or throws an error if max_tokens is 1
         if (


### PR DESCRIPTION
Multiple users have ran into issues with running various scenarios (verifiability, unitxt) due to the custom prompts. We should revert this for the v0.5.0 release until we figure out a better way to do custom prompts without breaking lots of scenarios.

The Claude 1 and 2 prompts can stay because they include the special Anthropic strings that are required for passing API validation.