### PR TITLE
Add Seed-Bench and MME scenarios

### DIFF
--- a/src/helm/benchmark/run_specs/vlm_run_specs.py
+++ b/src/helm/benchmark/run_specs/vlm_run_specs.py
@@ -416,6 +416,48 @@ def get_pope_spec() -> RunSpec:
     )
 
 
+@run_spec_function("seed_bench")
+def get_seed_bench_spec(subject: str) -> RunSpec:
+    scenario_spec = ScenarioSpec(
+        class_name="helm.benchmark.scenarios.vision_language.seed_bench_scenario.SEEDBenchScenario",
+        args={"subject": subject},
+    )
+    adapter_spec: AdapterSpec = get_multiple_choice_joint_adapter_spec(
+        input_noun=None, output_noun="Answer", max_train_instances=0
+    )
+    metric_specs: List[MetricSpec] = get_exact_match_metric_specs()
+
+    run_spec_name: str = "seed_bench"
+    return RunSpec(
+        name=run_spec_name,
+        scenario_spec=scenario_spec,
+        adapter_spec=adapter_spec,
+        metric_specs=metric_specs,
+        groups=[run_spec_name],
+    )
+
+
+@run_spec_function("mme")
+def get_mme_spec(subject: str) -> RunSpec:
+    scenario_spec = ScenarioSpec(
+        class_name="helm.benchmark.scenarios.vision_language.mme_scenario.MMEScenario",
+        args={"subject": subject},
+    )
+    adapter_spec: AdapterSpec = get_multiple_choice_joint_adapter_spec(
+        input_noun=None, output_noun="Answer", max_train_instances=0
+    )
+    metric_specs: List[MetricSpec] = get_exact_match_metric_specs()
+
+    run_spec_name: str = "mme"
+    return RunSpec(
+        name=run_spec_name,
+        scenario_spec=scenario_spec,
+        adapter_spec=adapter_spec,
+        metric_specs=metric_specs,
+        groups=[run_spec_name],
+    )
+
+
 @run_spec_function("heim_human_eval")
 def get_heim_human_eval_spec(question_type: str) -> RunSpec:
     scenario_spec = ScenarioSpec(

--- a/src/helm/benchmark/scenarios/vision_language/mme_scenario.py
+++ b/src/helm/benchmark/scenarios/vision_language/mme_scenario.py
@@ -1,0 +1,145 @@
+import os.path
+from typing import List
+
+from datasets import load_dataset
+from tqdm import tqdm
+
+from helm.benchmark.scenarios.scenario import (
+    CORRECT_TAG,
+    TEST_SPLIT,
+    Instance,
+    Input,
+    Output,
+    Reference,
+    Scenario,
+)
+from helm.common.media_object import MediaObject, MultimediaObject
+from helm.common.general import ensure_directory_exists
+
+
+class MMEScenario(Scenario):
+    """
+        MME: A Comprehensive Evaluation Benchmark for Multimodal Large Language Models
+
+        Multimodal Large Language Model (MLLM) relies on the powerful LLM to perform
+        multimodal tasks, showing amazing emergent abilities in recent studies. However,
+        it is difficult for these case studies to fully reflect the performance of MLLM,
+        lacking a comprehensive evaluation. In MME, we fill in this blank, presenting
+        the first comprehensive MLLM Evaluation benchmark MME. It measures both perception
+        and cognition abilities on a total of 14 subtasks. In order to avoid data leakage
+        that may arise from direct use of public datasets for evaluation, the annotations
+        of instruction-answer pairs are all manually designed. The concise instruction design
+        allows us to fairly compare MLLMs, instead of struggling in prompt engineering.
+        Besides, with such an instruction, we can also easily carry out quantitative
+        statistics. We rephrase the answer type of MME to multiple-choice question-answering.
+        We use the multiple-choice metrics for 14 different evaluation tasks.
+
+        @article{fu2023mme,
+        title={MME: A Comprehensive Evaluation Benchmark for Multimodal Large Language Models},
+        author={Fu, Chaoyou and Chen, Peixian and Shen, Yunhang and Qin, Yulei and
+        Zhang, Mengdan and Lin, Xu and Yang, Jinrui and Zheng, Xiawu and Li, Ke and
+        Sun, Xing and Wu, Yunsheng and Ji, Rongrong},
+        journal={arXiv preprint arXiv:2306.13394},
+        year={2023}
+    }
+
+        Paper: https://arxiv.org/abs/2306.13394
+    """
+
+    MME_HUGGINGFACE_DATASET_NAME: str = "lmms-lab/MME"
+
+    SUBJECTS: List[str] = [
+        "existence",
+        "scene",
+        "posters",
+        "color",
+        "OCR",
+        "position",
+        "celebrity",
+        "artwork",
+        "commonsense_reasoning",
+        "numerical_calculation",
+        "landmark",
+        "count",
+        "text_translation",
+        "code_reasoning",
+    ]
+
+    name = "mme"
+    description = "Evaluate multimodal models on  ([paper](https://arxiv.org/abs/2306.13394))."
+    tags = ["vision-language"]
+    options: List[str] = ["Yes", "No"]
+
+    def __init__(self, subject: str):
+        super().__init__()
+        assert subject in self.SUBJECTS, f"Invalid subject: {subject}"
+        self._subject: str = subject
+
+    def get_label_from_answer(self, answer: str):
+        label: str
+        if answer == "Yes":
+            label = "A"
+        elif answer == "No":
+            label = "B"
+        else:
+            raise NotImplementedError(f"Invalid answer: {answer}")
+        return label
+
+    def remove_question_suffix_for_mcqa(self, question: str):
+        return question.replace("Please answer yes or no.", "").strip()
+
+    def get_question_id(self, question_id: str):
+        return question_id.split(".")[0].replace("/", "-")
+
+    def get_instances(self, output_path: str) -> List[Instance]:
+        images_path: str = os.path.join(output_path, "images")
+        ensure_directory_exists(images_path)
+
+        # There is only the test split in Unicorn benchmark
+        instances: List[Instance] = []
+        # Process the test set
+        # Two open-ended generation instances and
+        # one multi-choice generation instance per row
+        for row in tqdm(
+            load_dataset(
+                self.MME_HUGGINGFACE_DATASET_NAME,
+                split=TEST_SPLIT,
+                cache_dir=output_path,
+            )
+        ):
+            if row["category"] != self._subject:
+                continue
+            question_id: str = self.get_question_id(row["question_id"])
+            # Save the image locally
+            image_path: str = os.path.join(images_path, f"{question_id}.png")
+            if not os.path.exists(image_path):
+                row["image"].save(image_path)
+
+            question: str = self.remove_question_suffix_for_mcqa(row["question"])
+            answer: str = row["answer"]
+            references: List[Reference] = []
+
+            answer = self.get_label_from_answer(answer)
+            # The given correct answer is a letter, but we need an index
+            correct_answer_index: int = ord(answer) - ord("A")
+            # The options are originally appended to the question
+
+            for i, option in enumerate(self.options):
+                reference: Reference
+                is_correct: bool = i == correct_answer_index
+                reference = Reference(Output(text=option), tags=[CORRECT_TAG] if is_correct else [])
+                references.append(reference)
+
+            content = [
+                MediaObject(location=image_path, content_type="image/png"),
+                MediaObject(text=question, content_type="text/plain"),
+            ]
+            instances.append(
+                Instance(
+                    Input(multimedia_content=MultimediaObject(content)),
+                    references=references,
+                    split=TEST_SPLIT,
+                )
+            )
+
+        return instances

--- a/src/helm/benchmark/scenarios/vision_language/pope_scenario.py
+++ b/src/helm/benchmark/scenarios/vision_language/pope_scenario.py
@@ -70,7 +70,7 @@ class POPEScenario(Scenario):
         ):
             image_source: str = row["image_source"]
             # Save the image locally
