### PR TITLE
Fix Open-ended VLM Generation Metrics

### DIFF
--- a/src/helm/benchmark/metrics/prometheus_vision_critique_metrics.py
+++ b/src/helm/benchmark/metrics/prometheus_vision_critique_metrics.py
@@ -11,47 +11,64 @@ from helm.benchmark.metrics.statistic import Stat, merge_stat
 from helm.common.critique_request import CritiqueTaskTemplate, CritiqueQuestionTemplate, CritiqueRequest, QuestionType
 from helm.common.hierarchical_logger import hlog
 from helm.common.request import RequestResult, GeneratedOutput
-from helm.common.media_object import MultimediaObject, IMAGE_TYPE, TEXT_TYPE, MediaObject
+from helm.common.media_object import MultimediaObject, IMAGE_TYPE, MediaObject, TEXT_TYPE
 
 
-class RekaVibeCritiqueMetric(MetricInterface):
+class PrometheusVisionCritiqueMetric(MetricInterface):
     """
-    Critique evaluation for evaluating the correctness of generated response given the image and
-    reference by Reka-vibe-eval.
+    We compute the same metrics from the Prometheus-Vision: Vision-Language Model as a Judge for
+    Fine-Grained Evaluation paper:
+    https://arxiv.org/pdf/2401.06591.pdf
+
+    In this paper, the output of a Vision-Language Model named Prometheus-Vision is used to evaluate
+    the quality of the output of other Vision-Language Models to be evaluated.
     """
 
     # We can add more evaluation aspects here
-    VIBE_EVAL_NAME: str = "reka_vibe"
-    REKA_VIBE_PROMPT_WITH_IMAGE: str = """\
-[Question]
-{{prompt}}
+    METRIC_NAME: str = "prometheus_vision"
+    METRIC_PROMPT: str = """A chat between a curious human and an artificial intelligence assistant. \
+        The assistant gives helpful, detailed, and polite answers to the human's questions.\nUSER:<image>\
+###Task Description:
+An instruction (might include an Input inside it), a response to evaluate, a reference answer that gets a score of 5, \
+    image and a score rubric representing an evaluation criterion is given.
+1. Write a detailed feedback that assesses the quality of the response strictly based on the given score rubric, not \
+    evaluating in general.
+2. After writing a feedback, write a score that is an integer between 1 and 5. You should refer to the score rubric.
+3. The output format should look as follows: Feedback: (write a feedback for criteria) [RESULT] (an integer number \
+    between 1 and 5)
+4. Please do not generate any other opening, closing, and explanations.
 
-[Assistant Response]
-{{generation}}
+###The instruction to evaluate:
+{{orig_instruction}}
 
-[Ground Truth Response]
-{{reference}}
+###Response to evaluate:
+{{orig_response}}
 
-[System]
-Rate whether the assistant response correctly matches the ground truth, in regards to the image above.
-The rating should be 1-5, where 1 is incorrect and 5 is correct.
-Your response should be in the format:
-Short Explanation: (explanation in only one sentence)
-Rating: (int)"""
+###Reference Answer (Score 5):
+{{orig_reference_answer}}
+
+###Score Rubrics:
+[{{orig_criteria}}]
+Score 1: {{orig_score1_description}}
+Score 2: {{orig_score2_description}}
+Score 3: {{orig_score3_description}}
+Score 4: {{orig_score4_description}}
+Score 5: {{orig_score5_description}}
+
+###Feedback:
+ASSISTANT:
+"""
 
     def __init__(self, num_respondents: int, max_tokens: int):
         self._num_respondents = num_respondents
         self._max_tokens = max_tokens
 
     def __repr__(self) -> str:
-        return "RekaVibeCritiqueMetric()"
+        return "PrometheusVisionCritiqueMetric()"
 
-    def _extract_score_from_reka_output(self, evaluator_response: str):
-        """
-        Extract the score from the evaluator response. Refer to the official Vibe-Eval implementation:
-        https://github.com/reka-ai/reka-vibe-eval/blob/3852d4712da172a7b85dddeffc4f9c3482a6f4c9/evaluate.py#L159-#L164
-        """
-        re_match = re.search(r"Rating:\s*([1-5])", evaluator_response)
+    def _extract_score_from_prometheus_vision_output(self, evaluator_response: str):
+        evaluator_response = evaluator_response.split("ASSISTANT:")[1]
+        re_match = re.search(r"\s*([1-5])", evaluator_response)
         if re_match is None:
             hlog(f"Error parsing answer: {evaluator_response}. Skipping question (and so the respondent entirely)")
             return None
