### PR TITLE
Update global landing page

### DIFF
--- a/helm-frontend/project_metadata.json
+++ b/helm-frontend/project_metadata.json
@@ -3,7 +3,8 @@
 		"title": "Lite",
 		"description": "Lightweight, broad evaluation of the capabilities of language models using in-context learning",
 		"id": "lite",
-		"releases": ["v1.1.0", "v1.0.0"]
+		"releases": ["v1.1.0", "v1.0.0"],
+		"imageUrl": "https://raw.githubusercontent.com/stanford-crfm/helm/main/helm-frontend/src/assets/helm-logo-simple.png"
 	},
 	{
 		"title": "Classic",
@@ -21,6 +22,12 @@
 		"title": "Instruct",
 		"description": "Evaluations of instruction following models with absolute ratings",
 		"id": "instruct",
+		"releases": ["v1.0.0"]
+	},
+	{
+		"title": "All Leaderboards",
+		"description": "Home page for all HELM leaderboards",
+		"id": "home",
 		"releases": ["v1.0.0"]
 	}
 ]

--- a/helm-frontend/project_metadata.json
+++ b/helm-frontend/project_metadata.json
@@ -3,8 +3,7 @@
 		"title": "Lite",
 		"description": "Lightweight, broad evaluation of the capabilities of language models using in-context learning",
 		"id": "lite",
