### PR TITLE
Allow dicts to be displayed in AnnotationsDisplay without a enclosing list

### DIFF
--- a/helm-frontend/src/components/AnnotationsDisplay.tsx
+++ b/helm-frontend/src/components/AnnotationsDisplay.tsx
@@ -2,11 +2,55 @@ import CompletionAnnotation from "@/types/CompletionAnnotation";
 import Preview from "./Preview";
 import MediaObjectDisplay from "./MediaObjectDisplay";
 
+// TODO: This is a dirty hack to support annotations from
+// Image2Structure and AIRBench, but eventually we should make sure
+// all annotations are supported generally.
 type Props = {
   predictionAnnotations:
-    | Record<string, Array<CompletionAnnotation>>
+    | Record<string, Array<CompletionAnnotation> | Map<string, string | number>>
     | undefined;
 };
+
+function listAnnotationDisplay(listAnnotation: Array<CompletionAnnotation>) {
+  return (
+    <div>
+      {listAnnotation.map((annotation, idx) => (
+        <div key={idx}>
+          {annotation.error && (
+            <div>
+              <h3 className="ml-1">Error</h3>
+              <Preview value={annotation["error"]} />{" "}
+            </div>
+          )}
+          {annotation.text && (
+            <div>
+              <h3 className="ml-1">Text</h3>
+              <Preview value={annotation["text"]} />{" "}
+            </div>
+          )}
+          {annotation.media_object && (
+            <MediaObjectDisplay mediaObject={annotation["media_object"]} />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function dictAnnotationDisplay(
+  dictAnnotation: Record<string, string | number>,
+) {
+  return (
+    <div>
+      {Object.entries(dictAnnotation).map(([key, value]) => (
+        <div>
+          <h3 className="ml-1">{key}</h3>
+          <Preview value={value.toString()} />
+        </div>
+      ))}
+    </div>
+  );
+}
 
 export default function AnnotationDisplay({ predictionAnnotations }: Props) {
   return (
@@ -17,27 +61,9 @@ export default function AnnotationDisplay({ predictionAnnotations }: Props) {
               <h3>
                 <strong>{key}</strong>
               </h3>
-              {value.map((annotation, idx) => (
-                <div key={idx}>
-                  {annotation.error && (
-                    <div>
-                      <h3 className="ml-1">Error</h3>
-                      <Preview value={annotation["error"]} />{" "}
-                    </div>
-                  )}
-                  {annotation.text && (
-                    <div>
-                      <h3 className="ml-1">Text</h3>
-                      <Preview value={annotation["text"]} />{" "}
-                    </div>
-                  )}
-                  {annotation.media_object && (
-                    <MediaObjectDisplay
-                      mediaObject={annotation["media_object"]}
-                    />
-                  )}
-                </div>
-              ))}
+              {Array.isArray(value)
+                ? listAnnotationDisplay(value)
+                : dictAnnotationDisplay(value)}
             </div>
           ))
         : null}


### PR DESCRIPTION
The current annotations display assumes that there is an enclosing list around the dict, but this may not be the case generally. For now, we hack in support for a dict without an enclosing list to support AIRBench 2024.

Addresses #2697