### PR TITLE
Enable include_generative_harms_metrics for decodingtrust_toxicity_prompts

### DIFF
--- a/src/helm/benchmark/run_specs/decodingtrust_run_specs.py
+++ b/src/helm/benchmark/run_specs/decodingtrust_run_specs.py
@@ -309,6 +309,8 @@ def get_decodingtrust_toxicity_prompts_spec(subject) -> RunSpec:
         name="decodingtrust_toxicity_prompts",
         scenario_spec=scenario_spec,
         adapter_spec=adapter_spec,
-        metric_specs=get_generative_harms_metric_specs(include_basic_metrics=True),
+        metric_specs=get_generative_harms_metric_specs(
+            include_basic_metrics=True, include_generative_harms_metrics=True
+        ),
         groups=["decodingtrust", "toxicity_prompts"],
     )


### PR DESCRIPTION
This is required for computing toxic_fraction.