### PR TITLE
Support text prompts for GPT-4o

### DIFF
--- a/src/helm/clients/client.py
+++ b/src/helm/clients/client.py
@@ -39,10 +39,9 @@ class CachingClient(Client):
         """
         if request.random is not None:
             assert "random" not in raw_request
-            cache_key: Mapping = {**raw_request, "random": request.random}
+            return {**raw_request, "random": request.random}
         else:
-            cache_key = raw_request
-        return cache_key
+            return {**raw_request}
 
 
 def truncate_sequence(sequence: GeneratedOutput, request: Request, print_warning: bool = True) -> GeneratedOutput:

--- a/src/helm/clients/openai_client.py
+++ b/src/helm/clients/openai_client.py
@@ -60,10 +60,10 @@ class OpenAIClient(CachingClient):
 
     def _get_cache_key(self, raw_request: Dict, request: Request):
         cache_key = CachingClient.make_cache_key(raw_request, request)
-        if is_vlm(request.model):
-            assert request.multimodal_prompt is not None
+        if request.multimodal_prompt:
             prompt_key: str = generate_uid_for_multimodal_prompt(request.multimodal_prompt)
             cache_key = {**cache_key, "multimodal_prompt": prompt_key}
+            assert not cache_key["messages"]
             del cache_key["messages"]
         return cache_key
 
@@ -103,6 +103,14 @@ class OpenAIClient(CachingClient):
 
     def _make_chat_request(self, request: Request) -> RequestResult:
         messages: Optional[List[Dict[str, Union[str, Any]]]] = request.messages
+        if (
+            (request.prompt and request.messages)
+            or (request.prompt and request.multimodal_prompt)
+            or (request.messages and request.multimodal_prompt)
+        ):
+            raise ValueError(
+                f"More than one of `prompt`, `messages` and `multimodal_prompt` was set in request: {request}"
+            )
         if request.messages is not None:
             # Checks that all messages have a role and some content
             for message in request.messages:


### PR DESCRIPTION
Currently any `OpenAIClient` model that has `VISION_LANGUAGE_MODEL_TAG` cannot accept text prompts only. This is because `OpenAIClient` previously assumed that every model was _either_ a text model _or_ a VLM, but not both. This is no longer true: `gpt-4-turbo-2024-04-09` and `gpt-4o-2024-05-13` support both image and text inputs.

Example failure:

```
  File "/.../helm/src/helm/clients/openai_client.py", line 299, in make_request
    return self._make_chat_request(request)
  File "/.../helm/src/helm/clients/openai_client.py", line 170, in _make_chat_request
    cache_key = self._get_cache_key(raw_request, request)
  File "/.../helm/src/helm/clients/openai_client.py", line 64, in _get_cache_key
    assert request.multimodal_prompt is not None
```


