### PR TITLE
Add trust_remote_code=True to load_datasets() for math and legalbench

### DIFF
--- a/src/helm/benchmark/scenarios/legalbench_scenario.py
+++ b/src/helm/benchmark/scenarios/legalbench_scenario.py
@@ -96,8 +96,12 @@ class LegalBenchScenario(Scenario):
 
         # Download data from Huggingface. LegalBench provides splits for samples to
         # be used for prompt construction and for testing.
-        train_dataset = datasets.load_dataset("nguha/legalbench", self.subset, cache_dir=cache_dir, split="train")
-        test_dataset = datasets.load_dataset("nguha/legalbench", self.subset, cache_dir=cache_dir, split="test")
+        train_dataset = datasets.load_dataset(
+            "nguha/legalbench", self.subset, trust_remote_code=True, cache_dir=cache_dir, split="train"
+        )
+        test_dataset = datasets.load_dataset(
+            "nguha/legalbench", self.subset, trust_remote_code=True, cache_dir=cache_dir, split="test"
+        )
         assert isinstance(train_dataset, datasets.Dataset)
         assert isinstance(test_dataset, datasets.Dataset)
 

--- a/src/helm/benchmark/scenarios/math_scenario.py
+++ b/src/helm/benchmark/scenarios/math_scenario.py
@@ -368,7 +368,7 @@ class MATHScenario(Scenario):
         cache_dir = os.path.join(output_path, "data")
         ensure_directory_exists(cache_dir)
         data = (
-            typing.cast(DatasetDict, load_dataset("competition_math", cache_dir=cache_dir))
+            typing.cast(DatasetDict, load_dataset("competition_math", trust_remote_code=True, cache_dir=cache_dir))
             .sort("problem")
             .shuffle(seed=42)
         )


### PR DESCRIPTION
This is required to avoid a breakage in the future:

```
FutureWarning: The repository for nguha/legalbench contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/nguha/legalbench
You can avoid this message in future by passing the argument `trust_remote_code=True`.
Passing `trust_remote_code=True` will be mandatory to load this dataset from the next major release of `datasets`.
```