### PR TITLE
Suppress logging AbortError when data fetching calls are aborted

### DIFF
--- a/helm-frontend/src/services/getDisplayPredictionsByName.ts
+++ b/helm-frontend/src/services/getDisplayPredictionsByName.ts
@@ -19,7 +19,9 @@ export default async function getDisplayPredictionsByName(
 
     return (await displayPrediction.json()) as DisplayPrediction[];
   } catch (error) {
-    console.log(error);
+    if (error.name === "AbortError") {
+      console.log(error);
+    }
     return [];
   }
 }

--- a/helm-frontend/src/services/getDisplayRequestsByName.ts
+++ b/helm-frontend/src/services/getDisplayRequestsByName.ts
@@ -19,7 +19,9 @@ export default async function getDisplayRequestsByName(
 
     return (await displayRequest.json()) as DisplayRequest[];
   } catch (error) {
-    console.log(error);
+    if (error.name !== "AbortError") {
+      console.log(error);
+    }
     return [];
   }
 }

--- a/helm-frontend/src/services/getGroupTablesByName.ts
+++ b/helm-frontend/src/services/getGroupTablesByName.ts
@@ -14,7 +14,9 @@ export default async function getGroupsTablesByName(
 
     return (await group.json()) as GroupsTable[];
   } catch (error) {
-    console.log(error);
+    if (error.name !== "AbortError") {
+      console.log(error);
+    }
     return [];
   }
 }

--- a/helm-frontend/src/services/getGroupsMetadata.ts
+++ b/helm-frontend/src/services/getGroupsMetadata.ts
@@ -13,7 +13,9 @@ export default async function getGroupsMetadata(
 
     return (await groups.json()) as GroupsMetadata;
   } catch (error) {
-    console.log(error);
+    if (error.name !== "AbortError") {
+      console.log(error);
+    }
     return {} as GroupsMetadata;
   }
 }

--- a/helm-frontend/src/services/getGroupsTables.ts
+++ b/helm-frontend/src/services/getGroupsTables.ts
@@ -14,7 +14,9 @@ export default async function getGroupsTables(
 
     return (await groups.json()) as GroupsTable[];
   } catch (error) {
-    console.log(error);
+    if (error.name !== "AbortError") {
+      console.log(error);
+    }
     return [];
   }
 }

--- a/helm-frontend/src/services/getInstances.ts
+++ b/helm-frontend/src/services/getInstances.ts
@@ -17,7 +17,9 @@ export default async function getInstancesByRunName(
 
     return (await instances.json()) as Instance[];
   } catch (error) {
-    console.log(error);
+    if (error.name !== "AbortError") {
+      console.log(error);
+    }
     return [];
   }
 }

--- a/helm-frontend/src/services/getRunSpecByName.ts
+++ b/helm-frontend/src/services/getRunSpecByName.ts
@@ -16,7 +16,9 @@ export default async function getRunSpecByName(
 
     return (await runSpec.json()) as RunSpec;
   } catch (error) {
-    console.log(error);
+    if (error.name !== "AbortError") {
+      console.log(error);
+    }
     return undefined;
   }
 }

--- a/helm-frontend/src/services/getRunSpecs.ts
+++ b/helm-frontend/src/services/getRunSpecs.ts
@@ -13,7 +13,9 @@ export default async function getRunSpecs(
 
     return (await runSpecs.json()) as RunSpec[];
   } catch (error) {
-    console.log(error);
+    if (error.name !== "AbortError") {
+      console.log(error);
+    }
     return [];
   }
 }

--- a/helm-frontend/src/services/getRunsToRunSuites.ts
+++ b/helm-frontend/src/services/getRunsToRunSuites.ts
@@ -14,7 +14,9 @@ export default async function getRunsToRunSuites(
 
     return (await runsToRunSuites.json()) as Record<string, string>;
   } catch (error) {
-    console.log(error);
+    if (error.name !== "AbortError") {
+      console.log(error);
+    }
     return {};
   }
 }

--- a/helm-frontend/src/services/getScenarioByName.ts
+++ b/helm-frontend/src/services/getScenarioByName.ts
@@ -17,7 +17,9 @@ export default async function getScenarioByName(
 
     return (await scenario.json()) as Scenario;
   } catch (error) {
-    console.log(error);
+    if (error.name !== "AbortError") {
+      console.log(error);
+    }
     return undefined;
   }
 }

--- a/helm-frontend/src/services/getSchema.ts
+++ b/helm-frontend/src/services/getSchema.ts
@@ -11,7 +11,9 @@ export default async function getSchema(signal: AbortSignal): Promise<Schema> {
 
     return (await resp.json()) as Schema;
   } catch (error) {
-    console.log(error);
+    if (error.name !== "AbortError") {
+      console.log(error);
+    }
     return {
       adapter: [],
       metric_groups: [],

--- a/helm-frontend/src/services/getStatsByName.ts
+++ b/helm-frontend/src/services/getStatsByName.ts
@@ -17,7 +17,9 @@ export default async function getStatsByName(
 
     return (await stats.json()) as Stat[];
   } catch (error) {
-    console.log(error);
+    if (error.name !== "AbortError") {
+      console.log(error);
+    }
     return [];
   }
 }


### PR DESCRIPTION
In strict model (i.e. development mode), components will be double-rendered, which will lead to data-fetching calls being aborted. Previously, this caused many `DOMException: signal is aborted without reason` error messages to be printed to the console. Since it is expected for the calls to be aborted, we suppress logging these errors instead.