### PR TITLE
Add React keys for ReleaseDropdown

### DIFF
--- a/helm-frontend/src/components/ReleaseDropdown.tsx
+++ b/helm-frontend/src/components/ReleaseDropdown.tsx
@@ -94,7 +94,7 @@ function ReleaseDropdown() {
         role="menu"
       >
         {releases.map((release) => (
-          <li>
+          <li key={release}>
             <a
               href={getReleaseUrl(
                 release,


### PR DESCRIPTION
This fixes the error `Warning: Each child in a list should have a unique "key" prop.` in `ReleaseDropdown`.