@@ -98,29 +115,28 @@ Rating: (int)"""
         eval_cache_path: str,
     ) -> List[Stat]:
         input_content = request_state.request
-        # Predicted outputs and their originality scores
+        # Predicted outputs and their prometheus vision scores
         assert request_state.result is not None
         request_result: RequestResult = request_state.result
-        # Get input image and generated response for the originality evaluation
+        # Get input image and generated response for evaluation
         assert input_content.multimodal_prompt is not None
         completions: List[GeneratedOutput] = request_result.completions
         generated_text: str = completions[0].text
         input_media: MultimediaObject = input_content.multimodal_prompt
         ref_text: str = request_state.instance.references[0].output.text
-
         image_objects: List[MediaObject] = [
             item for item in input_media.media_objects if item.is_type(IMAGE_TYPE) and item.location
         ]
         input_text: Optional[str] = [item for item in input_media.media_objects if item.is_type(TEXT_TYPE)][0].text
 
         template = CritiqueTaskTemplate(
-            name="vhelm_vibe_eval",
-            instructions=self.REKA_VIBE_PROMPT_WITH_IMAGE,
+            name="vhelm_prometheus_vision",
+            instructions=self.METRIC_PROMPT,
             num_respondents=self._num_respondents,
             max_tokens=self._max_tokens,
             questions=[
                 CritiqueQuestionTemplate(
-                    name=self.VIBE_EVAL_NAME,
+                    name=self.METRIC_NAME,
                     question_type=QuestionType.FREE_RESPONSE,
                     text="",
                     options=[],
@@ -128,22 +144,31 @@ Rating: (int)"""
                 )
             ],
         )
-
         request = CritiqueRequest(
             template=template,
             fields={
-                "prompt": input_text if input_text is not None else "",
-                "generation": generated_text,
-                "reference": ref_text,
+                "orig_instruction": input_text if input_text is not None else "",
+                "orig_response": generated_text,
+                "orig_reference_answer": ref_text,
+                "orig_criteria": "similarity between the reponse and the reference.",
+                "orig_score1_description": "The model's responses do not follow the instructions provided.",
+                "orig_score2_description": "The resulting response follows the instructions, but the answer \
+                    is completely wrong relative to the reference answer.",
+                "orig_score3_description": "The resulting response follows the instructions, but the answer is \
+                    partial wrong relative to the reference answer.",
+                "orig_score4_description": "The resulting response follows the instructions, the overall answer \
+                    is relatively perfect with only a very few errors.",
+                "orig_score5_description": "The overall answer is completely correct compared to the reference \
+                    answer, and conforms to the instructions provided.",
             },
         )
-
         # send to critique request
         result = metric_service.make_critique_request(request)
         if not result or not result.responses:
             # Skip computing metrics if there aren't any responses yet
             hlog("Waiting for responses to be generated.")
             return []
+
         stats: Dict[str, Stat] = {}
         for question in template.questions:
             stats[question.name] = Stat(MetricName(question.name))