-            image_path: str = os.path.join(output_path, f"{image_source}.jpg")
+            image_path: str = os.path.join(images_path, f"{image_source}.jpg")
             if not os.path.exists(image_path):
                 row["image"].save(image_path)
 

--- a/src/helm/benchmark/scenarios/vision_language/seed_bench_scenario.py
+++ b/src/helm/benchmark/scenarios/vision_language/seed_bench_scenario.py
@@ -1,0 +1,129 @@
+import os.path
+from typing import Dict, List
+
+from datasets import load_dataset
+from tqdm import tqdm
+
+from helm.benchmark.scenarios.scenario import (
+    CORRECT_TAG,
+    TEST_SPLIT,
+    Instance,
+    Input,
+    Output,
+    Reference,
+    Scenario,
+)
+from helm.common.media_object import MediaObject, MultimediaObject
+from helm.common.general import ensure_directory_exists
+
+
+class SEEDBenchScenario(Scenario):
+    """
+    SEED-Bench: Benchmarking Multimodal LLMs with Generative Comprehension
+
+    Based on powerful Large Language Models (LLMs), recent generative Multimodal
+    Large Language Models (MLLMs) have gained prominence as a pivotal research area.
+    In Seed-Bench, we address the evaluation of generative comprehension in MLLMs
+    as a preliminary step towards a comprehensive assessment of generative models.
+    SEED-Bench consists of 19K multiple choice questions with accurate human annotations
+    (x 6 larger than existing benchmarks), which spans 12 evaluation dimensions
+    including the comprehension of both the image and video modality. We select 9
+    evaluation aspects that take image as the input. In the benchmark,
+    Multiple-choice questions with groundtruth options derived from human
+    annotation enables an objective and efficient assessment of model performance,
+    eliminating the need for human or GPT intervention during evaluation. We employ
+    the multiple-choice metric for evaluating the performance of models.
+
+    @article{li2023seed,
+    title={Seed-bench: Benchmarking multimodal llms with generative comprehension},
+    author={Li, Bohao and Wang, Rui and Wang, Guangzhi and Ge, Yuying and Ge, Yixiao and Shan, Ying},
+    journal={arXiv preprint arXiv:2307.16125},
+    year={2023}
+    }
+
+    Paper: https://arxiv.org/abs/2307.16125
+    """
+
+    SEED_BENCH_HUGGINGFACE_DATASET_NAME: str = "lmms-lab/SEED-Bench"
+
+    SUBJECTS: Dict[str, int] = {
+        "scene-understanding": 1,
+        "instance-identity": 2,
+        "instance-attributes": 3,
+        "instance-location": 4,
+        "instances-counting": 5,
+        "spatial-relation": 6,
+        "instance-interaction": 7,
+        "visual-reasoning": 8,
+        "text-understanding": 9,
+    }
+
+    name = "seed_bench"
+    description = "Evaluate multimodal models on  ([paper](https://arxiv.org/abs/2307.16125))."
+    tags = ["vision-language"]
+
+    def __init__(self, subject: str):
+        super().__init__()
+        assert subject in self.SUBJECTS, f"Invalid subject: {subject}"
+        self._subject: str = subject
+
+    def get_subject_name(self, subject_name: str) -> str:
+        return "-".join(subject_name.lower().split())
+
+    def get_instances(self, output_path: str) -> List[Instance]:
+        images_path: str = os.path.join(output_path, "images")
+        ensure_directory_exists(images_path)
+
+        # There is only the test split in Unicorn benchmark
+        instances: List[Instance] = []
+        # Process the test set
+        # Two open-ended generation instances and
+        # one multi-choice generation instance per row
+        for row in tqdm(
+            load_dataset(
+                self.SEED_BENCH_HUGGINGFACE_DATASET_NAME,
+                split=TEST_SPLIT,
+                cache_dir=output_path,
+            )
+        ):
+            question_type_key: str = self.get_subject_name(self._subject)
+            if row["question_type_id"] != self.SUBJECTS[question_type_key]:
+                continue
+            question_id: str = row["question_id"]
+            # Download the image
+            # Save the image locally
+            image_path: str = os.path.join(images_path, f"{question_id}.png")
+            if not os.path.exists(image_path):
+                # some images are CMYK mode, convert to RGB.
+                row["image"][0].convert("RGB").save(image_path, "PNG", optimize=True)
+
+            # Add the references
+            references: List[Reference] = []
+            question: str = row["question"]
+            answer: str
+            content: List[MediaObject]
+            options: List[str] = [row["choice_a"], row["choice_b"], row["choice_c"], row["choice_d"]]
+            answer = row["answer"].strip()
+            # The given correct answer is a letter, but we need an index
+            correct_answer_index: int = ord(answer) - ord("A")
+            # The options are originally appended to the question
+
+            for i, option in enumerate(options):
+                reference: Reference
+                is_correct: bool = i == correct_answer_index
+                reference = Reference(Output(text=option), tags=[CORRECT_TAG] if is_correct else [])
+                references.append(reference)
+
+            content = [
+                MediaObject(location=image_path, content_type="image/png"),
+                MediaObject(text=question, content_type="text/plain"),
+            ]
+            instances.append(
+                Instance(
+                    Input(multimedia_content=MultimediaObject(content)),
+                    references=references,
+                    split=TEST_SPLIT,
+                )
+            )
+
+        return instances

