### PR TITLE
Add output_format_instructions run expander for MATH

### DIFF
--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -1435,6 +1435,8 @@ class OutputFormatInstructions(RunExpander):
                     instructions = "Answer yes or no."
             elif self.scenario == "wmt_14":
                 instructions = "Answer with the English translation."
+            elif self.scenario == "math_boxed":
+                instructions = "Wrap the final answer with the \\boxed{} command."
             else:
                 raise ValueError(f"Unknown scenario {self.scenario}")
 

--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -1435,7 +1435,7 @@ class OutputFormatInstructions(RunExpander):
                     instructions = "Answer yes or no."
             elif self.scenario == "wmt_14":
                 instructions = "Answer with the English translation."
-            elif self.scenario == "math_boxed":
+            elif self.scenario == "math":
                 instructions = "Wrap the final answer with the \\boxed{} command."
             else:
                 raise ValueError(f"Unknown scenario {self.scenario}")


### PR DESCRIPTION
Addresses a failure mode of MATH on Claude 3.5 Sonnet - it does not wrap the final answer in LaTeX box formatting, leading to a very low accuracy score. This pull request changes the `output_format_instructions` run expander to add instructions to do so.