### PR TITLE
Update HELM Medical run specs and run entries

### DIFF
--- a/src/helm/benchmark/presentation/run_entries_multimed_qa.conf
+++ b/src/helm/benchmark/presentation/run_entries_multimed_qa.conf
@@ -1,21 +1,21 @@
 entries: [
     # MedQA: USMLE QA multiple choice questions with 4-5 choices
-    {description: "med_qa:model=text,max_train_instances=0", priority: 1}
+    {description: "med_qa:eval_split=test,model=text,max_train_instances=0", priority: 1}
 
     # MedMCQA: AIIMS/NEET QA multiple choice questions with 4 choices
     {description: "med_mcqa:model=text,max_train_instances=0", priority: 1}
 
     # PubMedQA: biomedical literature Q + Context + A yes/no/maybe + long answer questions
-    {description: "pubmed_qa:model=text,max_train_instances=0", priority: 1}
+    {description: "pubmed_qa:eval_split=test,model=text,max_train_instances=0", priority: 1}
 
     # MMLU: exam questions QA multiple choice with 4 choices
     # NOTE: this is the subset used in the MultiMedQA dataset in the MedPaLM works
-    {description: "mmlu:model=text,subject=anatomy,max_train_instances=0", priority: 1}
-    {description: "mmlu:model=text,subject=clinical_knowledge,max_train_instances=0", priority: 1}
-    {description: "mmlu:model=text,subject=college_medicine,max_train_instances=0", priority: 1}
-    {description: "mmlu:model=text,subject=medical_genetics,max_train_instances=0", priority: 1}
-    {description: "mmlu:model=text,subject=professional_medicine,max_train_instances=0", priority: 1}
-    {description: "mmlu:model=text,subject=college_biology,max_train_instances=0", priority: 1}
+    {description: "mmlu:eval_split=test,model=text,subject=anatomy,max_train_instances=0", priority: 1}
+    {description: "mmlu:eval_split=test,model=text,subject=clinical_knowledge,max_train_instances=0", priority: 1}
+    {description: "mmlu:eval_split=test,model=text,subject=college_medicine,max_train_instances=0", priority: 1}
+    {description: "mmlu:eval_split=test,model=text,subject=medical_genetics,max_train_instances=0", priority: 1}
+    {description: "mmlu:eval_split=test,model=text,subject=professional_medicine,max_train_instances=0", priority: 1}
+    {description: "mmlu:eval_split=test,model=text,subject=college_biology,max_train_instances=0", priority: 1}
 
     # LiveQA: consumer health questions with librarian-generated reference answers. QA long answer
     {description: "live_qa:model=text", priority: 1}

--- a/src/helm/benchmark/run_specs/classic_run_specs.py
+++ b/src/helm/benchmark/run_specs/classic_run_specs.py
@@ -1166,8 +1166,6 @@ def get_pubmed_qa_spec() -> RunSpec:
 
 @run_spec_function("live_qa")
 def get_live_qa_spec() -> RunSpec:
-    from helm.common.gpu_utils import get_torch_device_name
-
     scenario_spec = ScenarioSpec(class_name="helm.benchmark.scenarios.live_qa_scenario.LiveQAScenario")
 
     adapter_spec = get_generation_adapter_spec(
@@ -1182,17 +1180,13 @@ def get_live_qa_spec() -> RunSpec:
         name="live_qa",
         scenario_spec=scenario_spec,
         adapter_spec=adapter_spec,
-        metric_specs=get_summarization_metric_specs(
-            {"task": "live_qa", "device": get_torch_device_name()},
-        ),
+        metric_specs=get_open_ended_generation_metric_specs(),
         groups=["live_qa"],
     )
 
 
 @run_spec_function("medication_qa")
 def get_medication_qa_spec() -> RunSpec:
-    from helm.common.gpu_utils import get_torch_device_name
-
     scenario_spec = ScenarioSpec(class_name="helm.benchmark.scenarios.medication_qa_scenario.MedicationQAScenario")
 
     adapter_spec = get_generation_adapter_spec(
@@ -1207,9 +1201,7 @@ def get_medication_qa_spec() -> RunSpec:
         name="medication_qa",
         scenario_spec=scenario_spec,
         adapter_spec=adapter_spec,
-        metric_specs=get_summarization_metric_specs(
-            {"task": "medication_qa", "device": get_torch_device_name()},
-        ),
+        metric_specs=get_open_ended_generation_metric_specs(),
         groups=["medication_qa"],
     )
 
@@ -1506,5 +1498,5 @@ def get_thai_exam_spec(exam: str = "onet", method: str = ADAPT_MULTIPLE_CHOICE_J
         scenario_spec=scenario_spec,
         adapter_spec=adapter_spec,
         metric_specs=get_exact_match_metric_specs(),
-        groups=["thai_exam"],
+        groups=["thai_exam", f"thai_exam_{exam}"],
     )

--- a/src/helm/benchmark/run_specs/classic_run_specs.py
+++ b/src/helm/benchmark/run_specs/classic_run_specs.py
@@ -1498,5 +1498,5 @@ def get_thai_exam_spec(exam: str = "onet", method: str = ADAPT_MULTIPLE_CHOICE_J
         scenario_spec=scenario_spec,
         adapter_spec=adapter_spec,
         metric_specs=get_exact_match_metric_specs(),
-        groups=["thai_exam", f"thai_exam_{exam}"],
+        groups=["thai_exam"],
     )


### PR DESCRIPTION
- Use only the test split for evaluation (rather than both the test and validation splits)
- Use open ended generation metrics for open ended QA (rather than summarization metrics)