### PR TITLE
Switch most Together chat models to use the chat client

### DIFF
--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -371,7 +371,7 @@ model_deployments:
     tokenizer_name: databricks/dbrx-instruct
     max_sequence_length: 32767
     client_spec:
-      class_name: "helm.clients.together_client.TogetherClient"
+      class_name: "helm.clients.together_client.TogetherChatClient"
 
   # DeepFloyd
 
@@ -1716,7 +1716,7 @@ model_deployments:
     tokenizer_name: meta/llama-3-8b
     max_sequence_length: 8191
     client_spec:
-      class_name: "helm.clients.together_client.TogetherClient"
+      class_name: "helm.clients.together_client.TogetherChatClient"
       args:
         together_model: meta-llama/Llama-3-8b-chat-hf
 
@@ -1725,7 +1725,7 @@ model_deployments:
     tokenizer_name: meta/llama-3-8b
     max_sequence_length: 8191
     client_spec:
-      class_name: "helm.clients.together_client.TogetherClient"
+      class_name: "helm.clients.together_client.TogetherChatClient"
       args:
         together_model: meta-llama/Llama-3-70b-chat-hf
 
@@ -1771,7 +1771,7 @@ model_deployments:
     tokenizer_name: 01-ai/Yi-6B
     max_sequence_length: 4095
     client_spec:
-      class_name: "helm.clients.together_client.TogetherClient"
+      class_name: "helm.clients.together_client.TogetherChatClient"
       args:
         together_model: zero-one-ai/Yi-6B-Chat
 
@@ -1780,7 +1780,7 @@ model_deployments:
     tokenizer_name: 01-ai/Yi-6B
     max_sequence_length: 4095
     client_spec:
-      class_name: "helm.clients.together_client.TogetherClient"
+      class_name: "helm.clients.together_client.TogetherChatClient"
       args:
         together_model: zero-one-ai/Yi-34B-Chat
 
@@ -1861,7 +1861,7 @@ model_deployments:
     tokenizer_name: mistralai/Mistral-7B-v0.1
     max_sequence_length: 4095 # Subtract 1 token to work around a off-by-one bug in Together's input validation token counting (#2080)
     client_spec:
-      class_name: "helm.clients.together_client.TogetherClient"
+      class_name: "helm.clients.together_client.TogetherChatClient"
 
   - name: together/mixtral-8x22b
     model_name: mistralai/mixtral-8x22b
@@ -1875,7 +1875,7 @@ model_deployments:
     tokenizer_name: mistralai/Mistral-7B-v0.1
     max_sequence_length: 65535
     client_spec:
-      class_name: "helm.clients.together_client.TogetherClient"
+      class_name: "helm.clients.together_client.TogetherChatClient"
 
 
   ## Snowflake
@@ -2162,35 +2162,35 @@ model_deployments:
     tokenizer_name: qwen/qwen1.5-7b
     max_sequence_length: 32767
     client_spec:
-      class_name: "helm.clients.together_client.TogetherClient"
+      class_name: "helm.clients.together_client.TogetherChatClient"
 
   - name: together/qwen1.5-14b-chat
     model_name: qwen/qwen1.5-14b-chat
     tokenizer_name: qwen/qwen1.5-7b
     max_sequence_length: 32767
     client_spec:
-      class_name: "helm.clients.together_client.TogetherClient"
+      class_name: "helm.clients.together_client.TogetherChatClient"
 
   - name: together/qwen1.5-32b-chat
     model_name: qwen/qwen1.5-32b-chat
     tokenizer_name: qwen/qwen1.5-7b
     max_sequence_length: 32767
     client_spec:
-      class_name: "helm.clients.together_client.TogetherClient"
+      class_name: "helm.clients.together_client.TogetherChatClient"
 
   - name: together/qwen1.5-72b-chat
     model_name: qwen/qwen1.5-72b-chat
     tokenizer_name: qwen/qwen1.5-7b
     max_sequence_length: 32767
     client_spec:
-      class_name: "helm.clients.together_client.TogetherClient"
+      class_name: "helm.clients.together_client.TogetherChatClient"
 
   - name: together/qwen1.5-110b-chat
     model_name: qwen/qwen1.5-110b-chat
     tokenizer_name: qwen/qwen1.5-7b
     max_sequence_length: 32767
     client_spec:
-      class_name: "helm.clients.together_client.TogetherClient"
+      class_name: "helm.clients.together_client.TogetherChatClient"
 
   - name: huggingface/qwen-vl
     model_name: qwen/qwen-vl

--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -1805,7 +1805,7 @@ model_deployments:
     tokenizer_name: allenai/olmo-7b
     max_sequence_length: 2047
     client_spec:
-      class_name: "helm.clients.together_client.TogetherClient"
+      class_name: "helm.clients.together_client.TogetherChatClient"
 
   - name: huggingface/olmo-1.7-7b
     model_name: allenai/olmo-1.7-7b


### PR DESCRIPTION
This ensures that the correct chat template and stop sequences are used.