### PR TITLE
Use two columns for card grid on small screens for home

### DIFF
--- a/helm-frontend/src/components/CardGrid.tsx
+++ b/helm-frontend/src/components/CardGrid.tsx
@@ -22,7 +22,7 @@ export default function CardGrid() {
 
   return (
     <div className="p-10 mb-20">
-      <div className="grid grid-cols-3 gap-4">
+      <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
         {projectEntries &&
           projectEntries.map((project, index) =>
             project.id === "home" ? null : (


### PR DESCRIPTION
Fixes #2772

Before:
![Screenshot 2024-07-26 135735](https://github.com/user-attachments/assets/16ddfebb-d088-4585-a335-bcd7ef64ac73)

After:
![Screenshot 2024-07-26 135741](https://github.com/user-attachments/assets/60ef61aa-59e6-4a02-8753-9f0437e35238)