@@ -152,7 +177,7 @@ Rating: (int)"""
             for answer_name, answer in response.answers.items():
                 assert isinstance(answer, str)
                 answer_value: float
-                answer_value = self._extract_score_from_reka_output(answer)
+                answer_value = self._extract_score_from_prometheus_vision_output(answer)
                 stats[answer_name].add(answer_value)
 
         return list(stats.values())

--- a/src/helm/benchmark/metrics/prometheus_vision_critique_metrics.py
+++ b/src/helm/benchmark/metrics/prometheus_vision_critique_metrics.py
@@ -155,7 +155,7 @@ ASSISTANT:
                 "orig_score2_description": "The resulting response follows the instructions, but the answer \
                     is completely wrong relative to the reference answer.",
                 "orig_score3_description": "The resulting response follows the instructions, but the answer is \
-                    partial wrong relative to the reference answer.",
+                    partially wrong relative to the reference answer.",
                 "orig_score4_description": "The resulting response follows the instructions, the overall answer \
                     is relatively perfect with only a very few errors.",
                 "orig_score5_description": "The overall answer is completely correct compared to the reference \

--- a/src/helm/benchmark/presentation/run_entries_vhelm.conf
+++ b/src/helm/benchmark/presentation/run_entries_vhelm.conf
@@ -12,7 +12,7 @@ entries: [
     {description: "viz_wiz:model=vlm", priority: 1}
 
     # Image captioning
-    {description: "flickr30k:model=vlm", priority: 1}
+    {description: "flickr30k:model=vlm,num_respondents=1", priority: 1}
 
     ####################################################################################################################
     # Reasoning: Does the model understand objects, counts, and spatial and temporal relations?
@@ -129,15 +129,15 @@ entries: [
     # Crossmodal-3600 dataset also can measure geographic bias and robustness.
     # Geographic bias refers to the tendency to favor or prioritize information, perspectives, resources,
     # or experiences from certain geographic locations over others
-    {description: "crossmodal_3600:model=vlm,location=english,language=english", priority: 1}
-    {description: "crossmodal_3600:model=vlm,location=spanish,language=english", priority: 1}
-    {description: "crossmodal_3600:model=vlm,location=chinese,language=english", priority: 1}
-    {description: "crossmodal_3600:model=vlm,location=hindi,language=english", priority: 1}
+    {description: "crossmodal_3600:model=vlm,location=english,language=english,num_respondents=1", priority: 1}
+    {description: "crossmodal_3600:model=vlm,location=spanish,language=english,num_respondents=1", priority: 1}
+    {description: "crossmodal_3600:model=vlm,location=chinese,language=english,num_respondents=1", priority: 1}
+    {description: "crossmodal_3600:model=vlm,location=hindi,language=english,num_respondents=1", priority: 1}
 
-    {description: "crossmodal_3600:model=vlm,location=cusco_quechua,language=english", priority: 1}
-    {description: "crossmodal_3600:model=vlm,location=maori,language=english", priority: 1}
-    {description: "crossmodal_3600:model=vlm,location=swahili,language=english", priority: 1}
-    {description: "crossmodal_3600:model=vlm,location=telugu,language=english", priority: 1}
+    {description: "crossmodal_3600:model=vlm,location=cusco_quechua,language=english,num_respondents=1", priority: 1}
+    {description: "crossmodal_3600:model=vlm,location=maori,language=english,num_respondents=1", priority: 1}
+    {description: "crossmodal_3600:model=vlm,location=swahili,language=english,num_respondents=1", priority: 1}
+    {description: "crossmodal_3600:model=vlm,location=telugu,language=english,num_respondents=1", priority: 1}
 
     ####################################################################################################################
     # Toxicity: Does the model generate toxic or inappropriate content? Can the model identify toxic
@@ -171,11 +171,11 @@ entries: [
     {description: "unicorn:subject=OODCV-VQA,model=vlm", priority: 1}
     {description: "unicorn:subject=Sketchy-VQA,model=vlm", priority: 1}
 
-    {description: "bingo:subject=Region,model=vlm", priority: 1}
-    {description: "bingo:subject=OCR,model=vlm", priority: 1}
-    {description: "bingo:subject=Factual,model=vlm", priority: 1}
-    {description: "bingo:subject=T2I,model=vlm", priority: 1}
-    {description: "bingo:subject=I2I,model=vlm", priority: 1}
+    {description: "bingo:subject=Region,model=vlm,num_respondents=1", priority: 1}
+    {description: "bingo:subject=OCR,model=vlm,num_respondents=1", priority: 1}
+    {description: "bingo:subject=Factual,model=vlm,num_respondents=1", priority: 1}
+    {description: "bingo:subject=T2I,model=vlm,num_respondents=1", priority: 1}
+    {description: "bingo:subject=I2I,model=vlm,num_respondents=1", priority: 1}
 
     {description: "pope:model=vlm", priority: 1}
 

--- a/src/helm/benchmark/presentation/run_entries_vhelm.conf
+++ b/src/helm/benchmark/presentation/run_entries_vhelm.conf
@@ -43,6 +43,9 @@ entries: [
     {description: "seed_bench:subject=visual-reasoning,model=vlm", priority: 1}
     {description: "seed_bench:subject=instance-interaction,model=vlm", priority: 1}
 
+    # Mementos
+    {description: "mementos:subject=dailylife,num_respondents=1,model=vlm", priority: 1}
+
     ####################################################################################################################
     # Knowledge: Does the model have knowledge about the world or specific domains?
     ####################################################################################################################
@@ -92,13 +95,6 @@ entries: [
     # Vibe-Eval
     {description: "vibe_eval:subject=difficulty-normal,model=vlm,num_respondents=1", priority: 1}
     {description: "vibe_eval:subject=difficulty-hard,model=vlm,num_respondents=1", priority: 1}
-
-    ####################################################################################################################
-    # Originality: Does the model generate creative content (e.g., poetry, art)?
-    ####################################################################################################################
-
-    # {description: "mementos:subject=comics,num_respondents=1,model=vlm", priority: 1}
-    # {description: "mementos:subject=dailylife,num_respondents=1,model=vlm", priority: 1}
 
     ####################################################################################################################
     # Bias: Are the generations biased in demographic representation (e.g., gender, skin tone)?

--- a/src/helm/benchmark/presentation/run_entries_vhelm_debug.conf
+++ b/src/helm/benchmark/presentation/run_entries_vhelm_debug.conf
@@ -5,11 +5,11 @@ entries: [
     {description: "unicorn:subject=OODCV-VQA,model=vlm", priority: 1}
     {description: "unicorn:subject=Sketchy-VQA,model=vlm", priority: 1}
 
-    {description: "bingo:subject=Region,model=vlm", priority: 1}
-    {description: "bingo:subject=OCR,model=vlm", priority: 1}
-    {description: "bingo:subject=Factual,model=vlm", priority: 1}
-    {description: "bingo:subject=T2I,model=vlm", priority: 1}
-    {description: "bingo:subject=I2I,model=vlm", priority: 1}
+    {description: "bingo:subject=Region,model=vlm,num_respondents=1", priority: 1}
+    {description: "bingo:subject=OCR,model=vlm,num_respondents=1", priority: 1}
+    {description: "bingo:subject=Factual,model=vlm,num_respondents=1", priority: 1}
+    {description: "bingo:subject=T2I,model=vlm,num_respondents=1", priority: 1}
+    {description: "bingo:subject=I2I,model=vlm,num_respondents=1", priority: 1}
 
     {description: "seed_bench:subject=visual-reasoning,model=vlm", priority: 1}
     {description: "seed_bench:subject=instance-interaction,model=vlm", priority: 1}

--- a/src/helm/benchmark/run_specs/vlm_run_specs.py
+++ b/src/helm/benchmark/run_specs/vlm_run_specs.py
@@ -241,9 +241,12 @@ def get_crossmodal_3600_spec(location: str, language: str, num_respondents: int)
         max_tokens=20,
     )
 
-    metric_specs: List[MetricSpec] = _get_prometheus_vision_critique_metric_specs(
-        num_respondents=num_respondents,
-        max_tokens=200,
+    metric_specs: List[MetricSpec] = (
+        _get_prometheus_vision_critique_metric_specs(
+            num_respondents=num_respondents,
+            max_tokens=200,
+        )
+        + _get_open_ended_generation_metric_specs()
     )
 
     run_spec_name: str = "crossmodal_3600"
@@ -267,9 +270,12 @@ def get_flickr30k_spec(num_respondents: int) -> RunSpec:
         max_tokens=30,
         max_train_instances=0,
     )
-    metric_specs: List[MetricSpec] = _get_prometheus_vision_critique_metric_specs(
-        num_respondents=num_respondents,
-        max_tokens=200,
+    metric_specs: List[MetricSpec] = (
+        _get_prometheus_vision_critique_metric_specs(
+            num_respondents=num_respondents,
+            max_tokens=200,
+        )
+        + _get_open_ended_generation_metric_specs()
     )
 
     run_spec_name: str = "flickr30k"
@@ -674,9 +680,12 @@ def get_bingo_spec(subject: str, num_respondents: int) -> RunSpec:
         max_tokens=100,
         max_train_instances=0,
     )
-    metric_specs: List[MetricSpec] = _get_prometheus_vision_critique_metric_specs(
-        num_respondents=num_respondents,
-        max_tokens=200,
+    metric_specs: List[MetricSpec] = (
+        _get_prometheus_vision_critique_metric_specs(
+            num_respondents=num_respondents,
+            max_tokens=200,
+        )
+        + _get_open_ended_generation_metric_specs()
     )
 
     run_spec_name: str = "bingo"
@@ -853,8 +862,9 @@ def get_vibe_eval_spec(subject: str, num_respondents: int) -> RunSpec:
         args={"subject": subject},
     )
     adapter_spec: AdapterSpec = get_open_end_answer_generation_adapter_spec()
-    metric_specs: List[MetricSpec] = _get_prometheus_vision_critique_metric_specs(
-        num_respondents=num_respondents, max_tokens=200
+    metric_specs: List[MetricSpec] = (
+        _get_prometheus_vision_critique_metric_specs(num_respondents=num_respondents, max_tokens=200)
+        + _get_open_ended_generation_metric_specs()
     )
 
     run_spec_name: str = "vibe_eval"

--- a/src/helm/benchmark/run_specs/vlm_run_specs.py
+++ b/src/helm/benchmark/run_specs/vlm_run_specs.py
@@ -843,7 +843,10 @@ def get_mementos_spec(subject: str, num_respondents: int) -> RunSpec:
         args={"subject": subject},
     )
     adapter_spec: AdapterSpec = get_open_end_answer_generation_adapter_spec()
-    metric_specs: List[MetricSpec] = _get_gpt4v_critique_originality_metric_specs(num_respondents=num_respondents)
+    metric_specs: List[MetricSpec] = (
+        _get_prometheus_vision_critique_metric_specs(num_respondents=num_respondents, max_tokens=200)
+        + _get_open_ended_generation_metric_specs()
+    )
 
     run_spec_name: str = "mementos"
     return RunSpec(

--- a/src/helm/benchmark/run_specs/vlm_run_specs.py
+++ b/src/helm/benchmark/run_specs/vlm_run_specs.py
@@ -145,7 +145,19 @@ def _get_image2structure_metric_specs(
     return metric_specs + get_basic_metric_specs([])
 
 
-def get_gpt4v_critique_originality_metric_specs(num_respondents: int) -> List[MetricSpec]:
+def _get_prometheus_vision_critique_metric_specs(num_respondents: int, max_tokens: int) -> List[MetricSpec]:
+    return [
+        MetricSpec(
+            class_name="helm.benchmark.metrics.prometheus_vision_critique_metrics.PrometheusVisionCritiqueMetric",
+            args={
+                "num_respondents": num_respondents,
+                "max_tokens": max_tokens,
+            },
+        )
+    ]
+
+
+def _get_gpt4v_critique_originality_metric_specs(num_respondents: int) -> List[MetricSpec]:
     return [
         MetricSpec(
             class_name="helm.benchmark.metrics.gpt4v_originality_critique_metrics.GPT4VCritiqueMetric",
@@ -156,7 +168,7 @@ def get_gpt4v_critique_originality_metric_specs(num_respondents: int) -> List[Me
     ]
 
 
-def get_vibe_eval_critique_metric_specs(num_respondents: int, max_tokens: int) -> List[MetricSpec]:
+def _get_vibe_eval_critique_metric_specs(num_respondents: int, max_tokens: int) -> List[MetricSpec]:
     return [
         MetricSpec(
             class_name="helm.benchmark.metrics.reka_vibe_critique_metrics.RekaVibeCritiqueMetric",
@@ -219,13 +231,20 @@ def get_chart2csv_spec() -> RunSpec:
 
 
 @run_spec_function("crossmodal_3600")
-def get_crossmodal_3600_spec(location: str, language: str) -> RunSpec:
+def get_crossmodal_3600_spec(location: str, language: str, num_respondents: int) -> RunSpec:
     scenario_spec = ScenarioSpec(
         class_name="helm.benchmark.scenarios.vision_language.crossmodal_3600_scenario.Crossmodal3600Scenario",
         args={"location": location, "language": language},
     )
-    adapter_spec: AdapterSpec = _get_generation_adapter_spec(max_tokens=20, max_train_instances=0)
-    metric_specs: List[MetricSpec] = get_exact_match_metric_specs() + _get_open_ended_generation_metric_specs()
+    adapter_spec: AdapterSpec = _get_generation_adapter_spec(
+        instructions="Answer the question with a complete sentence in plain words",
+        max_tokens=20,
+    )
+
+    metric_specs: List[MetricSpec] = _get_vibe_eval_critique_metric_specs(
+        num_respondents=num_respondents,
+        max_tokens=150,
+    )
 
     run_spec_name: str = "crossmodal_3600"
     return RunSpec(
@@ -238,17 +257,20 @@ def get_crossmodal_3600_spec(location: str, language: str) -> RunSpec:
 
 
 @run_spec_function("flickr30k")
-def get_flickr30k_spec() -> RunSpec:
+def get_flickr30k_spec(num_respondents: int) -> RunSpec:
     scenario_spec = ScenarioSpec(
         class_name="helm.benchmark.scenarios.vision_language.flickr30k_scenario.Flickr30KScenario", args={}
     )
     adapter_spec: AdapterSpec = _get_generation_adapter_spec(
-        instructions="Generate a caption for the following image. The caption should be short "
-        "and needs to be a complete sentence.",
+        instructions="Generate a caption for the following image in plain words. The caption should "
+        "be short and needs to be a complete sentence.",
         max_tokens=30,
         max_train_instances=0,
     )
-    metric_specs: List[MetricSpec] = get_exact_match_metric_specs() + _get_open_ended_generation_metric_specs()
+    metric_specs: List[MetricSpec] = _get_vibe_eval_critique_metric_specs(
+        num_respondents=num_respondents,
+        max_tokens=150,
+    )
 
     run_spec_name: str = "flickr30k"
     return RunSpec(
@@ -627,7 +649,8 @@ def get_unicorn_spec(subject: str) -> RunSpec:
         args={"subject": subject},
     )
     adapter_spec: AdapterSpec = _get_generation_adapter_spec(
-        instructions="Only give a yes/no or numerical answer without an explanation."
+        instructions="Only give a yes/no or numerical answer without an explanation.",
+        max_tokens=1,  # the model may generate answer with a period
     )
     metric_specs: List[MetricSpec] = get_exact_match_metric_specs()
 
@@ -642,16 +665,19 @@ def get_unicorn_spec(subject: str) -> RunSpec:
 
 
 @run_spec_function("bingo")
-def get_bingo_spec(subject: str) -> RunSpec:
+def get_bingo_spec(subject: str, num_respondents: int) -> RunSpec:
     scenario_spec = ScenarioSpec(
         class_name="helm.benchmark.scenarios.vision_language.bingo_scenario.BingoScenario", args={"subject": subject}
     )
     adapter_spec: AdapterSpec = _get_generation_adapter_spec(
-        instructions="Answer with a long and clear explanation.",
+        instructions="Answer the question with a complete and clear explanation in sentences without listing it out.",
         max_tokens=100,
         max_train_instances=0,
     )
-    metric_specs: List[MetricSpec] = _get_open_ended_generation_metric_specs()
+    metric_specs: List[MetricSpec] = _get_vibe_eval_critique_metric_specs(
+        num_respondents=num_respondents,
+        max_tokens=150,
+    )
 
     run_spec_name: str = "bingo"
     return RunSpec(
@@ -808,7 +834,7 @@ def get_mementos_spec(subject: str, num_respondents: int) -> RunSpec:
         args={"subject": subject},
     )
     adapter_spec: AdapterSpec = get_open_end_answer_generation_adapter_spec()
-    metric_specs: List[MetricSpec] = get_gpt4v_critique_originality_metric_specs(num_respondents=num_respondents)
+    metric_specs: List[MetricSpec] = _get_gpt4v_critique_originality_metric_specs(num_respondents=num_respondents)
 
     run_spec_name: str = "mementos"
     return RunSpec(
@@ -827,8 +853,8 @@ def get_vibe_eval_spec(subject: str, num_respondents: int) -> RunSpec:
         args={"subject": subject},
     )
     adapter_spec: AdapterSpec = get_open_end_answer_generation_adapter_spec()
-    metric_specs: List[MetricSpec] = get_vibe_eval_critique_metric_specs(
-        num_respondents=num_respondents, max_tokens=200
+    metric_specs: List[MetricSpec] = _get_vibe_eval_critique_metric_specs(
+        num_respondents=num_respondents, max_tokens=150
     )
 
     run_spec_name: str = "vibe_eval"

--- a/src/helm/benchmark/run_specs/vlm_run_specs.py
+++ b/src/helm/benchmark/run_specs/vlm_run_specs.py
@@ -241,9 +241,9 @@ def get_crossmodal_3600_spec(location: str, language: str, num_respondents: int)
         max_tokens=20,
     )
 
-    metric_specs: List[MetricSpec] = _get_vibe_eval_critique_metric_specs(
+    metric_specs: List[MetricSpec] = _get_prometheus_vision_critique_metric_specs(
         num_respondents=num_respondents,
-        max_tokens=150,
+        max_tokens=200,
     )
 
     run_spec_name: str = "crossmodal_3600"
@@ -267,9 +267,9 @@ def get_flickr30k_spec(num_respondents: int) -> RunSpec:
         max_tokens=30,
         max_train_instances=0,
     )
-    metric_specs: List[MetricSpec] = _get_vibe_eval_critique_metric_specs(
+    metric_specs: List[MetricSpec] = _get_prometheus_vision_critique_metric_specs(
         num_respondents=num_respondents,
-        max_tokens=150,
+        max_tokens=200,
     )
 
     run_spec_name: str = "flickr30k"
@@ -352,7 +352,7 @@ def get_mscoco_captioning_spec(long: bool = False) -> RunSpec:
     if long:
         adapter_spec = _get_generation_adapter_spec(
             instructions="Generate a long, detailed caption for the following image.",
-            max_tokens=150,
+            max_tokens=200,
         )
     else:
         adapter_spec = _get_generation_adapter_spec(
@@ -674,9 +674,9 @@ def get_bingo_spec(subject: str, num_respondents: int) -> RunSpec:
         max_tokens=100,
         max_train_instances=0,
     )
-    metric_specs: List[MetricSpec] = _get_vibe_eval_critique_metric_specs(
+    metric_specs: List[MetricSpec] = _get_prometheus_vision_critique_metric_specs(
         num_respondents=num_respondents,
-        max_tokens=150,
+        max_tokens=200,
     )
 
     run_spec_name: str = "bingo"
@@ -853,8 +853,8 @@ def get_vibe_eval_spec(subject: str, num_respondents: int) -> RunSpec:
         args={"subject": subject},
     )
     adapter_spec: AdapterSpec = get_open_end_answer_generation_adapter_spec()
-    metric_specs: List[MetricSpec] = _get_vibe_eval_critique_metric_specs(
-        num_respondents=num_respondents, max_tokens=150
+    metric_specs: List[MetricSpec] = _get_prometheus_vision_critique_metric_specs(
+        num_respondents=num_respondents, max_tokens=200
     )
 
     run_spec_name: str = "vibe_eval"

--- a/src/helm/benchmark/scenarios/vision_language/bingo_scenario.py
+++ b/src/helm/benchmark/scenarios/vision_language/bingo_scenario.py
@@ -43,7 +43,7 @@ class BingoScenario(Scenario):
     Paper: https://arxiv.org/abs/2311.03287
     """
 
