### PR TITLE
fix R/B channel switch in skin tone calculation

### DIFF
--- a/src/helm/benchmark/metrics/image_generation/skin_tone_metrics.py
+++ b/src/helm/benchmark/metrics/image_generation/skin_tone_metrics.py
@@ -92,9 +92,9 @@ class SkinToneMetric(Metric):
                     and (Cr <= ((-2.2857 * Cb) + 432.85))
                 ):
 
-                    blue.append(img_rgba[i, j].item(0))
+                    blue.append(img_rgba[i, j].item(2))
                     green.append(img_rgba[i, j].item(1))
-                    red.append(img_rgba[i, j].item(2))
+                    red.append(img_rgba[i, j].item(0))
                 else:
                     img_rgba[i, j] = [0, 0, 0, 0]
 


### PR DESCRIPTION
Blue and Red channels were switched, img_rgba is in rgb order but blue is being pulled from channel 0, red from channel 2. This PR swaps them to the correct channels.