### PR TITLE
Add CohereLocalTokenizer

### DIFF
--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -307,7 +307,7 @@ model_deployments:
 
   - name: cohere/command
     model_name: cohere/command
-    tokenizer_name: cohere/cohere
+    tokenizer_name: cohere/command
     max_sequence_length: 2019 # TODO: verify this
     max_request_length: 2020 # TODO: verify this
     client_spec:
@@ -317,7 +317,7 @@ model_deployments:
 
   - name: cohere/command-light
     model_name: cohere/command-light
-    tokenizer_name: cohere/cohere
+    tokenizer_name: cohere/command-light
     max_sequence_length: 2019 # TODO: verify this
     max_request_length: 2020 # TODO: verify this
     client_spec:

--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -327,7 +327,7 @@ model_deployments:
 
   - name: cohere/command-r
     model_name: cohere/command-r
-    tokenizer_name: cohere/c4ai-command-r-v01
+    tokenizer_name: cohere/command-r
     max_sequence_length: 128000
     max_request_length: 128000
     client_spec:
@@ -335,7 +335,7 @@ model_deployments:
 
   - name: cohere/command-r-plus
     model_name: cohere/command-r-plus
-    tokenizer_name: cohere/c4ai-command-r-plus
+    tokenizer_name: cohere/command-r-plus
     # "We have a known issue where prompts between 112K - 128K in length
     # result in bad generations."
     # Source: https://docs.cohere.com/docs/command-r-plus

--- a/src/helm/config/tokenizer_configs.yaml
+++ b/src/helm/config/tokenizer_configs.yaml
@@ -83,6 +83,18 @@ tokenizer_configs:
     end_of_text_token: ""
     prefix_token: ":"
 
+  - name: cohere/command-r
+    tokenizer_spec:
+      class_name: "helm.tokenizers.cohere_tokenizer.CohereLocalTokenizer"
+    end_of_text_token: "<|END_OF_TURN_TOKEN|>"
+    prefix_token: "<BOS_TOKEN>"
+
+  - name: cohere/command-r-plus
+    tokenizer_spec:
+      class_name: "helm.tokenizers.cohere_tokenizer.CohereLocalTokenizer"
+    end_of_text_token: "<|END_OF_TURN_TOKEN|>"
+    prefix_token: "<BOS_TOKEN>"
+
   - name: cohere/c4ai-command-r-v01
     tokenizer_spec:
       class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"

--- a/src/helm/config/tokenizer_configs.yaml
+++ b/src/helm/config/tokenizer_configs.yaml
@@ -83,16 +83,28 @@ tokenizer_configs:
     end_of_text_token: ""
     prefix_token: ":"
 
+  - name: cohere/command
+    tokenizer_spec:
+      class_name: "helm.tokenizers.cohere_tokenizer.CohereLocalTokenizer"
+    end_of_text_token: "<EOS_TOKEN>"
+    prefix_token: "<BOS_TOKEN>"
+
+  - name: cohere/command-light
+    tokenizer_spec:
+      class_name: "helm.tokenizers.cohere_tokenizer.CohereLocalTokenizer"
+    end_of_text_token: "<EOS_TOKEN>"
+    prefix_token: "<BOS_TOKEN>"
+
   - name: cohere/command-r
     tokenizer_spec:
       class_name: "helm.tokenizers.cohere_tokenizer.CohereLocalTokenizer"
-    end_of_text_token: "<|END_OF_TURN_TOKEN|>"
+    end_of_text_token: "<EOS_TOKEN>"
     prefix_token: "<BOS_TOKEN>"
 
   - name: cohere/command-r-plus
     tokenizer_spec:
       class_name: "helm.tokenizers.cohere_tokenizer.CohereLocalTokenizer"
-    end_of_text_token: "<|END_OF_TURN_TOKEN|>"
+    end_of_text_token: "<EOS_TOKEN>"
     prefix_token: "<BOS_TOKEN>"
 
   - name: cohere/c4ai-command-r-v01
@@ -100,7 +112,7 @@ tokenizer_configs:
       class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
       args:
         pretrained_model_name_or_path: CohereForAI/c4ai-command-r-v01
-    end_of_text_token: "<|END_OF_TURN_TOKEN|>"
+    end_of_text_token: "<EOS_TOKEN>"
     prefix_token: "<BOS_TOKEN>"
 
   - name: cohere/c4ai-command-r-plus
