### PR TITLE
Update get_helm_rank.md to reflect the renaming from huggingface/gpt2 to openai/gpt2

### DIFF
--- a/docs/get_helm_rank.md
+++ b/docs/get_helm_rank.md
@@ -38,7 +38,7 @@ Specifically, the authors calculated the CI 95% of Rank Location from the real r
 Choose your point on your tradeoff, how accurate do you need your rank? how much time do you want to wait? Once you have chosen, download the config and define your model
 ```bash
 export EXAMPLES_PER_SCENARIO=10 && \
-export MODEL_TO_RUN=huggingface/gpt2
+export MODEL_TO_RUN=openai/gpt2
 ```
 
 That's it, run the following to get the config file:


### PR DESCRIPTION
Model huggingface/gpt2 got renamed as openai/gpt2. get_helm_rank.md didn't reflect this.

References #2190