### PR TITLE
Add mini-leaderboard to VHELM

### DIFF
--- a/helm-frontend/src/components/Landing/MMLULanding.tsx
+++ b/helm-frontend/src/components/Landing/MMLULanding.tsx
@@ -7,7 +7,7 @@ export default function MMLULanding() {
         Massive Multitask Language Understanding (MMLU) on HELM
       </h1>
 
-      <div className="flex flex-row md:flex-row items-center gap-8">
+      <div className="flex flex-col lg:flex-row items-center gap-8">
         <div className="flex-1 text-xl">
           <p>
             <strong>Massive Multitask Language Understanding (MMLU)</strong>{" "}

--- a/helm-frontend/src/components/VHELMLanding.tsx
+++ b/helm-frontend/src/components/VHELMLanding.tsx
@@ -4,6 +4,7 @@ import getSchema from "@/services/getSchema";
 import type Schema from "@/types/Schema";
 
 import ModelsList from "@/components/ModelsList";
+import MiniLeaderboard from "@/components/MiniLeaderboard";
 import ScenariosList from "@/components/ScenariosList";
 
 import vhelmFrameworkImage from "@/assets/vhelm/vhelm-framework.png";
@@ -39,16 +40,24 @@ export default function VHELMLanding() {
         This is ongoing work to achieve holistic evaluation for vision-language
         models, so please stay tuned!
       </p>
-      <img
-        src={vhelmFrameworkImage}
-        alt="An image of a helm and the text 'This helm is a' is sent to a Vision-Language Model, which produces the text 'wheel for steering a ship...'"
-        className="mx-auto lg:max-w-3xl block my-8"
-      />
-      <img
-        src={vhelmModelImage}
-        alt="An example of an evaluation for an Aspect (Knowledge) - a Scenario (MMMU) undergoes Adaptation (multimodal multiple choice) for a Model (GPT-4 Vision), then Metrics (Exact match) are computed"
-        className="mx-auto lg:max-w-3xl block my-8"
-      />
+
+      <div className="my-16 flex flex-col lg:flex-row items-center gap-8">
+        <div className="flex-1 text-xl">
+          <img
+            src={vhelmFrameworkImage}
+            alt="An image of a helm and the text 'This helm is a' is sent to a Vision-Language Model, which produces the text 'wheel for steering a ship...'"
+            className=""
+          />
+          <img
+            src={vhelmModelImage}
+            alt="An example of an evaluation for an Aspect (Knowledge) - a Scenario (MMMU) undergoes Adaptation (multimodal multiple choice) for a Model (GPT-4 Vision), then Metrics (Exact match) are computed"
+            className=""
+          />
+        </div>
+        <div className="flex-1">
+          <MiniLeaderboard numModelsToAutoFilter={10} />
+        </div>
+      </div>
       {schema === undefined ? null : (
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-8">
           <ModelsList models={schema.models} />

--- a/helm-frontend/src/components/VHELMLanding.tsx
+++ b/helm-frontend/src/components/VHELMLanding.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 
 import getSchema from "@/services/getSchema";
 import type Schema from "@/types/Schema";
@@ -56,6 +57,12 @@ export default function VHELMLanding() {
         </div>
         <div className="flex-1">
           <MiniLeaderboard numModelsToAutoFilter={10} />
+          <Link
+            to="leaderboard"
+            className="px-4 mx-3 mt-1 btn bg-white rounded-md"
+          >
+            <span>See More</span>
+          </Link>
         </div>
       </div>
       {schema === undefined ? null : (


### PR DESCRIPTION
Layout is two column on large screens and one column on mobile. Also drive-by fix to MMLU make the column formatting identical between MMLU and VHELM.

![Screenshot 2024-05-08 111726](https://github.com/stanford-crfm/helm/assets/185227/b1fe8dad-fd5e-44f0-bb23-af4d01cb1d81)
