### PR TITLE
Pin version of scikit-images

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -261,6 +261,14 @@ heim =
     torch-fidelity~=0.3.0
     torchmetrics~=0.11.1
 
+    # Transitive dependency of NudeNet
+    # This needs to pinned to 0.21.0, which is the only version
+    # that provides wheels for all of HELM's supported Python versions
+    # i.e. Python 3.8, 3.9, 3.10
+    # https://github.com/scikit-image/scikit-image/pull/4920
+    # TODO(#1913): Upgrade to 0.22 after removing support for Python 3.8
+    scikit-image~=0.21.0
+
     # Shared image dependencies
     crfm-helm[images]
 


### PR DESCRIPTION
`scikit-images` needs to pinned to 0.21.0, which is the only version, that provides wheels for all of HELM's supported Python versions i.e. Python 3.8, 3.9, 3.10. Otherwise, pip will attempt download and build incompatible versions during dependency resolution, which leads to this error if numpy is not installed: https://github.com/scikit-image/scikit-image/pull/4920