--- a/src/helm/benchmark/static/schema_vlm.yaml
+++ b/src/helm/benchmark/static/schema_vlm.yaml
@@ -290,6 +290,8 @@ run_groups:
       - bingo
       - multipanelvqa
       - pope
+      - seed_bench
+      - mme
 
   - name: heim_human_eval
     display_name: HEIM Human Eval Scenario
@@ -450,9 +452,9 @@ run_groups:
       when: "2023"
       language: English
 
-    - name: seed_bench
+  - name: seed_bench
     display_name: Seed Bench 
-    description: A massive multiple-choice question-answering benchmark spans 9 evaluation aspects with the image input
+    description: A massive multiple-choice question-answering benchmark that spans 9 evaluation aspects with the image input
     including the comprehension of both the image and video modality
     metric_groups:
       - accuracy
@@ -468,7 +470,7 @@ run_groups:
       when: "2023"
       language: English
 
-    - name: mme
+  - name: mme
     display_name: MME
     description: A comprehensive MLLM Evaluation benchmark with perception and cognition evaluations on 14 subtasks
     metric_groups:

--- a/src/helm/benchmark/static/schema_vlm.yaml
+++ b/src/helm/benchmark/static/schema_vlm.yaml
@@ -450,6 +450,41 @@ run_groups:
       when: "2023"
       language: English
 
