### PR TITLE
Fix frontend breakage

### DIFF
--- a/helm-frontend/src/components/AnnotationsDisplay.tsx
+++ b/helm-frontend/src/components/AnnotationsDisplay.tsx
@@ -7,7 +7,10 @@ import MediaObjectDisplay from "./MediaObjectDisplay";
 // all annotations are supported generally.
 type Props = {
   predictionAnnotations:
-    | Record<string, Array<CompletionAnnotation> | Map<string, string | number>>
+    | Record<
+        string,
+        Array<CompletionAnnotation> | Record<string, string | number>
+      >
     | undefined;
 };
 


### PR DESCRIPTION
Breakage caused by #2700:

```
Argument of type 'Map<string, string \| number>' is not assignable to parameter of type 'Record<string, string \| number>'.
```