### PR TITLE
Add Model as Judge for medical scenarios

### DIFF
--- a/src/helm/benchmark/annotation/live_qa_annotator.py
+++ b/src/helm/benchmark/annotation/live_qa_annotator.py
@@ -1,4 +1,3 @@
-import datasets
 import os
 import re
 from typing import Any
@@ -35,8 +34,8 @@ The user's request will be provided in these tags:
 <user_request>
 {{QUESTION}}
 </user_request>
-The model's response will be provided in these tags:  
-<model_response> 
+The model's response will be provided in these tags:
+<model_response>
 {{ANSWER}}
 </model_response>
 Some potential correct responses will be provided in these tags:
@@ -49,9 +48,9 @@ Carefully analyze the <model_response> and determine if the model is correct wit
 # 0.3, if the model response contains some correct information but is incomplete and/or contains incorrect information relative to the correct response(s)
 # 0, if the model response is completely unrelated or incorrect relative to the correct response(s)
 Output your one-sentence concise reasoning in the ##short_reasoning tag and your score in the ##the_score tag. Your reasoning should be less than 20 tokens. The score should be a single number with no other output.
-Format: 
+Format:
 ##short_reasoning: <your concise and brief reasoning>
-##the_score: <your score>"""
+##the_score: <your score>"""  # noqa: E501
         annotator_prompt = (
             prompt_template.strip('"')
             .strip()

--- a/src/helm/benchmark/annotation/live_qa_annotator.py
+++ b/src/helm/benchmark/annotation/live_qa_annotator.py
@@ -1,0 +1,83 @@
+import datasets
+import os
+import re
+from typing import Any
+
+from helm.common.general import ensure_directory_exists
+from helm.benchmark.adaptation.request_state import RequestState
+from helm.benchmark.annotation.annotator import Annotator
+from helm.clients.auto_client import AutoClient
+from helm.common.request import Request
+
+
+class LiveQAAnnotator(Annotator):
+    """The LiveQA autograder."""
+
+    name = "live_qa"
+
+    def __init__(self, auto_client: AutoClient, file_storage_path: str):
+        self._auto_client = auto_client
+        cache_dir = os.path.join(file_storage_path, "data")
+        ensure_directory_exists(cache_dir)
+        # Regex pattern is lenient to allow for typos e.g. extra whitespace
+        self._pattern = re.compile("##\s*short_reasoning\s*:(.*)##\s*the_score\s*:(.*)", re.DOTALL)
+
+    def annotate(self, request_state: RequestState) -> Any:
+        assert request_state.result
+        assert len(request_state.result.completions) == 1
+        model_input_text = request_state.request.prompt
+        model_output_text = request_state.result.completions[0].text
+        correct_responses = ""
+        for i, reference in enumerate(request_state.instance.references):
+            correct_responses += "Correct Response #" + str(i) + ": " + reference.output.text + "\n"
+        prompt_template = """You are a medical judge will be given a user request and a model response to that request. Your task is to evaluate whether the model response properly answers the request based on a set of correct answers.
+The user's request will be provided in these tags:
+<user_request>
+{{QUESTION}}
+</user_request>
+The model's response will be provided in these tags:  
+<model_response> 
+{{ANSWER}}
+</model_response>
+Some potential correct responses will be provided in these tags:
+<correct_responses>
+{{CORRECT_RESPONSES}}
+</correct_responses>
+Carefully analyze the <model_response> and determine if the model is correct with respect to one or more of the <correct_responses> on a range from 0 to 1.
+# 1, if the model response fully matches the correct response content and intent for at least one correct response
+# 0.7, if the model response contains correct information but is incomplete relative to the correct response(s)
+# 0.3, if the model response contains some correct information but is incomplete and/or contains incorrect information relative to the correct response(s)
+# 0, if the model response is completely unrelated or incorrect relative to the correct response(s)
+Output your one-sentence concise reasoning in the ##short_reasoning tag and your score in the ##the_score tag. Your reasoning should be less than 20 tokens. The score should be a single number with no other output.
+Format: 
+##short_reasoning: <your concise and brief reasoning>
+##the_score: <your score>"""
+        annotator_prompt = (
+            prompt_template.strip('"')
+            .strip()
+            .replace("{{QUESTION}}", model_input_text)
+            .replace("{{ANSWER}}", model_output_text)
+            .replace("{{CORRECT_RESPONSES}}", correct_responses)
+        )
+        annotator_request = Request(
+            model="openai/gpt-4-turbo-2024-04-09",
+            model_deployment="openai/gpt-4-turbo-2024-04-09",
+            prompt=annotator_prompt,
+            temperature=0.0,
+            max_tokens=64,
+        )
+        annotator_response = self._auto_client.make_request(annotator_request)
+        if not annotator_response.success:
+            raise Exception(f"Annotation request failed: {annotator_response.error}")
+        assert len(annotator_response.completions) == 1
+        annotator_response_text = annotator_response.completions[0].text
+        annotator_response_parts = self._pattern.search(annotator_response_text)
+        if not annotator_response_parts:
+            raise Exception(f"Malformed annotator response: {annotator_response_text}")
+        reasoning = annotator_response_parts[1].strip()
+        try:
+            score = float(annotator_response_parts[2].strip())
+        except ValueError as e:
+            raise Exception(f"Malformed annotator response: {annotator_response_text}") from e
+
+        return {"prompt_text": annotator_prompt, "reasoning": reasoning, "score": score}

--- a/src/helm/benchmark/annotation/medication_qa_annotator.py
+++ b/src/helm/benchmark/annotation/medication_qa_annotator.py
@@ -1,4 +1,3 @@
-import datasets
 import os
 import re
 from typing import Any
@@ -33,8 +32,8 @@ The user's request will be provided in these tags:
 <user_request>
 {{QUESTION}}
 </user_request>
-The model's response will be provided in these tags:  
-<model_response> 
+The model's response will be provided in these tags:
+<model_response>
 {{ANSWER}}
 </model_response>
 Some potential correct responses will be provided in these tags:
@@ -46,9 +45,9 @@ Carefully analyze the <model_response> and determine if the model is correct wit
 # 0.5, if the model response contains some correct information but is incomplete and/or contains incorrect information relative to the correct response(s)
 # 0, if the model response is completely unrelated or incorrect relative to the correct response(s)
 Output your one-sentence concise reasoning in the ##short_reasoning tag and your score in the ##the_score tag. Your reasoning should be less than 20 tokens. The score should be a single number with no other output.
-Format: 
+Format:
 ##short_reasoning: <your concise and brief reasoning>
-##the_score: <your score>"""
+##the_score: <your score>"""  # noqa: E501
         annotator_prompt = (
             prompt_template.strip('"')
             .strip()

--- a/src/helm/benchmark/annotation/medication_qa_annotator.py
+++ b/src/helm/benchmark/annotation/medication_qa_annotator.py
@@ -1,0 +1,80 @@
+import datasets
+import os
+import re
+from typing import Any
+
+from helm.common.general import ensure_directory_exists
+from helm.benchmark.adaptation.request_state import RequestState
+from helm.benchmark.annotation.annotator import Annotator
+from helm.clients.auto_client import AutoClient
+from helm.common.request import Request
+
+
+class MedicationQAAnnotator(Annotator):
+    """The LiveQA autograder."""
+
+    name = "medication_qa"
+
+    def __init__(self, auto_client: AutoClient, file_storage_path: str):
+        self._auto_client = auto_client
+        cache_dir = os.path.join(file_storage_path, "data")
+        ensure_directory_exists(cache_dir)
+        # Regex pattern is lenient to allow for typos e.g. extra whitespace
+        self._pattern = re.compile("##\s*short_reasoning\s*:(.*)##\s*the_score\s*:(.*)", re.DOTALL)
+
+    def annotate(self, request_state: RequestState) -> Any:
+        assert request_state.result
+        assert len(request_state.result.completions) == 1
+        model_input_text = request_state.request.prompt
+        model_output_text = request_state.result.completions[0].text
+        correct_response = request_state.instance.references[0].output.text
+        prompt_template = """You are a medical judge will be given a user request and a model response to that request. Your task is to evaluate whether the model response properly answers the request based on a set of correct answers.
+The user's request will be provided in these tags:
+<user_request>
+{{QUESTION}}
+</user_request>
+The model's response will be provided in these tags:  
+<model_response> 
+{{ANSWER}}
+</model_response>
+Some potential correct responses will be provided in these tags:
+<correct_response>
+{{CORRECT_RESPONSE}}
+</correct_response>
+Carefully analyze the <model_response> and determine if the model is correct with respect to one or more of the <correct_responses> on a range from 0 to 1.
+# 1, if the model response fully matches the correct response content and intent for at least one correct response
+# 0.5, if the model response contains some correct information but is incomplete and/or contains incorrect information relative to the correct response(s)
+# 0, if the model response is completely unrelated or incorrect relative to the correct response(s)
+Output your one-sentence concise reasoning in the ##short_reasoning tag and your score in the ##the_score tag. Your reasoning should be less than 20 tokens. The score should be a single number with no other output.
+Format: 
+##short_reasoning: <your concise and brief reasoning>
+##the_score: <your score>"""
+        annotator_prompt = (
+            prompt_template.strip('"')
+            .strip()
+            .replace("{{QUESTION}}", model_input_text)
+            .replace("{{ANSWER}}", model_output_text)
+            .replace("{{CORRECT_RESPONSE}}", correct_response)
+        )
+        annotator_request = Request(
+            model="openai/gpt-4-turbo-2024-04-09",
+            model_deployment="openai/gpt-4-turbo-2024-04-09",
+            prompt=annotator_prompt,
+            temperature=0.0,
+            max_tokens=64,
+        )
+        annotator_response = self._auto_client.make_request(annotator_request)
+        if not annotator_response.success:
+            raise Exception(f"Annotation request failed: {annotator_response.error}")
+        assert len(annotator_response.completions) == 1
+        annotator_response_text = annotator_response.completions[0].text
+        annotator_response_parts = self._pattern.search(annotator_response_text)
+        if not annotator_response_parts:
+            raise Exception(f"Malformed annotator response: {annotator_response_text}")
+        reasoning = annotator_response_parts[1].strip()
+        try:
+            score = float(annotator_response_parts[2].strip())
+        except ValueError as e:
+            raise Exception(f"Malformed annotator response: {annotator_response_text}") from e
+
+        return {"prompt_text": annotator_prompt, "reasoning": reasoning, "score": score}

--- a/src/helm/benchmark/metrics/instruction_following_critique_metrics.py
+++ b/src/helm/benchmark/metrics/instruction_following_critique_metrics.py
@@ -1,3 +1,4 @@
+# noqa: E501
 from typing import Dict, List
 
 from helm.benchmark.adaptation.request_state import RequestState

--- a/src/helm/benchmark/metrics/live_qa_metrics.py
+++ b/src/helm/benchmark/metrics/live_qa_metrics.py
@@ -2,32 +2,10 @@ from typing import List
 
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.metrics.basic_metrics import compute_request_state_metrics
-from helm.benchmark.metrics.efficiency_metrics import EfficiencyMetric
 from helm.benchmark.metrics.metric import Metric
 from helm.benchmark.metrics.metric_name import MetricName
 from helm.benchmark.metrics.metric_service import MetricService
 from helm.benchmark.metrics.statistic import Stat
-
-
-class LiveQABasicGenerationMetric(Metric):
-    """Replacement for BasicGenerationMetric for LiveQA.
-
-    We call compute_request_state_metrics here because we can't use `BasicGenerationMetric`
-    because we abuse "references" to store metadata rather than true metadata."""
-
-    def __init__(self):
-        super().__init__()
-        self.efficiency_metric = EfficiencyMetric()
-
-    def evaluate_generation(
-        self,
-        adapter_spec: AdapterSpec,
-        request_state: RequestState,
-        metric_service: MetricService,
-        eval_cache_path: str,
-    ) -> List[Stat]:
-        return compute_request_state_metrics(self.efficiency_metric, adapter_spec, request_state, metric_service)
 
 
 class LiveQAScoreMetric(Metric):

--- a/src/helm/benchmark/metrics/live_qa_metrics.py
+++ b/src/helm/benchmark/metrics/live_qa_metrics.py
@@ -1,0 +1,45 @@
+from typing import List
+
+from helm.benchmark.adaptation.adapter_spec import AdapterSpec
+from helm.benchmark.adaptation.request_state import RequestState
+from helm.benchmark.metrics.basic_metrics import compute_request_state_metrics
+from helm.benchmark.metrics.efficiency_metrics import EfficiencyMetric
+from helm.benchmark.metrics.metric import Metric
+from helm.benchmark.metrics.metric_name import MetricName
+from helm.benchmark.metrics.metric_service import MetricService
+from helm.benchmark.metrics.statistic import Stat
+
+
+class LiveQABasicGenerationMetric(Metric):
+    """Replacement for BasicGenerationMetric for LiveQA.
+
+    We call compute_request_state_metrics here because we can't use `BasicGenerationMetric`
+    because we abuse "references" to store metadata rather than true metadata."""
+
+    def __init__(self):
+        super().__init__()
+        self.efficiency_metric = EfficiencyMetric()
+
+    def evaluate_generation(
+        self,
+        adapter_spec: AdapterSpec,
+        request_state: RequestState,
+        metric_service: MetricService,
+        eval_cache_path: str,
+    ) -> List[Stat]:
+        return compute_request_state_metrics(self.efficiency_metric, adapter_spec, request_state, metric_service)
+
+
+class LiveQAScoreMetric(Metric):
+    """Score metrics for LiveQA."""
+
+    def evaluate_generation(
+        self,
+        adapter_spec: AdapterSpec,
+        request_state: RequestState,
+        metric_service: MetricService,
+        eval_cache_path: str,
+    ) -> List[Stat]:
+        assert request_state.annotations
+        score = request_state.annotations["live_qa"]["score"]
+        return [Stat(MetricName("live_qa_score")).add(score)]

--- a/src/helm/benchmark/metrics/medication_qa_metrics.py
+++ b/src/helm/benchmark/metrics/medication_qa_metrics.py
@@ -1,0 +1,45 @@
+from typing import List
+
+from helm.benchmark.adaptation.adapter_spec import AdapterSpec
+from helm.benchmark.adaptation.request_state import RequestState
+from helm.benchmark.metrics.basic_metrics import compute_request_state_metrics
+from helm.benchmark.metrics.efficiency_metrics import EfficiencyMetric
+from helm.benchmark.metrics.metric import Metric
+from helm.benchmark.metrics.metric_name import MetricName
+from helm.benchmark.metrics.metric_service import MetricService
+from helm.benchmark.metrics.statistic import Stat
+
+
+class MedicationQABasicGenerationMetric(Metric):
+    """Replacement for BasicGenerationMetric for MedicationQA.
+
+    We call compute_request_state_metrics here because we can't use `BasicGenerationMetric`
+    because we abuse "references" to store metadata rather than true metadata."""
+
+    def __init__(self):
+        super().__init__()
+        self.efficiency_metric = EfficiencyMetric()
+
+    def evaluate_generation(
+        self,
+        adapter_spec: AdapterSpec,
+        request_state: RequestState,
+        metric_service: MetricService,
+        eval_cache_path: str,
+    ) -> List[Stat]:
+        return compute_request_state_metrics(self.efficiency_metric, adapter_spec, request_state, metric_service)
+
+
+class MedicationQAScoreMetric(Metric):
+    """Score metrics for MedicationQA."""
+
+    def evaluate_generation(
+        self,
+        adapter_spec: AdapterSpec,
+        request_state: RequestState,
+        metric_service: MetricService,
+        eval_cache_path: str,
+    ) -> List[Stat]:
+        assert request_state.annotations
+        score = request_state.annotations["medication_qa"]["score"]
+        return [Stat(MetricName("medication_qa_score")).add(score)]

--- a/src/helm/benchmark/metrics/medication_qa_metrics.py
+++ b/src/helm/benchmark/metrics/medication_qa_metrics.py
@@ -2,32 +2,10 @@ from typing import List
 
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.metrics.basic_metrics import compute_request_state_metrics
-from helm.benchmark.metrics.efficiency_metrics import EfficiencyMetric
 from helm.benchmark.metrics.metric import Metric
 from helm.benchmark.metrics.metric_name import MetricName
 from helm.benchmark.metrics.metric_service import MetricService
 from helm.benchmark.metrics.statistic import Stat
-
-
-class MedicationQABasicGenerationMetric(Metric):
-    """Replacement for BasicGenerationMetric for MedicationQA.
-
-    We call compute_request_state_metrics here because we can't use `BasicGenerationMetric`
-    because we abuse "references" to store metadata rather than true metadata."""
-
-    def __init__(self):
-        super().__init__()
-        self.efficiency_metric = EfficiencyMetric()
-
-    def evaluate_generation(
-        self,
-        adapter_spec: AdapterSpec,
-        request_state: RequestState,
-        metric_service: MetricService,
-        eval_cache_path: str,
-    ) -> List[Stat]:
-        return compute_request_state_metrics(self.efficiency_metric, adapter_spec, request_state, metric_service)
 
 
 class MedicationQAScoreMetric(Metric):

--- a/src/helm/benchmark/run_specs/classic_run_specs.py
+++ b/src/helm/benchmark/run_specs/classic_run_specs.py
@@ -46,6 +46,7 @@ from helm.benchmark.run_spec import RunSpec, run_spec_function
 from helm.benchmark.runner import get_benchmark_output_path
 from helm.benchmark.scenarios.scenario import ScenarioSpec, get_scenario_cache_path
 from helm.common.hierarchical_logger import hlog, htrack
+from helm.benchmark.annotation.annotator import AnnotatorSpec
 
 
 @run_spec_function("bbq")
@@ -1168,19 +1169,36 @@ def get_pubmed_qa_spec() -> RunSpec:
 def get_live_qa_spec() -> RunSpec:
     scenario_spec = ScenarioSpec(class_name="helm.benchmark.scenarios.live_qa_scenario.LiveQAScenario")
 
-    adapter_spec = get_generation_adapter_spec(
+    adapter_spec = AdapterSpec(
+        method=ADAPT_GENERATION,
+        global_prefix="",
+        global_suffix="",
         instructions="Please answer the following consumer health question.",
-        input_noun="Question",
-        output_noun="Answer",
+        input_prefix="Question",
+        input_suffix="",
+        output_prefix="Answer",
+        output_suffix="",
+        instance_prefix="",
         max_train_instances=0,
+        num_outputs=1,
         max_tokens=512,
+        temperature=0.0,
+        stop_sequences=[],
     )
+
+    annotator_specs = [AnnotatorSpec(class_name="helm.benchmark.annotation.live_qa_annotator.LiveQAAnnotator")]
+    metric_specs = [
+        MetricSpec(class_name="helm.benchmark.metrics.live_qa_metrics.LiveQAScoreMetric"),
+        MetricSpec(class_name="helm.benchmark.metrics.live_qa_metrics.LiveQABasicGenerationMetric"),
+        MetricSpec(class_name="helm.benchmark.metrics.basic_metrics.InstancesPerSplitMetric"),
+    ] + get_open_ended_generation_metric_specs()
 
     return RunSpec(
         name="live_qa",
         scenario_spec=scenario_spec,
         adapter_spec=adapter_spec,
-        metric_specs=get_open_ended_generation_metric_specs(),
+        metric_specs=metric_specs,
+        annotators=annotator_specs,
         groups=["live_qa"],
     )
 
@@ -1189,19 +1207,38 @@ def get_live_qa_spec() -> RunSpec:
 def get_medication_qa_spec() -> RunSpec:
     scenario_spec = ScenarioSpec(class_name="helm.benchmark.scenarios.medication_qa_scenario.MedicationQAScenario")
 
-    adapter_spec = get_generation_adapter_spec(
+    adapter_spec = AdapterSpec(
+        method=ADAPT_GENERATION,
+        global_prefix="",
+        global_suffix="",
         instructions="Please answer the following consumer health question.",
-        input_noun="Question",
-        output_noun="Answer",
+        input_prefix="Question",
+        input_suffix="",
+        output_prefix="Answer",
+        output_suffix="",
+        instance_prefix="",
         max_train_instances=0,
+        num_outputs=1,
         max_tokens=512,
+        temperature=0.0,
+        stop_sequences=[],
     )
+
+    annotator_specs = [
+        AnnotatorSpec(class_name="helm.benchmark.annotation.medication_qa_annotator.MedicationQAAnnotator")
+    ]
+    metric_specs = [
+        MetricSpec(class_name="helm.benchmark.metrics.medication_qa_metrics.MedicationQAScoreMetric"),
+        MetricSpec(class_name="helm.benchmark.metrics.medication_qa_metrics.MedicationQABasicGenerationMetric"),
+        MetricSpec(class_name="helm.benchmark.metrics.basic_metrics.InstancesPerSplitMetric"),
+    ] + get_open_ended_generation_metric_specs()
 
     return RunSpec(
         name="medication_qa",
         scenario_spec=scenario_spec,
         adapter_spec=adapter_spec,
-        metric_specs=get_open_ended_generation_metric_specs(),
+        metric_specs=metric_specs,
+        annotators=annotator_specs,
         groups=["medication_qa"],
     )
 

--- a/src/helm/benchmark/run_specs/classic_run_specs.py
+++ b/src/helm/benchmark/run_specs/classic_run_specs.py
@@ -24,6 +24,7 @@ from helm.benchmark.adaptation.common_adapter_specs import (
     get_ranking_binary_adapter_spec,
     get_summarization_adapter_spec,
 )
+from helm.benchmark.annotation.annotator import AnnotatorSpec
 from helm.benchmark.metrics.common_metric_specs import (
     get_basic_metric_specs,
     get_bias_metric_specs,
@@ -46,7 +47,6 @@ from helm.benchmark.run_spec import RunSpec, run_spec_function
 from helm.benchmark.runner import get_benchmark_output_path
 from helm.benchmark.scenarios.scenario import ScenarioSpec, get_scenario_cache_path
 from helm.common.hierarchical_logger import hlog, htrack
-from helm.benchmark.annotation.annotator import AnnotatorSpec
 
 
 @run_spec_function("bbq")
@@ -1169,36 +1169,24 @@ def get_pubmed_qa_spec() -> RunSpec:
 def get_live_qa_spec() -> RunSpec:
     scenario_spec = ScenarioSpec(class_name="helm.benchmark.scenarios.live_qa_scenario.LiveQAScenario")
 
-    adapter_spec = AdapterSpec(
-        method=ADAPT_GENERATION,
-        global_prefix="",
-        global_suffix="",
+    adapter_spec = get_generation_adapter_spec(
         instructions="Please answer the following consumer health question.",
-        input_prefix="Question",
-        input_suffix="",
-        output_prefix="Answer",
-        output_suffix="",
-        instance_prefix="",
+        input_noun="Question",
+        output_noun="Answer",
         max_train_instances=0,
-        num_outputs=1,
         max_tokens=512,
-        temperature=0.0,
-        stop_sequences=[],
     )
-
     annotator_specs = [AnnotatorSpec(class_name="helm.benchmark.annotation.live_qa_annotator.LiveQAAnnotator")]
-    metric_specs = [
-        MetricSpec(class_name="helm.benchmark.metrics.live_qa_metrics.LiveQAScoreMetric"),
-        MetricSpec(class_name="helm.benchmark.metrics.live_qa_metrics.LiveQABasicGenerationMetric"),
-        MetricSpec(class_name="helm.benchmark.metrics.basic_metrics.InstancesPerSplitMetric"),
-    ] + get_open_ended_generation_metric_specs()
+    metric_specs = get_open_ended_generation_metric_specs() + [
+        MetricSpec(class_name="helm.benchmark.metrics.live_qa_metrics.LiveQAScoreMetric")
+    ]
 
     return RunSpec(
         name="live_qa",
         scenario_spec=scenario_spec,
         adapter_spec=adapter_spec,
-        metric_specs=metric_specs,
         annotators=annotator_specs,
+        metric_specs=metric_specs,
         groups=["live_qa"],
     )
 
@@ -1207,38 +1195,25 @@ def get_live_qa_spec() -> RunSpec:
 def get_medication_qa_spec() -> RunSpec:
     scenario_spec = ScenarioSpec(class_name="helm.benchmark.scenarios.medication_qa_scenario.MedicationQAScenario")
 
-    adapter_spec = AdapterSpec(
-        method=ADAPT_GENERATION,
-        global_prefix="",
-        global_suffix="",
+    adapter_spec = get_generation_adapter_spec(
         instructions="Please answer the following consumer health question.",
-        input_prefix="Question",
-        input_suffix="",
-        output_prefix="Answer",
-        output_suffix="",
-        instance_prefix="",
+        input_noun="Question",
+        output_noun="Answer",
         max_train_instances=0,
-        num_outputs=1,
         max_tokens=512,
-        temperature=0.0,
-        stop_sequences=[],
     )
 
     annotator_specs = [
         AnnotatorSpec(class_name="helm.benchmark.annotation.medication_qa_annotator.MedicationQAAnnotator")
     ]
-    metric_specs = [
-        MetricSpec(class_name="helm.benchmark.metrics.medication_qa_metrics.MedicationQAScoreMetric"),
-        MetricSpec(class_name="helm.benchmark.metrics.medication_qa_metrics.MedicationQABasicGenerationMetric"),
-        MetricSpec(class_name="helm.benchmark.metrics.basic_metrics.InstancesPerSplitMetric"),
-    ] + get_open_ended_generation_metric_specs()
+    metric_specs = [MetricSpec(class_name="helm.benchmark.metrics.medication_qa_metrics.MedicationQAScoreMetric")]
 
     return RunSpec(
         name="medication_qa",
         scenario_spec=scenario_spec,
         adapter_spec=adapter_spec,
-        metric_specs=metric_specs,
         annotators=annotator_specs,
+        metric_specs=metric_specs,
         groups=["medication_qa"],
     )
 

--- a/src/helm/benchmark/static/schema_medical.yaml
+++ b/src/helm/benchmark/static/schema_medical.yaml
@@ -74,6 +74,14 @@ metrics:
     display_name: F1
     description: Average F1 score in terms of word overlap between the model output and correct reference.
     lower_is_better: false
+  - name: live_qa_score
+    display_name: Judge Score
+    description: LLM-as-judge score
+    lower_is_better: false
+  - name: medication_qa_score
+    display_name: Judge Score
+    description: LLM-as-judge score
+    lower_is_better: false
 
   # Toxicity metrics
   - name: expected_max_toxicity
@@ -220,7 +228,7 @@ run_groups:
       - efficiency
       - general_information
     environment:
-      main_name: f1_score
+      main_name: live_qa_score
       main_split: test
     taxonomy:
       task: question answering
@@ -237,7 +245,7 @@ run_groups:
       - efficiency
       - general_information
     environment:
-      main_name: f1_score
+      main_name: medication_qa_score
       main_split: test
     taxonomy:
       task: question answering


### PR DESCRIPTION
This updates these open ended medical scenarios (liveQA and medicationQA) to use model as judge.

This implementation uses 4 buckets as human judges did in the LiveQA paper, and then 3 for MedicationQA (no recommended approach).