### PR TITLE
Require google-cloud-aiplatform~=1.48

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -136,7 +136,7 @@ openai =
     pydantic~=2.0  # For model_dump(mode="json") - openai only requires pydantic>=1.9.0
 
 google =
-    google-cloud-aiplatform~=1.44
+    google-cloud-aiplatform~=1.48
 
 together =
     together~=1.1


### PR DESCRIPTION
On `google-cloud-aiplatform` versions 1.47 and below, VertexAIClient fails with the following error:

```
  File "/.../helm/src/helm/clients/vertexai_client.py", line 200, in do_it
    if response.prompt_feedback and response.prompt_feedback.block_reason:
AttributeError: 'GenerationResponse' object has no attribute 'prompt_feedback'
```