### PR TITLE
Add trust_remote_code to Snowflake Arctic tokenizer

### DIFF
--- a/src/helm/config/tokenizer_configs.yaml
+++ b/src/helm/config/tokenizer_configs.yaml
@@ -335,6 +335,9 @@ tokenizer_configs:
   - name: snowflake/snowflake-arctic-instruct
     tokenizer_spec:
       class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
+      args:
+        pretrained_model_name_or_path: Snowflake/snowflake-arctic-instruct
+        trust_remote_code: true
     end_of_text_token: "<|im_end|>"
     prefix_token: "<|im_start|>"
 


### PR DESCRIPTION
According to the [Hugging Face Hub page](https://huggingface.co/Snowflake/snowflake-arctic-instruct):

> Arctic is currently supported with `transformers` by leveraging the [custom code feature](https://huggingface.co/docs/transformers/en/custom_models#using-a-model-with-custom-code), to use this you simply need to add `trust_remote_code=True` to your `AutoTokenizer` and `AutoModelForCausalLM` calls.