-		"releases": ["v1.1.0", "v1.0.0"],
-		"imageUrl": "https://raw.githubusercontent.com/stanford-crfm/helm/main/helm-frontend/src/assets/helm-logo-simple.png"
+		"releases": ["v1.1.0", "v1.0.0"]
 	},
 	{
 		"title": "Classic",
@@ -16,7 +15,8 @@
 		"title": "HEIM",
 		"description": "Holistic evaluation of text-to-image models",
 		"id": "heim",
-		"releases": ["v1.1.0", "v1.0.0"]
+		"releases": ["v1.1.0", "v1.0.0"],
+		"imageUrl": "https://raw.githubusercontent.com/stanford-crfm/helm/main/helm-frontend/src/assets/heim-logo.png"
 	},
 	{
 		"title": "Instruct",

--- a/helm-frontend/project_metadata.json
+++ b/helm-frontend/project_metadata.json
@@ -15,8 +15,7 @@
 		"title": "HEIM",
 		"description": "Holistic evaluation of text-to-image models",
 		"id": "heim",
-		"releases": ["v1.1.0", "v1.0.0"],
-		"imageUrl": "https://raw.githubusercontent.com/stanford-crfm/helm/main/helm-frontend/src/assets/heim-logo.png"
+		"releases": ["v1.1.0", "v1.0.0"]
 	},
 	{
 		"title": "Instruct",

--- a/helm-frontend/project_metadata.json
+++ b/helm-frontend/project_metadata.json
@@ -3,7 +3,7 @@
 		"title": "Lite",
 		"description": "Lightweight, broad evaluation of the capabilities of language models using in-context learning",
 		"id": "lite",
-		"releases": ["v1.1.0", "v1.0.0"]
+		"releases": ["v1.2.0", "v1.1.0", "v1.0.0"]
 	},
 	{
 		"title": "Classic",
@@ -22,6 +22,12 @@
 		"description": "Evaluations of instruction following models with absolute ratings",
 		"id": "instruct",
 		"releases": ["v1.0.0"]
+	},
+	{
+		"title": "MMLU",
+		"description": "Massive Multitask Language Understanding (MMLU) evaluations using standardized prompts",
+		"id": "mmlu",
+		"releases": ["v1.1.0", "v1.0.0"]
 	},
 	{
 		"title": "All Leaderboards",

--- a/helm-frontend/public/config.js
+++ b/helm-frontend/public/config.js
@@ -1,4 +1,4 @@
 window.RELEASE = "v1.0.0";
 window.BENCHMARK_OUTPUT_BASE_URL =
 	"https://storage.googleapis.com/crfm-helm-public/lite/benchmark_output/";
-window.PROJECT_ID = "lite";
+window.PROJECT_ID = "home";

--- a/helm-frontend/public/config.js
+++ b/helm-frontend/public/config.js
@@ -1,4 +1,4 @@
 window.RELEASE = "v1.0.0";
 window.BENCHMARK_OUTPUT_BASE_URL =
 	"https://storage.googleapis.com/crfm-helm-public/lite/benchmark_output/";
-window.PROJECT_ID = "home";
+window.PROJECT_ID = "lite";

--- a/helm-frontend/src/components/CardGrid.tsx
+++ b/helm-frontend/src/components/CardGrid.tsx
@@ -9,7 +9,7 @@ export default function CardGrid() {
 
   useEffect(() => {
     fetch(
-      "https://storage.googleapis.com/crfm-helm-public/config/release_index.json",
+      "https://raw.githubusercontent.com/stanford-crfm/helm/main/helm-frontend/project_metadata.json",
     )
       .then((response) => response.json())
       .then((data: ReleaseIndexEntry[]) => {

--- a/helm-frontend/src/components/CardGrid.tsx
+++ b/helm-frontend/src/components/CardGrid.tsx
@@ -8,7 +8,9 @@ export default function CardGrid() {
   >();
 
   useEffect(() => {
-    fetch("project_metadata.json")
+    fetch(
+      "https://raw.githubusercontent.com/stanford-crfm/helm/main/helm-frontend/project_metadata.json",
+    )
       .then((response) => response.json())
       .then((data: ReleaseIndexEntry[]) => {
         setProjectEntries(data);

--- a/helm-frontend/src/components/CardGrid.tsx
+++ b/helm-frontend/src/components/CardGrid.tsx
@@ -22,19 +22,18 @@ export default function CardGrid() {
     <div className="p-10 mb-20">
       <div className="grid grid-cols-3 gap-4">
         {projectEntries &&
-          projectEntries.map((project, index) => (
-            <ProjectCard
-              key={index}
-              id={project.id}
-              title={project.title}
-              imageUrl={
-                project.imageUrl !== undefined
-                  ? String(project.imageUrl)
-                  : undefined
-              }
-              text={project.description}
-            />
-          ))}
+          projectEntries.map((project, index) =>
+            project.id === "home" ? (
+              <></>
+            ) : (
+              <ProjectCard
+                key={index}
+                id={project.id}
+                title={project.title}
+                text={project.description}
+              />
+            ),
+          )}
       </div>
     </div>
   );

--- a/helm-frontend/src/components/CardGrid.tsx
+++ b/helm-frontend/src/components/CardGrid.tsx
@@ -8,9 +8,7 @@ export default function CardGrid() {
   >();
 
   useEffect(() => {
-    fetch(
-      "https://raw.githubusercontent.com/stanford-crfm/helm/main/helm-frontend/project_metadata.json",
-    )
+    fetch("project_metadata.json")
       .then((response) => response.json())
       .then((data: ReleaseIndexEntry[]) => {
         setProjectEntries(data);

--- a/helm-frontend/src/components/CardGrid.tsx
+++ b/helm-frontend/src/components/CardGrid.tsx
@@ -25,9 +25,7 @@ export default function CardGrid() {
       <div className="grid grid-cols-3 gap-4">
         {projectEntries &&
           projectEntries.map((project, index) =>
-            project.id === "home" ? (
-              <></>
-            ) : (
+            project.id === "home" ? null : (
               <ProjectCard
                 key={index}
                 id={project.id}

--- a/helm-frontend/src/components/Landing/HomeLanding.tsx
+++ b/helm-frontend/src/components/Landing/HomeLanding.tsx
@@ -47,7 +47,7 @@ const logos = [
   zeroOne,
 ];
 
-export default function LegacyLanding() {
+export default function HomeLanding() {
   const [schema, setSchema] = useState<Schema | undefined>(undefined);
 
   useEffect(() => {
@@ -68,17 +68,19 @@ export default function LegacyLanding() {
   return (
     <>
       <SimpleHero />
-      <div className="container mt-40 mx-auto text-lg">
+      <div className="container mt-30 mx-auto text-lg">
         <div className="flex flex-col sm:flex-row justify-center mb-10 flex sm:gap-8 md:gap-32">
           <h1 className="text-4xl  mx-4 ">
-            <strong>HELM Projects</strong>
+            <strong>HELM Leaderboards</strong>
           </h1>
         </div>
         <div className="flex flex-col sm:flex-row flex sm:gap-8 md:gap-32">
-          <text>
-            HELM projects leverage the HELM framework and target particular
-            domains, languages, or use cases.
-          </text>
+          <body>
+            HELM leaderboards leverage the HELM framework and target particular
+            domains and/or capabilities. Leaderboards range from real world
+            applications and specific domains to ones focused on multimodal
+            capabilities and model-evaluations.
+          </body>
         </div>
       </div>
       <CardGrid />

--- a/helm-frontend/src/components/NavDropdown.tsx
+++ b/helm-frontend/src/components/NavDropdown.tsx
@@ -16,21 +16,10 @@ function NavDropdown() {
         setProjectMetadata(data);
         // set currProjectMetadata to val where projectMetadataEntry.id matches window.PROJECT_ID
         if (window.PROJECT_ID) {
-          if (window.PROJECT_ID === "global") {
-            // TODO replace this hardcoding if we choose to put global in the project metadata array
-            setCurrProjectMetadata({
-              id: "global",
-              title: "All Projects",
-              description: "description",
-              releases: ["releases"],
-              imageUrl: "imageUrl",
-            });
-          } else {
-            const currentEntry = data.find(
-              (entry) => entry.id === window.PROJECT_ID,
-            );
-            setCurrProjectMetadata(currentEntry);
-          }
+          const currentEntry = data.find(
+            (entry) => entry.id === window.PROJECT_ID,
+          );
+          setCurrProjectMetadata(currentEntry);
           // handles falling back to HELM lite as was previously done in this file
         } else {
           const currentEntry = data.find((entry) => entry.id === "lite");
@@ -74,10 +63,18 @@ function NavDropdown() {
           <li key={index}>
             <a
               href={getReleaseUrl(undefined, item.id)}
-              className="block"
+              className={"block "}
               role="menuitem"
             >
-              <strong>{item.title}:</strong> {item.description}
+              <strong
+                className={
+                  "" + (currProjectMetadata.title === item.title && "underline")
+                }
+              >
+                {item.title}
+              </strong>
+              {": "}
+              {item.description}
             </a>
           </li>
         ))}

--- a/helm-frontend/src/components/NavDropdown.tsx
+++ b/helm-frontend/src/components/NavDropdown.tsx
@@ -17,6 +17,10 @@ function NavDropdown() {
       .then((data: ProjectMetadata[]) => {
         setProjectMetadata(data);
         // set currProjectMetadata to val where projectMetadataEntry.id matches window.PROJECT_ID
+        const currentEntry = data.find(
+          (entry) => entry.id === window.PROJECT_ID,
+        );
+        setCurrProjectMetadata(currentEntry);
         if (window.PROJECT_ID) {
           const currentEntry = data.find(
             (entry) => entry.id === window.PROJECT_ID,

--- a/helm-frontend/src/components/NavDropdown.tsx
+++ b/helm-frontend/src/components/NavDropdown.tsx
@@ -10,7 +10,9 @@ function NavDropdown() {
   >();
 
   useEffect(() => {
-    fetch("project_metadata.json")
+    fetch(
+      "https://raw.githubusercontent.com/stanford-crfm/helm/main/helm-frontend/project_metadata.json",
+    )
       .then((response) => response.json())
       .then((data: ProjectMetadata[]) => {
         setProjectMetadata(data);

--- a/helm-frontend/src/components/NavDropdown.tsx
+++ b/helm-frontend/src/components/NavDropdown.tsx
@@ -10,9 +10,7 @@ function NavDropdown() {
   >();
 
   useEffect(() => {
-    fetch(
-      "https://storage.googleapis.com/crfm-helm-public/config/project_metadata.json",
-    )
+    fetch("project_metadata.json")
       .then((response) => response.json())
       .then((data: ProjectMetadata[]) => {
         setProjectMetadata(data);

--- a/helm-frontend/src/components/NavDropdown.tsx
+++ b/helm-frontend/src/components/NavDropdown.tsx
@@ -17,10 +17,6 @@ function NavDropdown() {
       .then((data: ProjectMetadata[]) => {
         setProjectMetadata(data);
         // set currProjectMetadata to val where projectMetadataEntry.id matches window.PROJECT_ID
-        const currentEntry = data.find(
-          (entry) => entry.id === window.PROJECT_ID,
-        );
-        setCurrProjectMetadata(currentEntry);
         if (window.PROJECT_ID) {
           const currentEntry = data.find(
             (entry) => entry.id === window.PROJECT_ID,

--- a/helm-frontend/src/components/NavDropdown.tsx
+++ b/helm-frontend/src/components/NavDropdown.tsx
@@ -65,12 +65,12 @@ function NavDropdown() {
           <li key={index}>
             <a
               href={getReleaseUrl(undefined, item.id)}
-              className={"block "}
+              className="block"
               role="menuitem"
             >
               <strong
                 className={
-                  "" + (currProjectMetadata.title === item.title && "underline")
+                  currProjectMetadata.title === item.title ? "underline" : ""
                 }
               >
                 {item.title}

--- a/helm-frontend/src/components/ProjectCard.tsx
+++ b/helm-frontend/src/components/ProjectCard.tsx
@@ -9,12 +9,27 @@ interface CardProps {
 }
 
 const ProjectCard: React.FC<CardProps> = ({ id, title, imageUrl, text }) => {
+  const defaultImageUrl =
+    "https://raw.githubusercontent.com/stanford-crfm/helm/main/helm-frontend/src/assets/helm-logo-simple.png";
   if (!title.includes("HE")) {
-    title = "HELM " + title;
+    if (title !== "All Leaderboards") {
+      title = "HELM " + title;
+    } else {
+      title = "All HELM Leaderboards";
+    }
+    if (imageUrl === undefined) {
+      imageUrl = defaultImageUrl;
+    }
   }
   return (
     <div className="max-w-sm rounded overflow-hidden bg-gray-100 hover:scale-105 transition-transform duration-300">
-      {imageUrl ? <img className="w-full" src={imageUrl} alt={title} /> : <></>}
+      {imageUrl ? (
+        <div className=" bg-white rounded-lg overflow-hidden px-4 mx-4 py-4 my-4">
+          <img className="w-full" src={imageUrl} alt={title} />
+        </div>
+      ) : (
+        <></>
+      )}
       <div className="px-6 py-4">
         <div className="font-bold text-xl mb-2">
           <a href={getReleaseUrl(undefined, id)}> {title + " →"}</a>

--- a/helm-frontend/src/components/ProjectCard.tsx
+++ b/helm-frontend/src/components/ProjectCard.tsx
@@ -4,38 +4,34 @@ import React from "react";
 interface CardProps {
   id: string;
   title: string;
-  imageUrl: string | undefined;
   text: string;
 }
 
-const ProjectCard: React.FC<CardProps> = ({ id, title, imageUrl, text }) => {
-  const defaultImageUrl =
-    "https://raw.githubusercontent.com/stanford-crfm/helm/main/helm-frontend/src/assets/helm-logo-simple.png";
+const ProjectCard: React.FC<CardProps> = ({ id, title, text }) => {
   if (!title.includes("HE")) {
-    if (title !== "All Leaderboards") {
-      title = "HELM " + title;
-    } else {
-      title = "All HELM Leaderboards";
-    }
-    if (imageUrl === undefined) {
-      imageUrl = defaultImageUrl;
-    }
+    title = "HELM " + title;
   }
   return (
     <div className="max-w-sm rounded overflow-hidden bg-gray-100 hover:scale-105 transition-transform duration-300">
-      {imageUrl ? (
-        <div className=" bg-white rounded-lg overflow-hidden px-4 mx-4 py-4 my-4">
-          <img className="w-full" src={imageUrl} alt={title} />
+      <a href={getReleaseUrl(undefined, id)}>
+        <div className="px-6 py-4">
+          <div className="font-bold text-xl mb-2">
+            <div className="py-3">
+              <svg
+                fill="#000000"
+                width="20px"
+                height="20px"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path d="M22,7H16.333V4a1,1,0,0,0-1-1H8.667a1,1,0,0,0-1,1v7H2a1,1,0,0,0-1,1v8a1,1,0,0,0,1,1H22a1,1,0,0,0,1-1V8A1,1,0,0,0,22,7ZM7.667,19H3V13H7.667Zm6.666,0H9.667V5h4.666ZM21,19H16.333V9H21Z" />
+              </svg>
+            </div>
+            {title + " →"}
+          </div>
+          <p className="text-gray-700 text-base">{text}</p>
         </div>
-      ) : (
-        <></>
-      )}
-      <div className="px-6 py-4">
-        <div className="font-bold text-xl mb-2">
-          <a href={getReleaseUrl(undefined, id)}> {title + " →"}</a>
-        </div>
-        <p className="text-gray-700 text-base">{text}</p>
-      </div>
+      </a>
     </div>
   );
 };

--- a/helm-frontend/src/components/ReleaseDropdown.tsx
+++ b/helm-frontend/src/components/ReleaseDropdown.tsx
@@ -18,9 +18,7 @@ function ReleaseDropdown() {
   >();
 
   useEffect(() => {
-    fetch(
-      "https://storage.googleapis.com/crfm-helm-public/config/project_metadata.json",
-    )
+    fetch("project_metadata.json")
       .then((response) => response.json())
       .then((data: ProjectMetadata[]) => {
         // set currProjectMetadata to val where projectMetadataEntry.id matches window.PROJECT_ID

--- a/helm-frontend/src/components/ReleaseDropdown.tsx
+++ b/helm-frontend/src/components/ReleaseDropdown.tsx
@@ -18,7 +18,9 @@ function ReleaseDropdown() {
   >();
 
   useEffect(() => {
-    fetch("project_metadata.json")
+    fetch(
+      "https://raw.githubusercontent.com/stanford-crfm/helm/main/helm-frontend/project_metadata.json",
+    )
       .then((response) => response.json())
       .then((data: ProjectMetadata[]) => {
         // set currProjectMetadata to val where projectMetadataEntry.id matches window.PROJECT_ID

--- a/helm-frontend/src/components/SimpleHero.tsx
+++ b/helm-frontend/src/components/SimpleHero.tsx
@@ -28,12 +28,12 @@ export default function SimpleHero() {
             className="px-6 btn btn-grey rounded-md mb-4 md:mb-0"
             onClick={() =>
               window.scrollTo({
-                top: 700,
+                top: 760,
                 behavior: "smooth",
               })
             }
           >
-            <body>Leaderboards</body>
+            <div>Leaderboards ↓</div>
           </button>
           <button className="px-6 btn btn-grey rounded-md md:ml-4">
             <Link to="https://github.com/stanford-crfm/helm">Github</Link>

--- a/helm-frontend/src/components/SimpleHero.tsx
+++ b/helm-frontend/src/components/SimpleHero.tsx
@@ -7,19 +7,18 @@ export default function SimpleHero() {
       <div className="flex-1 p-4 flex flex-col justify-center">
         <div className="flex justify-start">
           <div>
-            <h1 className="text-5xl mb-4 mx-4 mt-2">
+            <h1 className="text-4xl mb-4 mx-4 mt-2">
               <strong>
-                A holistic framework for evaluating foundation models.
+                A reproducible and transparent framework for evaluating
+                foundation models
               </strong>
             </h1>
             <h3
-              className="text-lg
+              className="text-xl
              mb-4 mx-4 mt-2"
             >
-              HELM is a powerful framework and leaderboard hub for reproducible
-              and transparent evaluations of foundation models. It supports many
-              scenarios, metrics, and models, including multimodality and
-              model-graded evaluations.
+              Find leaderboards with many scenarios, metrics, and models with
+              support for multimodality and model-graded evaluation.
             </h3>
           </div>
         </div>

--- a/helm-frontend/src/components/SimpleHero.tsx
+++ b/helm-frontend/src/components/SimpleHero.tsx
@@ -3,18 +3,29 @@ import { Link } from "react-router-dom";
 
 export default function SimpleHero() {
   return (
-    <div className="flex px-6 py-20">
+    <div className="flex flex-col md:flex-row px-6 py-36">
       <div className="flex-1 p-4 flex flex-col justify-center">
         <div className="flex justify-start">
-          <h1 className="text-5xl mb-4 mx-4 mt-2">
-            <strong>
-              A holistic framework for evaluating foundation models.
-            </strong>
-          </h1>
+          <div>
+            <h1 className="text-5xl mb-4 mx-4 mt-2">
+              <strong>
+                A holistic framework for evaluating foundation models.
+              </strong>
+            </h1>
+            <h3
+              className="text-lg
+             mb-4 mx-4 mt-2"
+            >
+              HELM is a powerful framework and leaderboard hub for reproducible
+              and transparent evaluations of foundation models. It supports many
+              scenarios, metrics, and models, including multimodality and
+              model-graded evaluations.
+            </h3>
+          </div>
         </div>
-        <div className="flex justify-start mt-6 ml-4">
+        <div className="flex flex-col md:flex-row justify-start mt-6 ml-4">
           <button
-            className="px-6 btn btn-grey rounded-md"
+            className="px-6 btn btn-grey rounded-md mb-4 md:mb-0"
             onClick={() =>
               window.scrollTo({
                 top: 700,
@@ -22,15 +33,15 @@ export default function SimpleHero() {
               })
             }
           >
-            <body>Projects</body>
+            <body>Leaderboards</body>
           </button>
-          <Link to="https://github.com/stanford-crfm/helm" className="ml-4">
-            <button className="px-6 btn btn-grey rounded-md">Github</button>
-          </Link>
+          <button className="px-6 btn btn-grey rounded-md md:ml-4">
+            <Link to="https://github.com/stanford-crfm/helm">Github</Link>
+          </button>
         </div>
       </div>
 
-      <div className="w-1/3 mx-4">
+      <div className="mx-4 mt-6 md:mt-0 md:w-1/3">
         <img
           src={helmHero}
           alt="HELM Hero"

--- a/helm-frontend/src/components/SimpleHero.tsx
+++ b/helm-frontend/src/components/SimpleHero.tsx
@@ -10,7 +10,7 @@ export default function SimpleHero() {
             <h1 className="text-4xl mb-4 mx-4 mt-2">
               <strong>
                 A reproducible and transparent framework for evaluating
-                foundation models
+                foundation models.
               </strong>
             </h1>
             <h3

--- a/helm-frontend/src/components/SimpleHero.tsx
+++ b/helm-frontend/src/components/SimpleHero.tsx
@@ -1,5 +1,4 @@
 import helmHero from "@/assets/helmhero.png";
-import { Link } from "react-router-dom";
 
 export default function SimpleHero() {
   return (
@@ -35,7 +34,7 @@ export default function SimpleHero() {
             <div>Leaderboards ↓</div>
           </button>
           <button className="px-6 btn btn-grey rounded-md md:ml-4">
-            <Link to="https://github.com/stanford-crfm/helm">Github</Link>
+            <a href="https://github.com/stanford-crfm/helm">Github</a>
           </button>
         </div>
       </div>

--- a/helm-frontend/src/routes/Home.tsx
+++ b/helm-frontend/src/routes/Home.tsx
@@ -3,7 +3,7 @@ import LiteLanding from "@/components/Landing/LiteLanding";
 import MMLULanding from "@/components/Landing/MMLULanding";
 import HEIMLanding from "@/components/Landing/HEIMLanding";
 import VHELMLanding from "@/components/VHELMLanding";
-import GlobalLanding from "@/components/Landing/GlobalLanding";
+import HomeLanding from "@/components/Landing/HomeLanding";
 
 export default function Home() {
   // TODO consider a more streamlined way to do this?
@@ -17,8 +17,8 @@ export default function Home() {
     return <MMLULanding />;
   } else if (window.PROJECT_ID === "vhelm") {
     return <VHELMLanding />;
-  } else if (window.PROJECT_ID === "global") {
-    return <GlobalLanding />;
+  } else if (window.PROJECT_ID === "home") {
+    return <HomeLanding />;
   } else {
     return <LiteLanding />;
   }


### PR DESCRIPTION
- Updates naming for global landing page -> home
- Updates global landing page to work on md and sm devices (tablet & mobile)
- Updates project metadata to be read from GH instead of GCP
- Updates naming for "projects" -> "leaderboards"
- Shows users which HELM subsite they are on in the dropdown
- Adds new copy (SEE BELOW)

Hero/landing: 
A reproducible and transparent framework for evaluating foundation models

Subtitle:
Find leaderboards with many scenarios, metrics, and models with support for multimodality and model-graded evaluation.

Leaderboard description: 
HELM leaderboards leverage the HELM framework and target particular domains and/or capabilities. Examples range from real-world applications or specific use cases to leaderboards focused on multimodal capabilities and model-evaluations.

PREVIEW: [farzaank.github.io/helm/](https://farzaank.github.io/helm/)