### PR TITLE
Widen VLM dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -181,12 +181,12 @@ vlm =
     crfm-helm[openai]
 
     # For OpenFlamingo
-    einops~=0.7.0
-    einops-exts~=0.0.4
-    open-clip-torch~=2.24.0
+    einops~=0.7
+    einops-exts~=0.0
+    open-clip-torch~=2.24
 
     # For IDEFICS
-    torch~=2.1.2
+    torch~=2.1
 
     # For Qwen: https://github.com/QwenLM/Qwen-VL/blob/master/requirements.txt
     transformers_stream_generator~=0.0.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -181,8 +181,8 @@ vlm =
     crfm-helm[openai]
 
     # For OpenFlamingo
-    einops~=0.7
-    einops-exts~=0.0
+    einops~=0.7.0
+    einops-exts~=0.0.4
     open-clip-torch~=2.24
 
     # For IDEFICS


### PR DESCRIPTION
Allow newer versions of `open-clip-torch` and `torch` to be used. This is needed to upgrade PyTorch to >=2.2, which is needed to address security issues.