### PR TITLE
Fix backports.zoneinfo and pkg_resources breakages in main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,8 +66,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+
       # Installs dependencies and performs static code checks
       - run: python3 -m pip install virtualenv && python3 -m virtualenv -p python3 venv
+      - run: source venv/bin/activate && pip install --upgrade pip setuptools
       - run: source venv/bin/activate && ./install-dev.sh
       - run: source venv/bin/activate && ./pre-commit.sh
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,16 +68,15 @@ jobs:
           cache: pip
 
       # Installs dependencies and performs static code checks
-      - run: python3 -m pip install virtualenv && python3 -m virtualenv -p python3 venv
-      - run: source venv/bin/activate && pip install --upgrade pip setuptools
-      - run: source venv/bin/activate && ./install-dev.sh
-      - run: source venv/bin/activate && ./pre-commit.sh
+      - run: pip install --upgrade pip
+      - run: ./install-dev.sh
+      - run: ./pre-commit.sh
       - name: Run tests
-        run: source venv/bin/activate && pytest --durations=20
+        run: pytest --durations=20
         env:
           TEST: ${{ matrix.test }}
           VERSION: ${{ github.head_ref || 'main' }}
       - name: Run entire pipeline quickly without any data
         # Checking RunSpecs with openai/davinci should be comprehensive enough
-        run: source venv/bin/activate && helm-run --suite test -m 100 --skip-instances --models-to-run openai/davinci --exit-on-error
+        run: helm-run --suite test -m 100 --skip-instances --models-to-run openai/davinci --exit-on-error
         

--- a/.github/workflows/update-requirements.yml
+++ b/.github/workflows/update-requirements.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.10"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/update-requirements.yml
+++ b/.github/workflows/update-requirements.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
       - name: Upgrade pip
-        run: pip install --upgrade pip
+        run: pip install --upgrade pip setuptools
       - name: Install PyTorch manually
         # PyTorch has to be installed manually in a separate step with --no-cache-dir
         # to avoid pip getting killed because PyTorch is too big

--- a/requirements.txt
+++ b/requirements.txt
@@ -321,7 +321,6 @@ uncertainty-calibration==0.1.4
 Unidecode==1.3.6
 uritemplate==4.1.1
 urllib3==1.26.18
-virtualenv==20.26.2
 wandb==0.13.11
 wasabi==1.1.3
 wcwidth==0.2.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ attrs==23.2.0
 autograd==1.6.2
 autokeras==1.0.20
 awscli==1.29.85
-backports.zoneinfo==0.2.1
 beautifulsoup4==4.12.3
 black==24.3.0
 blis==0.7.11


### PR DESCRIPTION
Fix error on Python 3.10 by removing `backports.zoneinfo` from `requirements.txt`:
```
Failed to build backports.zoneinfo
ERROR: Could not build wheels for backports.zoneinfo, which is required to install pyproject.toml-based projects
```

Also fix this error by switching `test.yml` to not use `virtualenv`:

```
________________ TestQ16.test_is_appropriate_single_appropriate ________________

self = <helm.benchmark.metrics.image_generation.q16.test_q16.TestQ16 object at 0x7f68f0bd6320>

    def test_is_appropriate_single_appropriate(self):
        image_path: str = os.path.join(self._base_path, "sample_appropriate.jpg")
>       assert not self._q16_detector.is_inappropriate(image_path)

src/helm/benchmark/metrics/image_generation/q16/test_q16.py:14: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
src/helm/benchmark/metrics/image_generation/q16/q16_toxicity_detector.py:56: in is_inappropriate
    self._load_models()
src/helm/benchmark/metrics/image_generation/q16/q16_toxicity_detector.py:36: in _load_models
    self._clip_wrapper = ClipWrapper(self._device)
src/helm/benchmark/metrics/image_generation/q16/q16_toxicity_detector.py:67: in __init__
    import clip
venv/lib/python3.10/site-packages/clip/__init__.py:1: in <module>
    from .clip import *
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    import hashlib
    import os
    import urllib
    import warnings
    from typing import Any, Union, List
>   from pkg_resources import packaging
E   ImportError: cannot import name 'packaging' from 'pkg_resources' (/home/runner/work/helm/helm/venv/lib/python3.10/site-packages/pkg_resources/__init__.py)

venv/lib/python3.10/site-packages/clip/clip.py:6: ImportError
```