### PR TITLE
Refactor home page slightly

### DIFF
--- a/helm-frontend/public/config.js
+++ b/helm-frontend/public/config.js
@@ -1,4 +1,4 @@
 window.RELEASE = "v1.0.0";
 window.BENCHMARK_OUTPUT_BASE_URL =
 	"https://storage.googleapis.com/crfm-helm-public/lite/benchmark_output/";
-window.PROJECT_ID = "lite";
+window.PROJECT_ID = "home";

--- a/helm-frontend/public/config.js
+++ b/helm-frontend/public/config.js
@@ -1,4 +1,4 @@
 window.RELEASE = "v1.0.0";
 window.BENCHMARK_OUTPUT_BASE_URL =
 	"https://storage.googleapis.com/crfm-helm-public/lite/benchmark_output/";
-window.PROJECT_ID = "home";
+window.PROJECT_ID = "lite";

--- a/helm-frontend/src/components/Landing/HomeLanding.tsx
+++ b/helm-frontend/src/components/Landing/HomeLanding.tsx
@@ -68,19 +68,11 @@ export default function HomeLanding() {
   return (
     <>
       <SimpleHero />
-      <div className="container mt-30 mx-auto text-lg">
+      <div className="container py-5 mx-auto text-lg">
         <div className="flex flex-col sm:flex-row justify-center mb-10 flex sm:gap-8 md:gap-32">
-          <h1 className="text-4xl  mx-4 ">
+          <h1 className="text-4xl mx-4 ">
             <strong>HELM Leaderboards</strong>
           </h1>
-        </div>
-        <div className="flex flex-col sm:flex-row flex sm:gap-8 md:gap-32">
-          <body>
-            HELM leaderboards leverage the HELM framework and target particular
-            domains and/or capabilities. Leaderboards range from real world
-            applications and specific domains to ones focused on multimodal
-            capabilities and model-evaluations.
-          </body>
         </div>
       </div>
       <CardGrid />

--- a/helm-frontend/src/components/SimpleHero.tsx
+++ b/helm-frontend/src/components/SimpleHero.tsx
@@ -2,7 +2,7 @@ import helmHero from "@/assets/helmhero.png";
 
 export default function SimpleHero() {
   return (
-    <div className="flex flex-col md:flex-row px-6 py-36">
+    <div className="flex flex-col md:flex-row px-6 py-32">
       <div className="flex-1 p-4 flex flex-col justify-center">
         <div className="flex justify-start">
           <div>


### PR DESCRIPTION
- remove redundant leaderboard copy
- remove whitespace so leaderboard header peaks into top (can make it higher/have the text fully visible if that's preferred)

<img width="1512" alt="Screenshot 2024-05-06 at 11 03 41 PM" src="https://github.com/stanford-crfm/helm/assets/39839866/d794c317-a4a6-455a-b47b-d45000056d15">