@@ -108,7 +120,7 @@ tokenizer_configs:
       class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
       args:
         pretrained_model_name_or_path: CohereForAI/c4ai-command-r-plus
-    end_of_text_token: "<|END_OF_TURN_TOKEN|>"
+    end_of_text_token: "<EOS_TOKEN>"
     prefix_token: "<BOS_TOKEN>"
 
   # Databricks

--- a/src/helm/tokenizers/cohere_tokenizer.py
+++ b/src/helm/tokenizers/cohere_tokenizer.py
@@ -2,6 +2,8 @@ import json
 import requests
 from typing import Any, Dict, List
 
+import cohere
+
 from helm.common.cache import CacheConfig
 from helm.common.tokenization_request import (
     TokenizationRequest,
@@ -10,7 +12,7 @@ from helm.common.tokenization_request import (
     TokenizationToken,
 )
 from helm.clients.cohere_utils import get_cohere_url, DEFAULT_COHERE_API_VERSION
-from .caching_tokenizer import CachingTokenizer
+from helm.tokenizers.caching_tokenizer import CachingTokenizer
 
 
 class CohereTokenizer(CachingTokenizer):
@@ -81,3 +83,27 @@ class CohereTokenizer(CachingTokenizer):
 
     def decode(self, request: DecodeRequest) -> DecodeRequestResult:
         raise NotImplementedError("The Cohere API does not support decoding.")
+
+
+class CohereLocalTokenizer(CachingTokenizer):
+    def __init__(self, api_key: str, cache_config: CacheConfig) -> None:
+        super().__init__(cache_config)
+        self.client = cohere.Client(api_key)
+
+    def _tokenize_do_it(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        model: str = request["tokenizer"].replace("cohere/", "")
+        response = self.client.tokenize(text=request["text"], model=model)
+        return response.dict()
+
+    def _tokenization_raw_response_to_tokens(
+        self, response: Dict[str, Any], request: TokenizationRequest
+    ) -> List[TokenizationToken]:
+        if request.encode:
+            return [TokenizationToken(token) for token in response["tokens"]]
+        else:
+            return [TokenizationToken(token) for token in response["token_strings"]]
+
+    def _decode_do_it(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        model: str = request["tokenizer"].replace("cohere/", "")
+        response = self.client.detokenize(tokens=request["tokens"], model=model)
+        return response.dict()

--- a/src/helm/tokenizers/cohere_tokenizer.py
+++ b/src/helm/tokenizers/cohere_tokenizer.py
@@ -1,8 +1,9 @@
 import json
 import requests
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import cohere
+from cohere.manually_maintained.tokenizers import get_hf_tokenizer
 
 from helm.common.cache import CacheConfig
 from helm.common.tokenization_request import (
@@ -86,24 +87,39 @@ class CohereTokenizer(CachingTokenizer):
 
 
 class CohereLocalTokenizer(CachingTokenizer):
-    def __init__(self, api_key: str, cache_config: CacheConfig) -> None:
+    """Cohere tokenizer using the Cohere Python library."""
+
+    def __init__(self, api_key: Optional[str], cache_config: CacheConfig) -> None:
         super().__init__(cache_config)
         self.client = cohere.Client(api_key)
 
+    def _tokenization_request_to_cache_key(self, request: TokenizationRequest) -> Dict[str, Any]:
+        return {"text": request.text, "tokenizer": request.tokenizer}
+
     def _tokenize_do_it(self, request: Dict[str, Any]) -> Dict[str, Any]:
-        model: str = request["tokenizer"].replace("cohere/", "")
+        model: str = request["tokenizer"].split("/")[1]
+        # Workaround for https://github.com/cohere-ai/cohere-python/issues/493
+        # `token_strings` are always set to `[]`, so we have to populate it ourselves.
         response = self.client.tokenize(text=request["text"], model=model)
-        return response.dict()
+        response_dict = response.dict()
+        response_dict["token_strings"] = get_hf_tokenizer(self.client, model).decode_batch(
+            [[token] for token in response.tokens]
+        )
+        return response_dict
 
     def _tokenization_raw_response_to_tokens(
         self, response: Dict[str, Any], request: TokenizationRequest
     ) -> List[TokenizationToken]:
+        tokens: List[TokenizationToken] = []
         if request.encode:
-            return [TokenizationToken(token) for token in response["tokens"]]
+            tokens = [TokenizationToken(token) for token in response["tokens"]]
         else:
-            return [TokenizationToken(token) for token in response["token_strings"]]
+            tokens = [TokenizationToken(token) for token in response["token_strings"]]
+        if request.truncation:
+            tokens = tokens[: request.max_length]
+        return tokens
 
     def _decode_do_it(self, request: Dict[str, Any]) -> Dict[str, Any]:
-        model: str = request["tokenizer"].replace("cohere/", "")
+        model: str = request["tokenizer"].split("/")[1]
         response = self.client.detokenize(tokens=request["tokens"], model=model)
         return response.dict()

--- a/src/helm/tokenizers/test_cohere_tokenizer.py
+++ b/src/helm/tokenizers/test_cohere_tokenizer.py
@@ -1,0 +1,39 @@
+import pytest
+
+from helm.common.cache import BlackHoleCacheConfig
+from helm.common.tokenization_request import (
+    DecodeRequest,
+    TokenizationRequest,
+    TokenizationToken,
+)
+from helm.tokenizers.cohere_tokenizer import CohereLocalTokenizer
+
+
+@pytest.mark.models
+def test_tokenize():
+    tokenizer = CohereLocalTokenizer(api_key="hi", cache_config=BlackHoleCacheConfig())
+    request = TokenizationRequest(tokenizer="cohere/command", text="otter 🦦")
+    result = tokenizer.tokenize(request)
+    assert result.success
+    assert not result.cached
+    assert result.tokens == [TokenizationToken(token) for token in ["o", "t", "t", "e", "r", " ", "🦦"]]
+
+
+@pytest.mark.models
+def test_encode():
+    tokenizer = CohereLocalTokenizer(api_key="hi", cache_config=BlackHoleCacheConfig())
+    request = TokenizationRequest(tokenizer="cohere/command", text="otter 🦦", encode=True)
+    result = tokenizer.tokenize(request)
+    assert result.success
+    assert not result.cached
+    assert result.tokens == [TokenizationToken(token) for token in [1741, 1779, 7728, 107, 107]]
+
+
+@pytest.mark.models
+def test_decode():
+    tokenizer = CohereLocalTokenizer(api_key="hi", cache_config=BlackHoleCacheConfig())
+    request = DecodeRequest(tokenizer="cohere/command", tokens=[1741, 1779, 7728, 107, 107])
+    result = tokenizer.decode(request)
+    assert result.success
+    assert not result.cached
+    assert result.text == "otter 🦦"

--- a/src/helm/tokenizers/test_cohere_tokenizer.py
+++ b/src/helm/tokenizers/test_cohere_tokenizer.py
@@ -11,17 +11,17 @@ from helm.tokenizers.cohere_tokenizer import CohereLocalTokenizer
 
 @pytest.mark.models
 def test_tokenize():
-    tokenizer = CohereLocalTokenizer(api_key="hi", cache_config=BlackHoleCacheConfig())
+    tokenizer = CohereLocalTokenizer(api_key=None, cache_config=BlackHoleCacheConfig())
     request = TokenizationRequest(tokenizer="cohere/command", text="otter 🦦")
     result = tokenizer.tokenize(request)
     assert result.success
     assert not result.cached
-    assert result.tokens == [TokenizationToken(token) for token in ["o", "t", "t", "e", "r", " ", "🦦"]]
+    assert result.tokens == [TokenizationToken(token) for token in ["ot", "ter", " �", "�", "�"]]
 
 
 @pytest.mark.models
 def test_encode():
-    tokenizer = CohereLocalTokenizer(api_key="hi", cache_config=BlackHoleCacheConfig())
+    tokenizer = CohereLocalTokenizer(api_key=None, cache_config=BlackHoleCacheConfig())
     request = TokenizationRequest(tokenizer="cohere/command", text="otter 🦦", encode=True)
     result = tokenizer.tokenize(request)
     assert result.success
@@ -31,7 +31,7 @@ def test_encode():
 
 @pytest.mark.models
 def test_decode():
-    tokenizer = CohereLocalTokenizer(api_key="hi", cache_config=BlackHoleCacheConfig())
+    tokenizer = CohereLocalTokenizer(api_key=None, cache_config=BlackHoleCacheConfig())
     request = DecodeRequest(tokenizer="cohere/command", tokens=[1741, 1779, 7728, 107, 107])
     result = tokenizer.decode(request)
     assert result.success


### PR DESCRIPTION
Add `CohereLocalTokenizer`, which uses the Cohere Python library to perform tokenization locally.

This will eventually allow us to delete `CohereWindowService`, which was intended to work around token limits on the Cohere remote tokenization API.