+    - name: seed_bench
+    display_name: Seed Bench 
+    description: A massive multiple-choice question-answering benchmark spans 9 evaluation aspects with the image input
+    including the comprehension of both the image and video modality
+    metric_groups:
+      - accuracy
+      - efficiency
+      - general_information
+    environment:
+      main_name: exact_match
+      main_split: test
+    taxonomy:
+      task: multiple-choice question answering
+      what: Real-world images
+      who: Human experts
+      when: "2023"
+      language: English
+
+    - name: mme
+    display_name: MME
+    description: A comprehensive MLLM Evaluation benchmark with perception and cognition evaluations on 14 subtasks
+    metric_groups:
+      - accuracy
+      - efficiency
+      - general_information
+    environment:
+      main_name: exact_match
+      main_split: test
+    taxonomy:
+      task: multiple-choice question answering
+      what: Real-world images
+      who: Human experts
+      when: "2023"
+      language: English
+
   - name: image2latex
     display_name: Image2LaTeX
     description: The Image2LaTeX benchmark for converting images of mathematical equations, tables. algorithms and tikz to LaTeX.


### PR DESCRIPTION
Hello, this PR is to add two vision-language scenarios to VHELM --- Seed-Bench from https://arxiv.org/abs/2307.16125 and the MME benchmark from https://arxiv.org/abs/2306.13394.

For both benchmarks, I reformulated both of them as MCQA tasks. For Seed-Bench, I excluded the video reasoning task because VHELM doesn't currently support it.

Here are successful execution screenshots, conf files, and scenario_state files for two benchmarks.

Seed-Bench
`screenshot`
![image](https://github.com/stanford-crfm/helm/assets/36613953/0824e055-952a-4c8f-af06-e8dbb435a287)

`conf file`
```
entries: [
    {description: "seed_bench:subject=scene-understanding,model=qwen/qwen-vl-chat", priority: 1}
    {description: "seed_bench:subject=spatial-relation,model=qwen/qwen-vl-chat", priority: 1}
    ]
```

`scenario state`
[seedbench_scenario_state.json](https://github.com/stanford-crfm/helm/files/14920361/seedbench_scenario_state.json)


MME
`screenshot`
![image](https://github.com/stanford-crfm/helm/assets/36613953/755cd9b0-4412-43a2-b416-4a71869adde8)

`conf file`
```
entries: [
    {description: "mme:subject=landmark,model=qwen/qwen-vl-chat", priority: 1}
    {description: "mme:subject=count,model=qwen/qwen-vl-chat", priority: 1}
    ]
```

`scenario state`
[mme_scenario_state.json](https://github.com/stanford-crfm/helm/files/14920369/mme_scenario_state.json)

Also, I've fixed a typo in the POPE scenario. Please let me know how I can improve it. Thanks!