### PR TITLE
Add "Answer only the last question" instruction using run expander

### DIFF
--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -1406,7 +1406,10 @@ class OutputFormatInstructions(RunExpander):
 
     def expand(self, run_spec: RunSpec) -> List[RunSpec]:
         if run_spec.adapter_spec.method == ADAPT_MULTIPLE_CHOICE_JOINT:
-            instructions = "Answer with only a single letter."
+            if self.scenario == "mmlu_only_last_question":
+                instructions = "Answer only the last question with only a single letter."
+            else:
+                instructions = "Answer with only a single letter."
             if run_spec.adapter_spec.instructions:
                 instructions = f"{instructions}\n\n{run_spec.adapter_spec.instructions}"
             return [
@@ -1449,7 +1452,7 @@ class OutputFormatInstructions(RunExpander):
                     adapter_spec=replace(run_spec.adapter_spec, instructions=instructions),
                 ),
             ]
-        return [run_spec]
+        raise ValueError(f"Unknown scenario {self.scenario}")
 
 
 RUN_EXPANDER_SUBCLASSES: List[Type[RunExpander]] = [


### PR DESCRIPTION
Some instruction-tuned models will try to answer the first question (i.e. the in-context learning question) instead of the last one. This change adds a way for the `output_format_instructions` run expander to tell the models to answer the last question.