### PR TITLE
Fix MongoKeyValueStore.remove()

### DIFF
--- a/src/helm/common/mongo_key_value_store.py
+++ b/src/helm/common/mongo_key_value_store.py
@@ -85,4 +85,5 @@ class MongoKeyValueStore(KeyValueStore):
         self._collection.bulk_write(operations)
 
     def remove(self, key: Dict) -> None:
-        self._collection.delete_one(key)
+        query = {self._REQUEST_KEY: self._canonicalize_key(key)}
+        self._collection.delete_one(query)


### PR DESCRIPTION
Previously, this method would not delete anything (and potentially stall for a long time on a large MongoDB collection) because the query was incorrect.