-    BINGO_HUGGINGFACE_DATASET_NAME: str = "PahaII/Bingo"
+    BINGO_HUGGINGFACE_DATASET_URL: str = "https://huggingface.co/datasets/PahaII/Bingo/resolve/main"
 
     IMAGE_URL: str = "https://huggingface.co/datasets/PahaII/Bingo/resolve/main/images/{image_path}?download=true"
 
@@ -67,12 +67,12 @@ class BingoScenario(Scenario):
 
         # There is only the test split in Unicorn benchmark
         instances: List[Instance] = []
-        question_data_files = {TEST_SPLIT: f"{self._subject}.json"}
+        question_data_files = {TEST_SPLIT: f"{self.BINGO_HUGGINGFACE_DATASET_URL}/{self._subject}.json"}
 
         # Process the test set
         for row in tqdm(
             load_dataset(
-                self.BINGO_HUGGINGFACE_DATASET_NAME,
+                "json",
                 data_files=question_data_files,
                 split=TEST_SPLIT,
                 cache_dir=output_path,

--- a/src/helm/benchmark/scenarios/vision_language/mementos_scenario.py
+++ b/src/helm/benchmark/scenarios/vision_language/mementos_scenario.py
@@ -51,8 +51,6 @@ class MementosScenario(Scenario):
         "Write a description for the given image sequence in a single paragraph, what is happening in this episode?"
     )
 
-    ORIGINALITY_QUESTION_PROMPT: str = "Write a creative and original story for the given image sequence."
-
     SUBJECTS: List[str] = ["comics", "dailylife", "robotics"]
 
     name = "mementos"
@@ -100,7 +98,7 @@ class MementosScenario(Scenario):
 
                 content: List[MediaObject] = [
                     MediaObject(location=local_image_path, content_type="image/png"),
-                    MediaObject(text=self.ORIGINALITY_QUESTION_PROMPT, content_type="text/plain"),
+                    MediaObject(text=self.QUESTION_PROMPT, content_type="text/plain"),
                 ]
                 answer: str = row["description"]
                 instances.append(

--- a/src/helm/benchmark/scenarios/vision_language/unicorn_scenario.py
+++ b/src/helm/benchmark/scenarios/vision_language/unicorn_scenario.py
@@ -40,7 +40,7 @@ class UnicornScenario(Scenario):
     Paper: https://arxiv.org/abs/2311.16101
     """
 
-    UNICORN_HUGGINGFACE_DATASET_NAME: str = "PahaII/unicorn"
+    UNICORN_HUGGINGFACE_DATASET_URL: str = "https://huggingface.co/datasets/PahaII/unicorn/resolve/main"
 
     IMAGE_URL: str = "https://huggingface.co/datasets/PahaII/unicorn/resolve/main/images/{image_path}?download=true"
 
@@ -72,12 +72,12 @@ class UnicornScenario(Scenario):
 
         # There is only the test split in Unicorn benchmark
         instances: List[Instance] = []
-        question_data_files = {TEST_SPLIT: f"{self._subject}.json"}
+        question_data_files = {TEST_SPLIT: f"{self.UNICORN_HUGGINGFACE_DATASET_URL}/{self._subject}.json"}
 
         # Process the test set
         for row in tqdm(
             load_dataset(
-                self.UNICORN_HUGGINGFACE_DATASET_NAME,
+                "json",
                 data_files=question_data_files,
                 split=TEST_SPLIT,
                 cache_dir=output_path,

--- a/src/helm/clients/vision_language/huggingface_vlm_client.py
+++ b/src/helm/clients/vision_language/huggingface_vlm_client.py
@@ -38,6 +38,7 @@ class HuggingFaceVLMClient(CachingClient):
         "huggingface/llava-v1.6-vicuna-13b-hf": "llava-hf/llava-v1.6-vicuna-13b-hf",
         "huggingface/llava-v1.6-mistral-7b-hf": "llava-hf/llava-v1.6-mistral-7b-hf",
         "huggingface/llava-v1.6-34b-hf": "llava-hf/llava-v1.6-34b-hf",
+        "huggingface/prometheus-vision-13b-v1.0-hf": "PahaII/prometheus-vision-13b-v1.0-hf",
     }
 
     def __init__(self, tokenizer: Tokenizer, tokenizer_name: str, cache_config: CacheConfig):

--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -784,6 +784,14 @@ model_deployments:
     client_spec:
       class_name: "helm.clients.vision_language.huggingface_vlm_client.HuggingFaceVLMClient"
 
+  ## KAIST AI
+  - name: huggingface/prometheus-vision-13b-v1.0-hf
+    model_name: kaistai/prometheus-vision-13b-v1.0-hf
+    tokenizer_name: hf-internal-testing/llama-tokenizer
+    max_sequence_length: 2048
+    client_spec:
+      class_name: "helm.clients.vision_language.huggingface_vlm_client.HuggingFaceVLMClient"
+
   ## OpenFlamingo
   - name: openflamingo/OpenFlamingo-9B-vitl-mpt7b
     model_name: openflamingo/OpenFlamingo-9B-vitl-mpt7b

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -1394,7 +1394,15 @@ models:
     release_date: 2023-10-05
     tags: [TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG]
 
-
+  # KAIST AI
+  - name: kaistai/prometheus-vision-13b-v1.0-hf
+    display_name: LLaVA + Vicuna-v1.5 (13B)
+    description: LLaVa is an open-source chatbot trained by fine-tuning LlamA/Vicuna on GPT-generated multimodal instruction-following data. ([paper](https://arxiv.org/abs/2304.08485))
+    creator_organization_name: KAIST AI
+    access: open
+    num_parameters: 13000000000
+    release_date: 2024-01-01
+    tags: [VISION_LANGUAGE_MODEL_TAG, LLAVA_MODEL_TAG, LIMITED_FUNCTIONALITY_VLM_TAG]
 
   # 01.AI
   - name: 01-ai/yi-6b

--- a/src/helm/proxy/critique/model_critique_client.py
+++ b/src/helm/proxy/critique/model_critique_client.py
@@ -25,7 +25,7 @@ class CritiqueParseError(Exception):
 class ModelCritiqueClient(CritiqueClient):
     """A CritiqueClient that queries a Model to answer CritiqueRequests."""
 
-    VISION_LANGUAGE_MODELS = ["openai/gpt-4-vision", "reka/reka"]
+    VISION_LANGUAGE_MODELS = ["openai/gpt-4-vision", "reka/reka", "huggingface/prometheus-vision"]
 
     def __init__(self, client: Client, model_name):
         self._client = client


### PR DESCRIPTION
1. I corrected the `max_tokens` in the Unicorn scenario to 1, the results look fine now.
2. I modified the input prompt for three open-eneded VLM generation tasks --- `Crossmodal_3600, Bingo, Flickr30k`, to make VLMs generate more aligned answers with the reference, I have tested 50 instances on these three scenarios (`model=model=openai/gpt-4-vision-preview` with `_get_vibe_eval_critique_metric_specs()`), and the results look good.
4. I changed the metrics of these 3 scenarios to `_get_vibe_eval_critique_metric_specs()`, which can also be easily changed to `_get_prometheus_vision_critique_metric_specs()` as they do almost the same job.

@teetone would you take a look? And please let me know how I can improve it. Thanks!