### PR TITLE
Add FollowTheFormatInstructionsRunExpander

### DIFF
--- a/docs/reproducing_leaderboards.md
+++ b/docs/reproducing_leaderboards.md
@@ -37,7 +37,7 @@ The following specifies the appropriate parameters and configuration files for a
 ### Lite
 
 ```bash
-export RUN_ENTRIES_CONF_PATH=run_entries_dec2023.conf
+export RUN_ENTRIES_CONF_PATH=run_entries_lite_20240424.conf
 export SCHEMA_PATH=schema_lite.yaml
 export NUM_TRAIN_TRIALS=1
 export MAX_EVAL_INSTANCES=1000

--- a/src/helm/benchmark/presentation/run_entries_lite_20240424.conf
+++ b/src/helm/benchmark/presentation/run_entries_lite_20240424.conf
@@ -1,0 +1,133 @@
+# HELM scenarios.
+
+entries: [
+  # NarrativeQA
+  {description: "narrative_qa:model=text,follow_the_format_instructions=instruct", priority: 1}
+
+  # NaturalQuestions
+  {description: "natural_qa:model=text,mode=openbook_longans,follow_the_format_instructions=instruct", priority: 1}
+  {description: "natural_qa:model=text,mode=closedbook,follow_the_format_instructions=instruct", priority: 1}
+
+  # OpenbookQA
+  {description: "commonsense:model=text_code,dataset=openbookqa,method=multiple_choice_joint", priority: 1}
+
+  # MMLU
+  {description: "mmlu:model=text,subject=abstract_algebra", priority: 2}
+  {description: "mmlu:model=text,subject=anatomy", priority: 3}
+  {description: "mmlu:model=text,subject=college_chemistry", priority: 2}
+  {description: "mmlu:model=text,subject=computer_security", priority: 2}
+  {description: "mmlu:model=text,subject=econometrics", priority: 2}
+  {description: "mmlu:model=text,subject=global_facts", priority: 3}
+  {description: "mmlu:model=text,subject=jurisprudence", priority: 3}
+  {description: "mmlu:model=text,subject=philosophy", priority: 3}
+  {description: "mmlu:model=text,subject=professional_medicine", priority: 3}
+  {description: "mmlu:model=text,subject=us_foreign_policy", priority: 2}
+  {description: "mmlu:model=text,subject=astronomy", priority: 4}
+  {description: "mmlu:model=text,subject=business_ethics", priority: 4}
+  {description: "mmlu:model=text,subject=clinical_knowledge", priority: 4}
+  {description: "mmlu:model=text,subject=college_biology", priority: 4}
+  {description: "mmlu:model=text,subject=college_computer_science", priority: 4}
+  {description: "mmlu:model=text,subject=college_mathematics", priority: 4}
+  {description: "mmlu:model=text,subject=college_medicine", priority: 4}
+  {description: "mmlu:model=text,subject=college_physics", priority: 4}
+  {description: "mmlu:model=text,subject=conceptual_physics", priority: 4}
+  {description: "mmlu:model=text,subject=electrical_engineering", priority: 4}
+  {description: "mmlu:model=text,subject=elementary_mathematics", priority: 4}
+  {description: "mmlu:model=text,subject=formal_logic", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_biology", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_chemistry", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_computer_science", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_european_history", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_geography", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_government_and_politics", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_macroeconomics", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_mathematics", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_microeconomics", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_physics", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_psychology", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_statistics", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_us_history", priority: 4}
+  {description: "mmlu:model=text,subject=high_school_world_history", priority: 4}
+  {description: "mmlu:model=text,subject=human_aging", priority: 4}
+  {description: "mmlu:model=text,subject=human_sexuality", priority: 4}
+  {description: "mmlu:model=text,subject=international_law", priority: 4}
+  {description: "mmlu:model=text,subject=logical_fallacies", priority: 4}
+  {description: "mmlu:model=text,subject=machine_learning", priority: 4}
+  {description: "mmlu:model=text,subject=management", priority: 4}
+  {description: "mmlu:model=text,subject=marketing", priority: 4}
+  {description: "mmlu:model=text,subject=medical_genetics", priority: 4}
+  {description: "mmlu:model=text,subject=miscellaneous", priority: 4}
+  {description: "mmlu:model=text,subject=moral_disputes", priority: 4}
+  {description: "mmlu:model=text,subject=moral_scenarios", priority: 4}
+  {description: "mmlu:model=text,subject=nutrition", priority: 4}
+  {description: "mmlu:model=text,subject=prehistory", priority: 4}
+  {description: "mmlu:model=text,subject=professional_accounting", priority: 4}
+  {description: "mmlu:model=text,subject=professional_law", priority: 4}
+  {description: "mmlu:model=text,subject=professional_psychology", priority: 4}
+  {description: "mmlu:model=text,subject=public_relations", priority: 4}
+  {description: "mmlu:model=text,subject=security_studies", priority: 4}
+  {description: "mmlu:model=text,subject=sociology", priority: 4}
+  {description: "mmlu:model=text,subject=virology", priority: 4}
+  {description: "mmlu:model=text,subject=world_religions", priority: 4}
+
+  # MATH
+  {description: "math:model=text_code,subject=number_theory,level=1,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 2}
+  {description: "math:model=text_code,subject=intermediate_algebra,level=1,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 2}
+  {description: "math:model=text_code,subject=algebra,level=1,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 2}
+  {description: "math:model=text_code,subject=prealgebra,level=1,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 2}
+  {description: "math:model=text_code,subject=geometry,level=1,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 2}
+  {description: "math:model=text_code,subject=counting_and_probability,level=1,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 2}
+  {description: "math:model=text_code,subject=precalculus,level=1,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 2}
+
+  {description: "math:model=text_code,subject=number_theory,level=2,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 4}
+  {description: "math:model=text_code,subject=intermediate_algebra,level=2,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 4}
+  {description: "math:model=text_code,subject=algebra,level=2,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 4}
+  {description: "math:model=text_code,subject=prealgebra,level=2,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 4}
+  {description: "math:model=text_code,subject=geometry,level=2,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 4}
+  {description: "math:model=text_code,subject=counting_and_probability,level=2,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 4}
+  {description: "math:model=text_code,subject=precalculus,level=2,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 4}
+
+  {description: "math:model=text_code,subject=number_theory,level=3,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 3}
+  {description: "math:model=text_code,subject=intermediate_algebra,level=3,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 3}
+  {description: "math:model=text_code,subject=algebra,level=3,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 3}
+  {description: "math:model=text_code,subject=prealgebra,level=3,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 3}
+  {description: "math:model=text_code,subject=geometry,level=3,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 3}
+  {description: "math:model=text_code,subject=counting_and_probability,level=3,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 3}
+  {description: "math:model=text_code,subject=precalculus,level=3,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 3}
+
+  {description: "math:model=text_code,subject=number_theory,level=4,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 4}
+  {description: "math:model=text_code,subject=intermediate_algebra,level=4,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 4}
+  {description: "math:model=text_code,subject=algebra,level=4,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 4}
+  {description: "math:model=text_code,subject=prealgebra,level=4,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 4}
+  {description: "math:model=text_code,subject=geometry,level=4,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 4}
+  {description: "math:model=text_code,subject=counting_and_probability,level=4,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 4}
+  {description: "math:model=text_code,subject=precalculus,level=4,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 4}
+
+  {description: "math:model=text_code,subject=number_theory,level=5,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 3}
+  {description: "math:model=text_code,subject=intermediate_algebra,level=5,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 3}
+  {description: "math:model=text_code,subject=algebra,level=5,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 3}
+  {description: "math:model=text_code,subject=prealgebra,level=5,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 3}
+  {description: "math:model=text_code,subject=geometry,level=5,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 3}
+  {description: "math:model=text_code,subject=counting_and_probability,level=5,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 3}
+  {description: "math:model=text_code,subject=precalculus,level=5,use_chain_of_thought=True,follow_the_format_instructions=instruct", priority: 3}
+
+  # GSM
+  {description: "gsm:model=text_code,follow_the_format_instructions=instruct", priority: 2}
+
+  # LegalBench
+  {description: "legalbench:model=text_code,subset=abercrombie,follow_the_format_instructions=instruct", priority: 2}
+  {description: "legalbench:model=text_code,subset=corporate_lobbying,follow_the_format_instructions=instruct", priority: 2}
+  {description: "legalbench:model=text_code,subset=international_citizenship_questions,follow_the_format_instructions=instruct", priority: 2}
+  {description: "legalbench:model=text_code,subset=function_of_decision_section,follow_the_format_instructions=instruct", priority: 2}
+  {description: "legalbench:model=text_code,subset=proa,follow_the_format_instructions=instruct", priority: 2}
+
+  # MedQA
+  {description: "med_qa:model=text_code", priority: 2}
+
+  # WMT14
+  {description: "wmt_14:language_pair=cs-en,model=text,follow_the_format_instructions=instruct", priority: 2}
+  {description: "wmt_14:language_pair=de-en,model=text,follow_the_format_instructions=instruct", priority: 2}
+  {description: "wmt_14:language_pair=fr-en,model=text,follow_the_format_instructions=instruct", priority: 2}
+  {description: "wmt_14:language_pair=hi-en,model=text,follow_the_format_instructions=instruct", priority: 2}
+  {description: "wmt_14:language_pair=ru-en,model=text,follow_the_format_instructions=instruct", priority: 2}
+]

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -263,8 +263,6 @@ models:
     release_date: 2021-12-01
     tags: [TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG, ABLATION_MODEL_TAG]
 
-
-
   # Berkeley
   - name: berkeley/koala-13b # NOT SUPPORTED
     display_name: Koala (13B)
@@ -534,7 +532,7 @@ models:
     access: open
     num_parameters: 132000000000
     release_date: 2024-03-27
-    tags: [TEXT_MODEL_TAG, PARTIAL_FUNCTIONALITY_TEXT_MODEL_TAG]
+    tags: [TEXT_MODEL_TAG, PARTIAL_FUNCTIONALITY_TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
 
 
   # DeepMind
@@ -670,7 +668,7 @@ models:
     creator_organization_name: Google
     access: limited
     release_date: 2023-12-13
-    tags: [TEXT_MODEL_TAG, GOOGLE_GEMINI_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG]
+    tags: [TEXT_MODEL_TAG, GOOGLE_GEMINI_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
 
   - name: google/gemini-1.0-pro-001
     display_name: Gemini 1.0 Pro
@@ -678,7 +676,7 @@ models:
     creator_organization_name: Google
     access: limited
     release_date: 2023-12-13
-    tags: [TEXT_MODEL_TAG, GOOGLE_GEMINI_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG]
+    tags: [TEXT_MODEL_TAG, GOOGLE_GEMINI_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
 
     # Note: This is aliased to a snapshot of gemini-pro-vision. When possible, please use a versioned snapshot instead.
   - name: google/gemini-pro-vision
@@ -703,7 +701,7 @@ models:
     creator_organization_name: Google
     access: limited
     release_date: 2024-04-10
-    tags: [TEXT_MODEL_TAG, GOOGLE_GEMINI_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG]
+    tags: [TEXT_MODEL_TAG, GOOGLE_GEMINI_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
 
   - name: google/gemma-2b
     display_name: Gemma (2B)

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -263,6 +263,8 @@ models:
     release_date: 2021-12-01
     tags: [TEXT_MODEL_TAG, FULL_FUNCTIONALITY_TEXT_MODEL_TAG, ABLATION_MODEL_TAG]
 
+
+
   # Berkeley
   - name: berkeley/koala-13b # NOT SUPPORTED
     display_name: Koala (13B)


### PR DESCRIPTION
This implements the policy for the "follow the format" prompt that we discussed in person: in HELM Lite *only*, a model gets the "follow the format" prompt if and only if it is an instruction following model.