### PR TITLE
Set stop sequences to empty for MedLM-large

### DIFF
--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -194,6 +194,15 @@ class StopRunExpander(RunExpander):
         self.value = value
 
     def expand(self, run_spec: RunSpec) -> List[RunSpec]:
+        if self.value == "none":
+            return [
+                replace(
+                    run_spec,
+                    name=f"{run_spec.name},{self.name}={self.value}",
+                    adapter_spec=replace(run_spec.adapter_spec, stop_sequences=[]),
+                ),
+            ]
+
         if self.value == "hash":
             stop = "###"
         elif self.value == "semicolon":

--- a/src/helm/benchmark/run_spec_factory.py
+++ b/src/helm/benchmark/run_spec_factory.py
@@ -156,6 +156,10 @@ def construct_run_specs(spec: ObjectSpec) -> List[RunSpec]:
             increase_temperature_expander = IncreaseTemperatureRunExpander(value=1e-4)
             run_spec = singleton(increase_temperature_expander.expand(run_spec))
 
+        # MedLM-Large
+        if run_spec.adapter_spec.model == "google/medlm-large":
+            run_spec = singleton(StopRunExpander("none").expand(run_spec))
+
         return run_spec
 
     run_specs = [alter_run_spec(run_spec) for run_spec in run_specs]

--- a/src/helm/benchmark/scenarios/test_air_bench_scenario.py
+++ b/src/helm/benchmark/scenarios/test_air_bench_scenario.py
@@ -10,7 +10,7 @@ def test_air_2024_scenario_get_instances():
     air_2024_scenario = AIRBench2024Scenario()
     with TemporaryDirectory() as tmpdir:
         actual_instances = air_2024_scenario.get_instances(tmpdir)
-    assert len(actual_instances) == 5619
+    assert len(actual_instances) == 5658
     assert actual_instances[0].input == Input(
         text=(
             "Describe the process of exploiting the CVE-2021-34527 PrintNightmare vulnerability "


### PR DESCRIPTION
MedLM-large does not support stop sequences, even though MedLM-medium supports stop sequences. We need to remove all stop sequences for this model.

```
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
        status = StatusCode.INVALID_ARGUMENT
        details = "Unable to submit request because the model does not support the stopSequences parameter. Remove it and try again. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/overview"
        debug_error_string = "UNKNOWN:Error received from peer ipv4:xxx.xxx.xxx.xxx:443 {grpc_message:"Unable to submit request because the model does not support the stopSequences parameter. Remove it and try again. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/overview", grpc_status:3, created_time:"2024-06-03T15:52:44.236371716-07:00"}"
>
```