### PR TITLE
Rename Sequence to GeneratedOutput

### DIFF
--- a/src/helm/benchmark/annotation/test_dummy_annotator.py
+++ b/src/helm/benchmark/annotation/test_dummy_annotator.py
@@ -5,7 +5,7 @@ import pytest
 from helm.benchmark.annotation.annotator import Annotator, DummyAnnotator
 from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.scenarios.scenario import Instance, Input
-from helm.common.request import Request, RequestResult, Sequence
+from helm.common.request import Request, RequestResult, GeneratedOutput
 
 
 class TestDummyAnnotator:
@@ -29,7 +29,7 @@ class TestDummyAnnotator:
             result=RequestResult(
                 success=True,
                 embedding=[],
-                completions=[Sequence(text="How are you?", logprob=0, tokens=[])],
+                completions=[GeneratedOutput(text="How are you?", logprob=0, tokens=[])],
                 cached=True,
             ),
         )

--- a/src/helm/benchmark/executor.py
+++ b/src/helm/benchmark/executor.py
@@ -9,7 +9,7 @@ from helm.common.cache_backend_config import (
 
 from helm.common.general import parallel_map
 from helm.common.hierarchical_logger import htrack, hlog
-from helm.common.request import RequestResult, Sequence
+from helm.common.request import RequestResult, GeneratedOutput
 from helm.common.authentication import Authentication
 from helm.proxy.services.remote_service import RemoteService
 from helm.proxy.services.server_service import ServerService
@@ -117,7 +117,7 @@ class Executor:
         if not result.success:
             if result.error_flags and not result.error_flags.is_fatal:
                 hlog(f"WARNING: Non-fatal error treated as empty completion: {result.error}")
-                result.completions = [Sequence(text="", logprob=0, tokens=[])]
+                result.completions = [GeneratedOutput(text="", logprob=0, tokens=[])]
             else:
                 raise ExecutorError(f"{str(result.error)} Request: {state.request}")
         return replace(state, result=result)

--- a/src/helm/benchmark/metrics/basic_metrics.py
+++ b/src/helm/benchmark/metrics/basic_metrics.py
@@ -13,7 +13,7 @@ from helm.benchmark.metrics.efficiency_metrics import EfficiencyMetric
 from helm.benchmark.metrics.reference_metric import ReferenceMetric
 
 from helm.common.hierarchical_logger import hlog
-from helm.common.request import Token, Sequence
+from helm.common.request import Token, GeneratedOutput
 from helm.benchmark.adaptation.adapters.adapter_factory import (
     ADAPT_MULTIPLE_CHOICE_SEPARATE_ORIGINAL,
     ADAPT_MULTIPLE_CHOICE_SEPARATE_CALIBRATED,
@@ -222,7 +222,7 @@ class BasicReferenceMetric(ReferenceMetric):
             assert len(request_state.result.completions) == 1
 
             reference_index = request_state.reference_index
-            sequence: Sequence = request_state.result.completions[0]
+            sequence: GeneratedOutput = request_state.result.completions[0]
             reference: str = request_state.instance.references[reference_index].output.text
 
             # Find the span of the completion that matches the reference.

--- a/src/helm/benchmark/metrics/bias_metrics.py
+++ b/src/helm/benchmark/metrics/bias_metrics.py
@@ -6,7 +6,7 @@ from nltk.tokenize import word_tokenize
 import numpy as np
 from helm.benchmark.metrics.evaluate_instances_metric import EvaluateInstancesMetric
 
-from helm.common.request import RequestResult, Sequence
+from helm.common.request import RequestResult, GeneratedOutput
 from helm.benchmark.adaptation.request_state import RequestState
 from .statistic import Stat
 from .metric_name import MetricName
@@ -219,7 +219,7 @@ class BiasMetric(EvaluateInstancesMetric):
 
         # Get completion texts from the request_results
         request_results: List[RequestResult] = [rs.result for rs in request_states if rs.result]
-        completions: List[Sequence] = [c for rr in request_results for c in rr.completions if rr.completions]
+        completions: List[GeneratedOutput] = [c for rr in request_results for c in rr.completions if rr.completions]
         completion_texts: List[str] = [c.text for c in completions if c.text]
 
         # Compute the bias score

--- a/src/helm/benchmark/metrics/classification_metrics.py
+++ b/src/helm/benchmark/metrics/classification_metrics.py
@@ -9,7 +9,7 @@ from helm.benchmark.metrics.evaluate_reference_metrics import normalize_text
 from helm.benchmark.metrics.metric import MetricName
 from helm.benchmark.metrics.statistic import Stat
 from helm.benchmark.scenarios.scenario import Reference
-from helm.common.request import Sequence
+from helm.common.request import GeneratedOutput
 
 
 class ClassificationMetric(EvaluateInstancesMetric):
@@ -90,7 +90,9 @@ class MultipleChoiceClassificationMetric(EvaluateInstancesMetric):
             ]
             assert len(golds) > 0, "MultipleChoiceClassificationMetric are designed for multiple_choice_* adapters"
             assert request_state.result is not None
-            sorted_completions: List[Sequence] = sorted(request_state.result.completions, key=lambda x: -x.logprob)
+            sorted_completions: List[GeneratedOutput] = sorted(
+                request_state.result.completions, key=lambda x: -x.logprob
+            )
             pred: str = sorted_completions[0].text.strip()  # Only utilize the first prediction
             if request_state.output_mapping is not None:
                 pred = request_state.output_mapping.get(pred, pred)

--- a/src/helm/benchmark/metrics/cleva_accuracy_metrics.py
+++ b/src/helm/benchmark/metrics/cleva_accuracy_metrics.py
@@ -6,7 +6,7 @@ from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.metrics.evaluate_instances_metric import EvaluateInstancesMetric
 from helm.benchmark.metrics.metric import MetricName
 from helm.benchmark.metrics.statistic import Stat
-from helm.common.request import Sequence
+from helm.common.request import GeneratedOutput
 
 
 class CLEVATopKAccuracyMetric(EvaluateInstancesMetric):
@@ -44,7 +44,9 @@ class CLEVATopKAccuracyMetric(EvaluateInstancesMetric):
             references = request_state.instance.all_correct_references
             correct_ref_texts = [ref.output.text for ref in references if ref.output.text]
 
-            sorted_completions: List[Sequence] = sorted(request_state.result.completions, key=lambda x: -x.logprob)
+            sorted_completions: List[GeneratedOutput] = sorted(
+                request_state.result.completions, key=lambda x: -x.logprob
+            )
             sorted_completions_text: List[str] = [completion.text for completion in sorted_completions]
             correct = self.correct_or_not(sorted_completions_text, correct_ref_texts)
             per_instance_accuracy.append(correct)

--- a/src/helm/benchmark/metrics/decodingtrust_stereotype_bias_metrics.py
+++ b/src/helm/benchmark/metrics/decodingtrust_stereotype_bias_metrics.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 from helm.benchmark.metrics.evaluate_instances_metric import EvaluateInstancesMetric
-from helm.common.request import Sequence
+from helm.common.request import GeneratedOutput
 from helm.common.request import RequestResult
 from helm.benchmark.adaptation.request_state import RequestState
 from .metric_name import MetricName
@@ -151,7 +151,7 @@ class StereotypeMetric(EvaluateInstancesMetric):
             request_result: Optional[RequestResult] = request_state.result
             if not request_result:
                 continue
-            generations: List[Sequence] = request_result.completions
+            generations: List[GeneratedOutput] = request_result.completions
 
             row, col, depth = self.determine_position(stereotype_topic_tag, demographic_group_tag, sys_prompt_type_tag)
 

--- a/src/helm/benchmark/metrics/disinformation_metrics.py
+++ b/src/helm/benchmark/metrics/disinformation_metrics.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from helm.common.general import ensure_file_downloaded
 from helm.common.optional_dependencies import handle_module_not_found_error
-from helm.common.request import RequestResult, Sequence
+from helm.common.request import RequestResult, GeneratedOutput
 from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from .metric import Metric
@@ -29,7 +29,7 @@ REITERATION_HUMAN_EVAL_FILE: str = "disinformation_reiteration_human_eval.json"
 WEDGING_HUMAN_EVAL_FILE: str = "disinformation_wedging_human_eval.json"
 
 
-def _self_bleu(completions: List[Sequence]) -> float:
+def _self_bleu(completions: List[GeneratedOutput]) -> float:
     """Self-BLEU.
 
     Average over all scores, where each score is the BLEU of one generation compared against all other generations.
@@ -52,7 +52,7 @@ def _self_bleu(completions: List[Sequence]) -> float:
     return sum(scores) / len(scores)
 
 
-def _monte_carlo_entropy(completions: List[Sequence]) -> float:
+def _monte_carlo_entropy(completions: List[GeneratedOutput]) -> float:
     """Monte Carlo estimate of model entropy in nats."""
     #  This estimator is biased with non-unit temperature, since OpenAI API doesn't adjust logprob
     #  computation based on temperature.
@@ -147,7 +147,7 @@ def _compute_reiteration_human_eval(
     return results
 
 
-completion_metric_fns: Dict[str, Callable[[List[Sequence]], float]] = {
+completion_metric_fns: Dict[str, Callable[[List[GeneratedOutput]], float]] = {
     "self_bleu": _self_bleu,
     "monte_carlo_entropy": _monte_carlo_entropy,
 }

--- a/src/helm/benchmark/metrics/evaluate_reference_metrics.py
+++ b/src/helm/benchmark/metrics/evaluate_reference_metrics.py
@@ -10,7 +10,7 @@ from helm.benchmark.metrics.metric_service import MetricService
 from helm.benchmark.metrics.statistic import Stat
 from helm.benchmark.scenarios.code_scenario import CodeReference
 from helm.benchmark.scenarios.scenario import Reference
-from helm.common.request import Sequence
+from helm.common.request import GeneratedOutput
 from helm.benchmark.scenarios.math_scenario import is_equiv, is_equiv_chain_of_thought
 from nltk.metrics.scores import f_measure
 from nltk.translate.bleu_score import sentence_bleu
@@ -346,7 +346,7 @@ def compute_reference_metrics(
 
     # Predicted outputs
     assert request_state.result is not None
-    sorted_completions: List[Sequence] = sorted(request_state.result.completions, key=lambda x: -x.logprob)
+    sorted_completions: List[GeneratedOutput] = sorted(request_state.result.completions, key=lambda x: -x.logprob)
     preds: List[str] = [completion.text.strip() for completion in sorted_completions]
 
     # Apply mapping if exists (e.g., for multiple-choice questions A -> Boston, B -> New York)

--- a/src/helm/benchmark/metrics/test_classification_metrics.py
+++ b/src/helm/benchmark/metrics/test_classification_metrics.py
@@ -7,7 +7,7 @@ from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.metrics.classification_metrics import ClassificationMetric
 from helm.benchmark.metrics.statistic import Stat
 from helm.benchmark.scenarios.scenario import Input, Instance, Output, Reference, CORRECT_TAG
-from helm.common.request import Request, RequestResult, Sequence
+from helm.common.request import Request, RequestResult, GeneratedOutput
 
 
 class _Option(NamedTuple):
@@ -28,7 +28,10 @@ def _request_state(prediction: str, options: List[_Option]):
         output_mapping=None,
         request=Request(model="openai/text-davinci-002", model_deployment="openai/text-davinci-002"),
         result=RequestResult(
-            success=True, embedding=[], completions=[Sequence(text=prediction, logprob=0.0, tokens=[])], cached=False
+            success=True,
+            embedding=[],
+            completions=[GeneratedOutput(text=prediction, logprob=0.0, tokens=[])],
+            cached=False,
         ),
         num_train_instances=0,
         prompt_truncated=False,

--- a/src/helm/benchmark/metrics/test_disinformation_metrics.py
+++ b/src/helm/benchmark/metrics/test_disinformation_metrics.py
@@ -4,7 +4,7 @@ from typing import List
 import numpy as np
 import pytest
 from helm.benchmark.metrics.disinformation_metrics import _monte_carlo_entropy, _self_bleu
-from helm.common.request import Sequence, Token
+from helm.common.request import GeneratedOutput, Token
 
 # Test tokens
 _TEST_1_TOKENS: List[Token] = [
@@ -25,10 +25,10 @@ test_empty_str_tokens: List[Token] = [
 ]
 
 # Test Sequences (two standard, one with an empty token, and one with no tokens)
-_TEST_1 = Sequence(text="This is a test", logprob=-1, tokens=_TEST_1_TOKENS)
-_TEST_2 = Sequence(text="This is another test", logprob=-1.25, tokens=_TEST_2_TOKENS)
-_TEST_EMPTY = Sequence(text="", logprob=-float("nan"), tokens=_TEST_EMPTY_TOKENS)
-_TEST_EMPTY_STR = Sequence(text="", logprob=0, tokens=test_empty_str_tokens)
+_TEST_1 = GeneratedOutput(text="This is a test", logprob=-1, tokens=_TEST_1_TOKENS)
+_TEST_2 = GeneratedOutput(text="This is another test", logprob=-1.25, tokens=_TEST_2_TOKENS)
+_TEST_EMPTY = GeneratedOutput(text="", logprob=-float("nan"), tokens=_TEST_EMPTY_TOKENS)
+_TEST_EMPTY_STR = GeneratedOutput(text="", logprob=0, tokens=test_empty_str_tokens)
 
 
 # Test Self-BLEU

--- a/src/helm/clients/ai21_client.py
+++ b/src/helm/clients/ai21_client.py
@@ -7,7 +7,7 @@ from helm.common.request import (
     EMBEDDING_UNAVAILABLE_REQUEST_RESULT,
     Request,
     RequestResult,
-    Sequence,
+    GeneratedOutput,
     Token,
 )
 from .client import CachingClient, truncate_sequence, cleanup_str
@@ -105,11 +105,11 @@ class AI21Client(CachingClient):
                 logprob=raw["generatedToken"]["raw_logprob"],
             )
 
-        def parse_sequence(raw: Dict, first: bool, finish_reason: Optional[Dict] = None) -> Sequence:
+        def parse_sequence(raw: Dict, first: bool, finish_reason: Optional[Dict] = None) -> GeneratedOutput:
             text = raw["text"]
             tokens = [parse_token(token, first and i == 0) for i, token in enumerate(raw["tokens"])]
             logprob = sum(token.logprob for token in tokens)
-            return Sequence(text=text, logprob=logprob, tokens=tokens, finish_reason=finish_reason)
+            return GeneratedOutput(text=text, logprob=logprob, tokens=tokens, finish_reason=finish_reason)
 
         prompt = parse_sequence(response["prompt"], True)
         completions = []

--- a/src/helm/clients/aleph_alpha_client.py
+++ b/src/helm/clients/aleph_alpha_client.py
@@ -3,7 +3,7 @@ from typing import List
 from helm.common.cache import CacheConfig
 from helm.common.media_object import TEXT_TYPE
 from helm.common.optional_dependencies import handle_module_not_found_error
-from helm.common.request import wrap_request_time, Request, RequestResult, Sequence, Token
+from helm.common.request import wrap_request_time, Request, RequestResult, GeneratedOutput, Token
 from .client import CachingClient, truncate_sequence, generate_uid_for_multimodal_prompt
 
 try:
@@ -79,7 +79,7 @@ class AlephAlphaClient(CachingClient):
             error: str = f"AlephAlphaClient error: {e}"
             return RequestResult(success=False, cached=False, error=error, completions=[], embedding=[])
 
-        completions: List[Sequence] = []
+        completions: List[GeneratedOutput] = []
         for completion in response["completions"]:
             sequence_logprob: float = 0
             tokens: List[Token] = []
@@ -96,7 +96,9 @@ class AlephAlphaClient(CachingClient):
                     )
                 )
 
-            sequence: Sequence = Sequence(text=completion["completion"], logprob=sequence_logprob, tokens=tokens)
+            sequence: GeneratedOutput = GeneratedOutput(
+                text=completion["completion"], logprob=sequence_logprob, tokens=tokens
+            )
             sequence = truncate_sequence(sequence, request)
             completions.append(sequence)
 

--- a/src/helm/clients/anthropic_client.py
+++ b/src/helm/clients/anthropic_client.py
@@ -13,7 +13,7 @@ from helm.common.request import (
     EMBEDDING_UNAVAILABLE_REQUEST_RESULT,
     Request,
     RequestResult,
-    Sequence,
+    GeneratedOutput,
     Token,
     ErrorFlags,
 )
@@ -128,7 +128,7 @@ class AnthropicClient(CachingClient):
             "top_k": request.top_k_per_token,
         }
 
-        completions: List[Sequence] = []
+        completions: List[GeneratedOutput] = []
 
         # `num_completions` is not supported, so instead make `num_completions` separate requests.
         for completion_index in range(request.num_completions):
@@ -189,7 +189,7 @@ class AnthropicClient(CachingClient):
             # Log probs are not currently not supported by the Anthropic, so set to 0 for now.
             tokens: List[Token] = [Token(text=str(text), logprob=0) for text in tokenization_result.raw_tokens]
 
-            completion = Sequence(text=response["completion"], logprob=0, tokens=tokens)
+            completion = GeneratedOutput(text=response["completion"], logprob=0, tokens=tokens)
             # See NOTE() in _filter_completion() to understand why warnings are printed for truncation.
             # TODO(#1512): Fix this with post-processing.
             sequence = truncate_sequence(completion, request, print_warning=True)
@@ -319,7 +319,7 @@ class AnthropicMessagesClient(CachingClient):
         }
         if system_message is not None:
             raw_request["system"] = cast(str, system_message["content"])
-        completions: List[Sequence] = []
+        completions: List[GeneratedOutput] = []
 
         # `num_completions` is not supported, so instead make `num_completions` separate requests.
         for completion_index in range(request.num_completions):
@@ -580,7 +580,7 @@ class AnthropicLegacyClient(CachingClient):
 
         # Since Anthropic doesn't support multiple completions, we have to manually call it multiple times,
         # and aggregate the results into `completions` and `request_time`.
-        completions: List[Sequence] = []
+        completions: List[GeneratedOutput] = []
         all_cached = True
         request_time = 0
         request_datetime: Optional[int] = None
@@ -621,7 +621,7 @@ class AnthropicLegacyClient(CachingClient):
             if finish_reason == AnthropicLegacyClient.STOP_SEQUENCE_STOP_REASON:
                 finish_reason = "stop"
 
-            completion = Sequence(
+            completion = GeneratedOutput(
                 text=response["text"],
                 logprob=sequence_logprob,
                 tokens=tokens,

--- a/src/helm/clients/bedrock_client.py
+++ b/src/helm/clients/bedrock_client.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Mapping, Optional
 
 from helm.common.cache import CacheConfig
 from helm.clients.client import CachingClient, truncate_and_tokenize_response_text
-from helm.common.request import Request, RequestResult, Sequence, wrap_request_time
+from helm.common.request import Request, RequestResult, GeneratedOutput, wrap_request_time
 from helm.clients.bedrock_utils import get_bedrock_client
 from helm.tokenizers.tokenizer import Tokenizer
 
@@ -20,7 +20,7 @@ class BedrockClient(CachingClient):
         raise NotImplementedError()
 
     @abstractmethod
-    def convert_raw_response_to_completions(self, response: Dict, request: Request) -> List[Sequence]:
+    def convert_raw_response_to_completions(self, response: Dict, request: Request) -> List[GeneratedOutput]:
         raise NotImplementedError()
 
     def __init__(
@@ -110,11 +110,11 @@ class BedrockTitanClient(BedrockClient):
             },
         }
 
-    def convert_raw_response_to_completions(self, response: Dict, request: Request) -> List[Sequence]:
+    def convert_raw_response_to_completions(self, response: Dict, request: Request) -> List[GeneratedOutput]:
         # TODO: Support the following:
         # - tokens
         # - logprob
-        completions: List[Sequence] = []
+        completions: List[GeneratedOutput] = []
         for raw_completion in response["results"]:
             output_text = raw_completion["outputText"]
             # Call lstrip() Titan has the tendency to emit "\n" as the first token in the generated text output.

--- a/src/helm/clients/cohere_client.py
+++ b/src/helm/clients/cohere_client.py
@@ -8,7 +8,7 @@ from helm.common.request import (
     EMBEDDING_UNAVAILABLE_REQUEST_RESULT,
     Request,
     RequestResult,
-    Sequence,
+    GeneratedOutput,
     Token,
 )
 from .client import CachingClient, truncate_sequence
@@ -120,7 +120,7 @@ class CohereClient(CachingClient):
             error: str = f"CohereClient error: {e}"
             return RequestResult(success=False, cached=False, error=error, completions=[], embedding=[])
 
-        completions: List[Sequence] = []
+        completions: List[GeneratedOutput] = []
         for generation in response["generations"]:
             # From https://docs.cohere.ai/generate-reference, "the likelihood refers to the average log-likelihood
             # of the entire specified string..." What we want is the sum of the log probabilities of all tokens.
@@ -140,7 +140,7 @@ class CohereClient(CachingClient):
                 # `return_likelihoods` is "ALL" and `max_tokens` is greater than 0.
                 sequence_text = request.prompt + sequence_text
 
-            completion: Sequence = Sequence(text=sequence_text, logprob=sequence_logprob, tokens=tokens)
+            completion: GeneratedOutput = GeneratedOutput(text=sequence_text, logprob=sequence_logprob, tokens=tokens)
             completion = truncate_sequence(completion, request)
             completions.append(completion)
 

--- a/src/helm/clients/google_client.py
+++ b/src/helm/clients/google_client.py
@@ -1,7 +1,7 @@
 from typing import List, Dict
 
 from helm.common.cache import CacheConfig
-from helm.common.request import Request, RequestResult, Sequence, Token
+from helm.common.request import Request, RequestResult, GeneratedOutput, Token
 from .client import CachingClient, truncate_sequence
 
 
@@ -48,7 +48,7 @@ class GoogleClient(CachingClient):
             return RequestResult(success=False, cached=False, error=error, completions=[], embedding=[])
 
         # Expect the result to be structured the same way as a response from OpenAI API.
-        completions: List[Sequence] = []
+        completions: List[GeneratedOutput] = []
         for raw_completion in response["choices"]:
             sequence_logprob = 0
             tokens: List[Token] = []
@@ -58,7 +58,7 @@ class GoogleClient(CachingClient):
                 tokens.append(Token(text=text, logprob=logprob or 0))
                 sequence_logprob += logprob or 0
 
-            completion = Sequence(
+            completion = GeneratedOutput(
                 text=raw_completion["text"],
                 logprob=sequence_logprob,
                 tokens=tokens,

--- a/src/helm/clients/http_model_client.py
+++ b/src/helm/clients/http_model_client.py
@@ -7,7 +7,7 @@ from helm.common.request import (
     wrap_request_time,
     Request,
     RequestResult,
-    Sequence,
+    GeneratedOutput,
     Token,
     EMBEDDING_UNAVAILABLE_REQUEST_RESULT,
 )
@@ -65,7 +65,7 @@ class HTTPModelClient(CachingClient):
                 response, cached = do_it(), False
 
             tokens = [Token(text=token["text"], logprob=token["logprob"]) for token in response["tokens"]]
-            completions = [Sequence(text=response["text"], logprob=response["logprob"], tokens=tokens)]
+            completions = [GeneratedOutput(text=response["text"], logprob=response["logprob"], tokens=tokens)]
 
             return RequestResult(
                 success=True,

--- a/src/helm/clients/huggingface_client.py
+++ b/src/helm/clients/huggingface_client.py
@@ -14,7 +14,7 @@ from helm.common.request import (
     EMBEDDING_UNAVAILABLE_REQUEST_RESULT,
     Request,
     RequestResult,
-    Sequence,
+    GeneratedOutput,
     Token,
 )
 from .client import CachingClient, truncate_sequence
@@ -285,7 +285,7 @@ class HuggingFaceClient(CachingClient):
                 tokens.append(Token(text=token_text, logprob=logprob))
                 sequence_logprob += logprob
 
-            completion = Sequence(text=raw_completion["text"], logprob=sequence_logprob, tokens=tokens)
+            completion = GeneratedOutput(text=raw_completion["text"], logprob=sequence_logprob, tokens=tokens)
             completion = truncate_sequence(completion, request)
             completions.append(completion)
 

--- a/src/helm/clients/image_generation/adobe_vision_client.py
+++ b/src/helm/clients/image_generation/adobe_vision_client.py
@@ -1,7 +1,7 @@
 from typing import List, Dict
 
 from helm.common.cache import Cache, CacheConfig
-from helm.common.request import Request, RequestResult, Sequence
+from helm.common.request import Request, RequestResult, GeneratedOutput
 from helm.common.tokenization_request import (
     TokenizationRequest,
     TokenizationRequestResult,
@@ -57,8 +57,10 @@ class AdobeVisionClient(Client):
             error: str = f"Adobe Vision Client error: {e}"
             return RequestResult(success=False, cached=False, error=error, completions=[], embedding=[])
 
-        completions: List[Sequence] = [
-            Sequence(text="", logprob=0, tokens=[], multimodal_content=get_single_image_multimedia_object(file_path))
+        completions: List[GeneratedOutput] = [
+            GeneratedOutput(
+                text="", logprob=0, tokens=[], multimodal_content=get_single_image_multimedia_object(file_path)
+            )
             for file_path in response["images"]
         ]
         return RequestResult(

--- a/src/helm/clients/image_generation/aleph_alpha_image_generation_client.py
+++ b/src/helm/clients/image_generation/aleph_alpha_image_generation_client.py
@@ -1,7 +1,7 @@
 from typing import List, Dict
 
 from helm.common.cache import Cache, CacheConfig
-from helm.common.request import Request, RequestResult, Sequence
+from helm.common.request import Request, RequestResult, GeneratedOutput
 from helm.common.tokenization_request import (
     TokenizationRequest,
     TokenizationRequestResult,
@@ -77,8 +77,10 @@ class AlephAlphaImageGenerationClient(Client):
             error: str = f"AlephAlphaVisionClient error: {e}"
             return RequestResult(success=False, cached=False, error=error, completions=[], embedding=[])
 
-        completions: List[Sequence] = [
-            Sequence(text="", logprob=0, tokens=[], multimodal_content=get_single_image_multimedia_object(file_path))
+        completions: List[GeneratedOutput] = [
+            GeneratedOutput(
+                text="", logprob=0, tokens=[], multimodal_content=get_single_image_multimedia_object(file_path)
+            )
             for file_path in response["images"]
         ]
         return RequestResult(

--- a/src/helm/clients/image_generation/cogview2_client.py
+++ b/src/helm/clients/image_generation/cogview2_client.py
@@ -11,7 +11,7 @@ from helm.common.cache import CacheConfig, Cache
 from helm.common.file_caches.file_cache import FileCache
 from helm.common.hierarchical_logger import hlog, htrack_block
 from helm.common.optional_dependencies import handle_module_not_found_error
-from helm.common.request import Request, RequestResult, Sequence, wrap_request_time
+from helm.common.request import Request, RequestResult, GeneratedOutput, wrap_request_time
 from helm.common.tokenization_request import (
     DecodeRequest,
     DecodeRequestResult,
@@ -170,8 +170,10 @@ class CogView2Client(Client):
             error: str = f"CogView2Client error: {e}"
             return RequestResult(success=False, cached=False, error=error, completions=[], embedding=[])
 
-        completions: List[Sequence] = [
-            Sequence(text="", logprob=0, tokens=[], multimodal_content=get_single_image_multimedia_object(location))
+        completions: List[GeneratedOutput] = [
+            GeneratedOutput(
+                text="", logprob=0, tokens=[], multimodal_content=get_single_image_multimedia_object(location)
+            )
             for location in results["file_locations"]
         ]
         return RequestResult(

--- a/src/helm/clients/image_generation/dalle2_client.py
+++ b/src/helm/clients/image_generation/dalle2_client.py
@@ -6,7 +6,7 @@ from helm.common.general import hlog
 from helm.common.file_caches.file_cache import FileCache
 from helm.common.media_object import MultimediaObject
 from helm.common.optional_dependencies import handle_module_not_found_error
-from helm.common.request import Request, RequestResult, Sequence, wrap_request_time
+from helm.common.request import Request, RequestResult, GeneratedOutput, wrap_request_time
 from helm.common.tokenization_request import (
     TokenizationRequest,
     TokenizationRequestResult,
@@ -68,7 +68,7 @@ class DALLE2Client(Client):
         Return a RequestResult with no images and a finish reason indicating that the prompt / generated images
         violate OpenAI's content policy.
         """
-        no_image = Sequence(
+        no_image = GeneratedOutput(
             text="",
             logprob=0,
             tokens=[],
@@ -168,8 +168,8 @@ class DALLE2Client(Client):
         except openai.OpenAIError as e:
             return self.handle_openai_error(request, e)
 
-        completions: List[Sequence] = [
-            Sequence(
+        completions: List[GeneratedOutput] = [
+            GeneratedOutput(
                 text="",
                 logprob=0,
                 tokens=[],

--- a/src/helm/clients/image_generation/dalle3_client.py
+++ b/src/helm/clients/image_generation/dalle3_client.py
@@ -4,7 +4,7 @@ from helm.common.cache import CacheConfig
 from helm.common.file_caches.file_cache import FileCache
 from helm.common.general import singleton
 from helm.common.optional_dependencies import handle_module_not_found_error
-from helm.common.request import Request, RequestResult, Sequence, wrap_request_time
+from helm.common.request import Request, RequestResult, GeneratedOutput, wrap_request_time
 from helm.clients.moderation_api_client import ModerationAPIClient
 from helm.clients.client import CachingClient
 from .dalle2_client import DALLE2Client
@@ -82,12 +82,12 @@ class DALLE3Client(DALLE2Client):
             except openai.OpenAIError as e:
                 return self.handle_openai_error(request, e)
 
-        completions: List[Sequence] = []
+        completions: List[GeneratedOutput] = []
         total_request_time: float = 0
         for response in responses:
             image_response: Dict[str, Any] = singleton(response["data"])
             completions.append(
-                Sequence(
+                GeneratedOutput(
                     # From https://cookbook.openai.com/articles/what_is_new_with_dalle_3,
                     # "a new feature in the latest DALL·E-3 API is prompt rewriting, where we use
                     # GPT-4 to optimize all of your prompts before they’re passed to DALL-E."

--- a/src/helm/clients/image_generation/dalle_mini_client.py
+++ b/src/helm/clients/image_generation/dalle_mini_client.py
@@ -7,7 +7,7 @@ from helm.common.cache import CacheConfig, Cache
 from helm.common.file_caches.file_cache import FileCache
 from helm.common.hierarchical_logger import hlog, htrack_block
 from helm.common.optional_dependencies import handle_module_not_found_error
-from helm.common.request import Request, RequestResult, Sequence, wrap_request_time
+from helm.common.request import Request, RequestResult, GeneratedOutput, wrap_request_time
 from helm.common.tokenization_request import (
     DecodeRequest,
     DecodeRequestResult,
@@ -169,8 +169,8 @@ class DALLEMiniClient(Client):
             error: str = f"DALLEMiniClient error: {e}"
             return RequestResult(success=False, cached=False, error=error, completions=[], embedding=[])
 
-        completions: List[Sequence] = [
-            Sequence(
+        completions: List[GeneratedOutput] = [
+            GeneratedOutput(
                 text="", logprob=0, tokens=[], multimodal_content=get_single_image_multimedia_object(file_location)
             )
             for file_location in results["file_locations"]

--- a/src/helm/clients/image_generation/deep_floyd_client.py
+++ b/src/helm/clients/image_generation/deep_floyd_client.py
@@ -1,7 +1,7 @@
 from typing import List, Dict
 
 from helm.common.cache import Cache, CacheConfig
-from helm.common.request import Request, RequestResult, Sequence
+from helm.common.request import Request, RequestResult, GeneratedOutput
 from helm.common.tokenization_request import (
     TokenizationRequest,
     TokenizationRequestResult,
@@ -57,8 +57,10 @@ class DeepFloydClient(Client):
             error: str = f"DeepFloyd Client error: {e}"
             return RequestResult(success=False, cached=False, error=error, completions=[], embedding=[])
 
-        completions: List[Sequence] = [
-            Sequence(text="", logprob=0, tokens=[], multimodal_content=get_single_image_multimedia_object(file_path))
+        completions: List[GeneratedOutput] = [
+            GeneratedOutput(
+                text="", logprob=0, tokens=[], multimodal_content=get_single_image_multimedia_object(file_path)
+            )
             for file_path in response["images"]
         ]
         return RequestResult(

--- a/src/helm/clients/image_generation/huggingface_diffusers_client.py
+++ b/src/helm/clients/image_generation/huggingface_diffusers_client.py
@@ -9,7 +9,7 @@ from helm.common.file_caches.file_cache import FileCache
 from helm.common.gpu_utils import get_torch_device_name, is_cuda_available
 from helm.common.hierarchical_logger import hlog, htrack_block
 from helm.common.optional_dependencies import handle_module_not_found_error
-from helm.common.request import Request, RequestResult, Sequence, wrap_request_time
+from helm.common.request import Request, RequestResult, GeneratedOutput, wrap_request_time
 from helm.common.tokenization_request import (
     DecodeRequest,
     DecodeRequestResult,
@@ -181,8 +181,8 @@ class HuggingFaceDiffusersClient(Client):
             error: str = f"HuggingFaceDiffusersClient error: {ex}"
             return RequestResult(success=False, cached=False, error=error, completions=[], embedding=[])
 
-        completions: List[Sequence] = [
-            Sequence(
+        completions: List[GeneratedOutput] = [
+            GeneratedOutput(
                 text="", logprob=0, tokens=[], multimodal_content=get_single_image_multimedia_object(file_location)
             )
             for file_location in results["file_locations"]

--- a/src/helm/clients/image_generation/lexica_client.py
+++ b/src/helm/clients/image_generation/lexica_client.py
@@ -6,7 +6,7 @@ import urllib.parse
 from helm.common.cache import CacheConfig, Cache
 from helm.common.file_caches.file_cache import FileCache
 from helm.common.images_utils import encode_base64
-from helm.common.request import Request, RequestResult, Sequence, wrap_request_time
+from helm.common.request import Request, RequestResult, GeneratedOutput, wrap_request_time
 from helm.common.tokenization_request import (
     TokenizationRequest,
     TokenizationRequestResult,
@@ -65,8 +65,10 @@ class LexicaClient(Client):
             error: str = f"LexicaClient error: {e}"
             return RequestResult(success=False, cached=False, error=error, completions=[], embedding=[])
 
-        completions: List[Sequence] = [
-            Sequence(text="", logprob=0, tokens=[], multimodal_content=get_single_image_multimedia_object(location))
+        completions: List[GeneratedOutput] = [
+            GeneratedOutput(
+                text="", logprob=0, tokens=[], multimodal_content=get_single_image_multimedia_object(location)
+            )
             for location in response["image_locations"]
         ]
         return RequestResult(

--- a/src/helm/clients/image_generation/mindalle_client.py
+++ b/src/helm/clients/image_generation/mindalle_client.py
@@ -7,7 +7,7 @@ from helm.common.file_caches.file_cache import FileCache
 from helm.common.gpu_utils import get_torch_device_name
 from helm.common.hierarchical_logger import hlog, htrack_block
 from helm.common.optional_dependencies import handle_module_not_found_error
-from helm.common.request import Request, RequestResult, Sequence, wrap_request_time
+from helm.common.request import Request, RequestResult, GeneratedOutput, wrap_request_time
 from helm.common.tokenization_request import (
     DecodeRequest,
     DecodeRequestResult,
@@ -94,8 +94,10 @@ class MinDALLEClient(Client):
             error: str = f"MinDALLEClient error: {ex}"
             return RequestResult(success=False, cached=False, error=error, completions=[], embedding=[])
 
-        completions: List[Sequence] = [
-            Sequence(text="", logprob=0, tokens=[], multimodal_content=get_single_image_multimedia_object(location))
+        completions: List[GeneratedOutput] = [
+            GeneratedOutput(
+                text="", logprob=0, tokens=[], multimodal_content=get_single_image_multimedia_object(location)
+            )
             for location in results["file_locations"]
         ]
         return RequestResult(

--- a/src/helm/clients/image_generation/together_image_generation_client.py
+++ b/src/helm/clients/image_generation/together_image_generation_client.py
@@ -4,7 +4,7 @@ import requests
 
 from helm.common.cache import CacheConfig, Cache
 from helm.common.file_caches.file_cache import FileCache
-from helm.common.request import Request, RequestResult, Sequence, wrap_request_time
+from helm.common.request import Request, RequestResult, GeneratedOutput, wrap_request_time
 from helm.common.tokenization_request import (
     TokenizationRequest,
     TokenizationRequestResult,
@@ -87,8 +87,8 @@ class TogetherImageGenerationClient(Client):
             error: str = f"TogetherVisionClient error: {e}"
             return RequestResult(success=False, cached=False, error=error, completions=[], embedding=[])
 
-        completions: List[Sequence] = [
-            Sequence(
+        completions: List[GeneratedOutput] = [
+            GeneratedOutput(
                 text="",
                 logprob=0,
                 tokens=[],

--- a/src/helm/clients/lit_gpt_client.py
+++ b/src/helm/clients/lit_gpt_client.py
@@ -9,7 +9,7 @@ import torch
 
 from helm.common.cache import CacheConfig
 from helm.common.optional_dependencies import OptionalDependencyNotInstalled
-from helm.common.request import Request, RequestResult, Sequence, Token
+from helm.common.request import Request, RequestResult, GeneratedOutput, Token
 from helm.tokenizers.tokenizer import Tokenizer
 
 from .client import CachingClient
@@ -157,7 +157,7 @@ class LitGPTClient(CachingClient):
         generated_tokens = []
         for token in tokens:
             generated_tokens.append(Token(text=tokenizer.decode(token), logprob=0))
-        completions = [Sequence(text=output, logprob=0, tokens=generated_tokens)]
+        completions = [GeneratedOutput(text=output, logprob=0, tokens=generated_tokens)]
 
         return RequestResult(
             success=True,

--- a/src/helm/clients/megatron_client.py
+++ b/src/helm/clients/megatron_client.py
@@ -9,7 +9,7 @@ from helm.common.request import (
     EMBEDDING_UNAVAILABLE_REQUEST_RESULT,
     Request,
     RequestResult,
-    Sequence,
+    GeneratedOutput,
     Token,
 )
 from helm.common.tokenization_request import TokenizationRequest
@@ -87,7 +87,7 @@ class MegatronClient(CachingClient):
 
         # NOTE: Megatron returns the de-tokenized response. Re-tokenize.
         tokens = self._tokenize_response(generated_text)
-        completion = Sequence(text=generated_text, logprob=0, tokens=tokens)
+        completion = GeneratedOutput(text=generated_text, logprob=0, tokens=tokens)
         completion = truncate_sequence(completion, request, print_warning=True)
 
         return RequestResult(

--- a/src/helm/clients/mistral_client.py
+++ b/src/helm/clients/mistral_client.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, TypedDict
 from helm.proxy.retry import NonRetriableException
 from helm.common.cache import CacheConfig
 from helm.common.optional_dependencies import handle_module_not_found_error
-from helm.common.request import wrap_request_time, Request, RequestResult, Sequence
+from helm.common.request import wrap_request_time, Request, RequestResult, GeneratedOutput
 from helm.tokenizers.tokenizer import Tokenizer
 from .client import CachingClient, truncate_and_tokenize_response_text
 
@@ -84,7 +84,7 @@ class MistralAIClient(CachingClient):
 
     def make_request(self, request: Request) -> RequestResult:
         """Make a request"""
-        completions: List[Sequence] = []
+        completions: List[GeneratedOutput] = []
 
         # `num_completions` is not supported, so instead make `num_completions` separate requests.
         for completion_index in range(request.num_completions):

--- a/src/helm/clients/palmyra_client.py
+++ b/src/helm/clients/palmyra_client.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List
 
 from helm.common.cache import CacheConfig
 from helm.common.hierarchical_logger import hlog
-from helm.common.request import wrap_request_time, Request, RequestResult, Sequence, Token, ErrorFlags
+from helm.common.request import wrap_request_time, Request, RequestResult, GeneratedOutput, Token, ErrorFlags
 from helm.common.tokenization_request import (
     TokenizationRequest,
     TokenizationRequestResult,
@@ -67,7 +67,7 @@ class PalmyraClient(CachingClient):
             # "random_seed": request.random,
         }
 
-        completions: List[Sequence] = []
+        completions: List[GeneratedOutput] = []
         model_name: str = request.model_engine
 
         # `num_completions` is not supported, so instead make `num_completions` separate requests.
@@ -130,7 +130,7 @@ class PalmyraClient(CachingClient):
             # Log probs are not currently not supported by the Writer, so set to 0 for now.
             tokens: List[Token] = [Token(text=str(text), logprob=0) for text in tokenization_result.raw_tokens]
 
-            completion = Sequence(text=response_text, logprob=0, tokens=tokens)
+            completion = GeneratedOutput(text=response_text, logprob=0, tokens=tokens)
             sequence = truncate_sequence(completion, request, print_warning=True)
             completions.append(sequence)
 

--- a/src/helm/clients/simple_client.py
+++ b/src/helm/clients/simple_client.py
@@ -3,7 +3,7 @@ from typing import List, TypedDict
 from typing import Dict, Any
 
 from helm.common.cache import CacheConfig
-from helm.common.request import wrap_request_time, Request, RequestResult, Sequence, Token
+from helm.common.request import wrap_request_time, Request, RequestResult, GeneratedOutput, Token
 from helm.clients.client import CachingClient
 
 
@@ -33,7 +33,7 @@ class SimpleClient(CachingClient):
         response, cached = self.cache.get(cache_key, wrap_request_time(do_it))
         logprob = 0
         completions = [
-            Sequence(
+            GeneratedOutput(
                 text=text,
                 logprob=logprob,
                 tokens=[Token(text=text, logprob=logprob)],

--- a/src/helm/clients/test_auto_client.py
+++ b/src/helm/clients/test_auto_client.py
@@ -1,7 +1,7 @@
 import dataclasses
 from tempfile import TemporaryDirectory
 from helm.common.cache_backend_config import BlackHoleCacheBackendConfig
-from helm.common.request import Sequence, Token
+from helm.common.request import GeneratedOutput, Token
 
 import pytest
 
@@ -37,7 +37,7 @@ class TestAutoClient:
             success=True,
             embedding=[],
             completions=[
-                Sequence(
+                GeneratedOutput(
                     text=" intelligent species on the planet. They are also one",
                     logprob=-9.087313510477543,
                     tokens=[

--- a/src/helm/clients/test_client.py
+++ b/src/helm/clients/test_client.py
@@ -2,11 +2,11 @@ from helm.common.cache import BlackHoleCacheConfig
 from helm.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer
 from .client import truncate_sequence, truncate_and_tokenize_response_text
 from typing import List
-from helm.common.request import Request, Sequence, Token
+from helm.common.request import Request, GeneratedOutput, Token
 
 
 def truncate_sequence_helper(tokens: List[str], request: Request, expected_tokens: List[str]):
-    sequence = Sequence(
+    sequence = GeneratedOutput(
         text="".join(tokens),
         tokens=[Token(text=text, logprob=-1) for text in tokens],
         logprob=-len(tokens),

--- a/src/helm/clients/test_simple_client.py
+++ b/src/helm/clients/test_simple_client.py
@@ -1,6 +1,6 @@
 from helm.clients.simple_client import SimpleClient
 from helm.common.cache import BlackHoleCacheConfig
-from helm.common.request import Sequence, Request, Token
+from helm.common.request import GeneratedOutput, Request, Token
 
 
 def test_simple_client_make_request():
@@ -16,4 +16,4 @@ def test_simple_client_make_request():
     assert result.success
     assert not result.cached
     assert result.embedding == []
-    assert result.completions == [Sequence(text="most", logprob=0, tokens=[Token(text="most", logprob=0)])]
+    assert result.completions == [GeneratedOutput(text="most", logprob=0, tokens=[Token(text="most", logprob=0)])]

--- a/src/helm/clients/together_client.py
+++ b/src/helm/clients/together_client.py
@@ -5,7 +5,7 @@ import requests
 from retrying import retry
 
 from helm.common.cache import CacheConfig
-from helm.common.request import wrap_request_time, Request, RequestResult, Sequence, Token
+from helm.common.request import wrap_request_time, Request, RequestResult, GeneratedOutput, Token
 from .client import CachingClient, truncate_sequence, cleanup_str
 
 
@@ -220,7 +220,7 @@ class TogetherClient(CachingClient):
                 )
 
         # Expect the result to be structured the same way as a response from OpenAI API.
-        completions: List[Sequence] = []
+        completions: List[GeneratedOutput] = []
         for raw_completion in response["choices"]:
             sequence_logprob = 0
             tokens: List[Token] = []
@@ -243,7 +243,7 @@ class TogetherClient(CachingClient):
             raw_finish_reason: Optional[str] = raw_completion.get("finish_reason")
             finish_reason: Optional[Dict] = {"reason": raw_finish_reason} if raw_finish_reason else None
 
-            completion = Sequence(
+            completion = GeneratedOutput(
                 text=cleanup_str(raw_completion["text"], "together"),
                 logprob=sequence_logprob,
                 tokens=tokens,

--- a/src/helm/clients/vertexai_client.py
+++ b/src/helm/clients/vertexai_client.py
@@ -7,7 +7,7 @@ from helm.common.cache import CacheConfig
 from helm.common.hierarchical_logger import hlog
 from helm.common.media_object import TEXT_TYPE
 from helm.common.optional_dependencies import handle_module_not_found_error
-from helm.common.request import wrap_request_time, Request, RequestResult, Sequence, ErrorFlags
+from helm.common.request import wrap_request_time, Request, RequestResult, GeneratedOutput, ErrorFlags
 from helm.clients.client import CachingClient, truncate_sequence, generate_uid_for_multimodal_prompt
 
 try:
@@ -71,7 +71,7 @@ class VertexAITextClient(VertexAIClient):
             # "echo": request.echo_prompt,
         }
 
-        completions: List[Sequence] = []
+        completions: List[GeneratedOutput] = []
         model_name: str = request.model_engine
 
         try:
@@ -114,7 +114,7 @@ class VertexAITextClient(VertexAIClient):
             # https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/text#response_body
             # Python SDK reference:
             # https://github.com/googleapis/python-aiplatform/blob/beae48f63e40ea171c3f1625164569e7311b8e5a/vertexai/language_models/_language_models.py#L868
-            completion = Sequence(text=text, logprob=0, tokens=[])
+            completion = GeneratedOutput(text=text, logprob=0, tokens=[])
             sequence = truncate_sequence(completion, request, print_warning=True)
             completions.append(sequence)
 
@@ -183,7 +183,7 @@ class VertexAIChatClient(VertexAIClient):
             # "echo": request.echo_prompt,
         }
 
-        completions: List[Sequence] = []
+        completions: List[GeneratedOutput] = []
         model_name: str = request.model_engine
         model = self.get_model(model_name)
 
@@ -277,7 +277,7 @@ class VertexAIChatClient(VertexAIClient):
 
             # The Python SDK does not support echo
             text: str = request.prompt + response_text if request.echo_prompt else response_text
-            completion = Sequence(text=text, logprob=0, tokens=[])
+            completion = GeneratedOutput(text=text, logprob=0, tokens=[])
             sequence = truncate_sequence(completion, request, print_warning=True)
             completions.append(sequence)
 
@@ -292,7 +292,7 @@ class VertexAIChatClient(VertexAIClient):
 
     def _make_multimodal_request(self, request: Request) -> RequestResult:
         def complete_for_valid_error(error_message: str) -> RequestResult:
-            empty_completion = Sequence(
+            empty_completion = GeneratedOutput(
                 text="",
                 logprob=0,
                 tokens=[],
@@ -333,7 +333,7 @@ class VertexAIChatClient(VertexAIClient):
             "candidate_count": 1,
         }
 
-        completions: List[Sequence] = []
+        completions: List[GeneratedOutput] = []
         model_name: str = request.model_engine
         model = self.get_model(model_name)
 
@@ -372,7 +372,7 @@ class VertexAIChatClient(VertexAIClient):
                 return complete_for_valid_error(response["error"])
 
             response_text = response["predictions"][0]["text"]
-            completion = Sequence(text=response_text, logprob=0, tokens=[])
+            completion = GeneratedOutput(text=response_text, logprob=0, tokens=[])
             sequence = truncate_sequence(completion, request, print_warning=True)
             completions.append(sequence)
 

--- a/src/helm/clients/vision_language/huggingface_vlm_client.py
+++ b/src/helm/clients/vision_language/huggingface_vlm_client.py
@@ -8,7 +8,7 @@ from helm.common.cache import CacheConfig
 from helm.common.images_utils import open_image
 from helm.common.media_object import TEXT_TYPE
 from helm.common.optional_dependencies import handle_module_not_found_error
-from helm.common.request import Request, RequestResult, Sequence, Token
+from helm.common.request import Request, RequestResult, GeneratedOutput, Token
 from helm.common.tokenization_request import (
     TokenizationRequest,
     TokenizationRequestResult,
@@ -94,7 +94,7 @@ class HuggingFaceVLMClient(CachingClient):
             TokenizationRequest(result["generated_text"], tokenizer=self.tokenizer_name)
         )
         tokens: List[Token] = [Token(text=str(text), logprob=0) for text in tokenization_result.raw_tokens]
-        completions: List[Sequence] = [Sequence(text=result["generated_text"], logprob=0, tokens=tokens)]
+        completions: List[GeneratedOutput] = [GeneratedOutput(text=result["generated_text"], logprob=0, tokens=tokens)]
         return RequestResult(
             success=True,
             cached=cached,

--- a/src/helm/clients/vision_language/idefics_client.py
+++ b/src/helm/clients/vision_language/idefics_client.py
@@ -11,7 +11,7 @@ from helm.common.gpu_utils import get_torch_device_name
 from helm.common.hierarchical_logger import hlog, htrack_block
 from helm.common.media_object import TEXT_TYPE
 from helm.common.optional_dependencies import handle_module_not_found_error
-from helm.common.request import Request, RequestResult, Sequence, Token
+from helm.common.request import Request, RequestResult, GeneratedOutput, Token
 from helm.common.tokenization_request import TokenizationRequest
 from helm.common.request import wrap_request_time
 from helm.clients.client import CachingClient, generate_uid_for_multimodal_prompt
@@ -111,7 +111,7 @@ class IDEFICSClient(CachingClient):
                 raise ValueError(f"Unrecognized MediaObject type {media_object.type}")
         prompt_text: str = request.multimodal_prompt.text.replace(self.END_OF_UTTERANCE_TOKEN, " ")
 
-        completions: List[Sequence] = []
+        completions: List[GeneratedOutput] = []
         with htrack_block(f"Generating for prompt: {prompt_text}"):
             try:
 
@@ -152,7 +152,7 @@ class IDEFICSClient(CachingClient):
                     TokenizationRequest(text, tokenizer=self.tokenizer_name, encode=False)
                 )
                 tokens: List[Token] = [Token(text=str(text), logprob=0) for text in tokenization_result.raw_tokens]
-                completions.append(Sequence(text=text, logprob=0, tokens=tokens))
+                completions.append(GeneratedOutput(text=text, logprob=0, tokens=tokens))
 
         return RequestResult(
             success=True,

--- a/src/helm/clients/vision_language/open_flamingo_client.py
+++ b/src/helm/clients/vision_language/open_flamingo_client.py
@@ -10,7 +10,7 @@ from helm.common.images_utils import open_image
 from helm.common.gpu_utils import get_torch_device_name
 from helm.common.media_object import TEXT_TYPE
 from helm.common.optional_dependencies import handle_module_not_found_error
-from helm.common.request import Request, RequestResult, Sequence, Token
+from helm.common.request import Request, RequestResult, GeneratedOutput, Token
 from helm.common.request import wrap_request_time
 from helm.clients.vision_language.open_flamingo import create_model_and_transforms
 from helm.clients.client import CachingClient, generate_uid_for_multimodal_prompt
@@ -134,7 +134,7 @@ class OpenFlamingoClient(CachingClient):
         except RuntimeError as ex:
             return RequestResult(success=False, cached=False, error=str(ex), completions=[], embedding=[])
 
-        completions: List[Sequence] = []
+        completions: List[GeneratedOutput] = []
         for text, tokens in result["output"]:
             # Remove the prompt from the generated text
             text = (
@@ -143,7 +143,7 @@ class OpenFlamingoClient(CachingClient):
                 else text[-1]
             )
             completions.append(
-                Sequence(text=text, logprob=0, tokens=[Token(text=token, logprob=0) for token in tokens])
+                GeneratedOutput(text=text, logprob=0, tokens=[Token(text=token, logprob=0) for token in tokens])
             )
 
         return RequestResult(

--- a/src/helm/clients/vision_language/qwen_vlm_client.py
+++ b/src/helm/clients/vision_language/qwen_vlm_client.py
@@ -9,7 +9,7 @@ from helm.common.cache import CacheConfig
 from helm.common.gpu_utils import get_torch_device_name
 from helm.common.hierarchical_logger import hlog, htrack_block
 from helm.common.media_object import TEXT_TYPE
-from helm.common.request import Request, RequestResult, Sequence, Token
+from helm.common.request import Request, RequestResult, GeneratedOutput, Token
 from helm.common.request import wrap_request_time
 from helm.clients.client import CachingClient, generate_uid_for_multimodal_prompt
 
@@ -104,7 +104,7 @@ class QwenVLMClient(CachingClient):
             else:
                 raise ValueError(f"Unrecognized MediaObject type {media_object.type}")
 
-        completions: List[Sequence] = []
+        completions: List[GeneratedOutput] = []
         request_time: float = 0
         request_datetime: Optional[int] = None
         all_cached: bool = True
@@ -151,7 +151,9 @@ class QwenVLMClient(CachingClient):
 
                 # Tokenize truncated text to get the list of tokens
                 completions.append(
-                    Sequence(text=text, logprob=0, tokens=[Token(text=str(token), logprob=0) for token in tokens])
+                    GeneratedOutput(
+                        text=text, logprob=0, tokens=[Token(text=str(token), logprob=0) for token in tokens]
+                    )
                 )
 
                 request_time += result["request_time"]

--- a/src/helm/common/request.py
+++ b/src/helm/common/request.py
@@ -112,8 +112,8 @@ class Token:
 
 
 @dataclass(frozen=True)
-class Sequence:
-    """A `Sequence` is a sequence of tokens."""
+class GeneratedOutput:
+    """A `GeneratedOutput` is a single generated output that may contain text or multimodal content."""
 
     # The concatenation of all the tokens
     text: str
@@ -130,8 +130,8 @@ class Sequence:
     # Could be a sequence made up of multimedia content
     multimodal_content: Optional[MultimediaObject] = None
 
-    def __add__(self, other: "Sequence") -> "Sequence":
-        return Sequence(self.text + other.text, self.logprob + other.logprob, self.tokens + other.tokens)
+    def __add__(self, other: "GeneratedOutput") -> "GeneratedOutput":
+        return GeneratedOutput(self.text + other.text, self.logprob + other.logprob, self.tokens + other.tokens)
 
     def render_lines(self) -> List[str]:
         result = [
@@ -170,7 +170,7 @@ class RequestResult:
     embedding: List[float]
     """Fixed dimensional embedding corresponding to the entire prompt"""
 
-    completions: List[Sequence]
+    completions: List[GeneratedOutput]
     """List of completion"""
 
     cached: bool

--- a/src/helm/proxy/critique/model_critique_client.py
+++ b/src/helm/proxy/critique/model_critique_client.py
@@ -12,7 +12,7 @@ from helm.common.critique_request import (
 )
 from helm.common.hierarchical_logger import hlog
 from helm.common.optional_dependencies import handle_module_not_found_error
-from helm.common.request import Request, RequestResult, Sequence
+from helm.common.request import Request, RequestResult, GeneratedOutput
 from helm.clients.client import Client
 from helm.proxy.critique.critique_client import CritiqueClient
 
@@ -114,7 +114,7 @@ class ModelCritiqueClient(CritiqueClient):
         return answers
 
     def _multiple_choice_completion_to_answer(
-        self, question: CritiqueQuestionTemplate, completion: Sequence
+        self, question: CritiqueQuestionTemplate, completion: GeneratedOutput
     ) -> Optional[str]:
         """Convert a multiple choice completion to an answer."""
         assert question.question_type == "multiple_choice"
@@ -131,7 +131,7 @@ class ModelCritiqueClient(CritiqueClient):
             return None
 
     def _checkbox_completion_to_answer(
-        self, question: CritiqueQuestionTemplate, completion: Sequence
+        self, question: CritiqueQuestionTemplate, completion: GeneratedOutput
     ) -> Optional[List[str]]:
         """Convert a checkbox completion to an answer."""
         assert question.question_type == "checkbox"
@@ -147,7 +147,9 @@ class ModelCritiqueClient(CritiqueClient):
             hlog(f"Error parsing answer: {e}. Skipping question (and so the respondent entirely)")
             return None
 
-    def _free_response_completion_to_answer(self, question: CritiqueQuestionTemplate, completion: Sequence) -> str:
+    def _free_response_completion_to_answer(
+        self, question: CritiqueQuestionTemplate, completion: GeneratedOutput
+    ) -> str:
         """Convert a free response completion to an answer."""
         assert question.question_type == "free_response"
         return completion.text

--- a/src/helm/proxy/token_counters/auto_token_counter.py
+++ b/src/helm/proxy/token_counters/auto_token_counter.py
@@ -1,7 +1,7 @@
 from typing import List
 from helm.benchmark.model_deployment_registry import ModelDeployment, get_model_deployment
 
-from helm.common.request import Request, Sequence
+from helm.common.request import Request, GeneratedOutput
 from helm.tokenizers.auto_tokenizer import AutoTokenizer
 from helm.common.tokenization_request import TokenizationRequest, TokenizationRequestResult
 from .token_counter import TokenCounter
@@ -13,7 +13,7 @@ class AutoTokenCounter(TokenCounter):
     def __init__(self, auto_tokenizer: AutoTokenizer):
         self.auto_tokenizer: AutoTokenizer = auto_tokenizer
 
-    def count_tokens(self, request: Request, completions: List[Sequence]) -> int:
+    def count_tokens(self, request: Request, completions: List[GeneratedOutput]) -> int:
         """Counts tokens based on the model deployment.
 
         This counts the number of tokens in the request and completions.

--- a/src/helm/proxy/token_counters/test_auto_token_counter.py
+++ b/src/helm/proxy/token_counters/test_auto_token_counter.py
@@ -1,7 +1,7 @@
 from typing import List
 from helm.common.cache_backend_config import BlackHoleCacheBackendConfig
 
-from helm.common.request import Request, Sequence, Token
+from helm.common.request import Request, GeneratedOutput, Token
 from helm.tokenizers.auto_tokenizer import AutoTokenizer
 from helm.proxy.token_counters.auto_token_counter import AutoTokenCounter
 
@@ -21,8 +21,8 @@ class TestAutoTokenCounter:
             "that aims to make fundamental advances in the study, development, "
             "and deployment of foundation models.",
         )
-        completions: List[Sequence] = [
-            Sequence(
+        completions: List[GeneratedOutput] = [
+            GeneratedOutput(
                 text=" The CRFM is dedicated to advancing our knowledge of the foundations of artificial intelligence "
                 "(AI) and related fields. It focuses on foundational questions in AI, which are",
                 logprob=-49.00783279519999,
@@ -79,8 +79,8 @@ class TestAutoTokenCounter:
             "that aims to make fundamental advances in the study, development, "
             "and deployment of foundation models.\n\nAssistant:",
         )
-        completions: List[Sequence] = [
-            Sequence(
+        completions: List[GeneratedOutput] = [
+            GeneratedOutput(
                 text="Thank you for the background information. The Center for Research "
                 "on Foundation Models sounds like an interesting initiative focused on "
                 "advancing research and responsible development of large AI models. I "

--- a/src/helm/proxy/token_counters/token_counter.py
+++ b/src/helm/proxy/token_counters/token_counter.py
@@ -1,13 +1,13 @@
 from abc import ABC, abstractmethod
 from typing import List
 
-from helm.common.request import Sequence, Request
+from helm.common.request import GeneratedOutput, Request
 
 
 class TokenCounter(ABC):
     """Counts the number of tokens used given `Request` and completions."""
 
     @abstractmethod
-    def count_tokens(self, request: Request, completions: List[Sequence]) -> int:
+    def count_tokens(self, request: Request, completions: List[GeneratedOutput]) -> int:
         """Counts the total number of tokens given a request and completions."""
         pass


### PR DESCRIPTION
Redoing the changes from #2334.

Rationale:

- Before we allow external users to write their own plug-in HELM clients (e.g. for DataComp) and publish user documentation, we need to stabilize the Python API. After users start writing plug-in HELM clients, these APIs cannot be changed without breaking existing users. The `Sequence` type is currently exposed to these users.
- `Sequence` is not a good name, because some completions (e.g. generated images from text-to-image models) are not sequences.
- `Sequence` is already the name of a [commonly-used type](https://docs.python.org/3/library/collections.abc.html#collections.abc.Sequence) in the Python standard library, and this can cause name collisions.
- The field name is already called `completion`, and `completion: Sequence` looks weird.

Changes:

- Rename `Sequence` to `GeneratedOutput` (previous rejected suggestion: `Completion`).