### PR TITLE
Update dependencies in manual install scripts

### DIFF
--- a/.github/workflows/update-requirements.yml
+++ b/.github/workflows/update-requirements.yml
@@ -31,9 +31,9 @@ jobs:
         # PyTorch has to be installed manually in a separate step with --no-cache-dir
         # to avoid pip getting killed because PyTorch is too big
         # See: https://stackoverflow.com/a/54329850
-        run: pip install torch==2.1.2 torchvision==0.16.2 --index-url https://download.pytorch.org/whl/cu121 --no-cache-dir
+        run: pip install torch==2.2.2 torchvision==0.17.2 --index-url https://download.pytorch.org/whl/cu121 --no-cache-dir
       - name: Upgrade dependencies for Dependabot alerts
-        run: pip install -e .[all,dev] onnx~=1.16 aiohttp>=3.9.4 aiohttp~=3.9 gunicorn~=22.0 scikit-learn~=1.5 urllib3~=1.26 urllib3>=1.26.19 requests~=2.32 Jinja2>=3.1.4 Jinja2~=3.1 aiohttp~=3.9 aiohttp>=3.9.4 idna~=3.7
+        run: pip install -e .[all,dev] gunicorn>=22.0.0 onnx>=1.16.0 urllib3>=2.2.2
       - name: Verify dependencies
         run: pip check
       - name: Write header to requirements.txt

--- a/.github/workflows/update-requirements.yml
+++ b/.github/workflows/update-requirements.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.8"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -33,7 +33,7 @@ jobs:
         # See: https://stackoverflow.com/a/54329850
         run: pip install torch==2.2.2 torchvision==0.17.2 --index-url https://download.pytorch.org/whl/cu121 --no-cache-dir
       - name: Upgrade dependencies for Dependabot alerts
-        run: pip install -e .[all,dev] gunicorn>=22.0.0 onnx>=1.16.0 urllib3>=2.2.2
+        run: pip install -e .[all,dev]
       - name: Verify dependencies
         run: pip check
       - name: Write header to requirements.txt

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -7,7 +7,7 @@ set -e
 # On Mac OS, skip installing pytorch with CUDA because CUDA is not supported
 if [[ $OSTYPE != 'darwin'* ]]; then
   # Manually install pytorch with `--no-cache-dir` to avoid pip getting killed: https://stackoverflow.com/a/54329850
-  pip install torch==2.1.2 torchvision==0.16.2 --index-url https://download.pytorch.org/whl/cu121 --no-cache-dir
+  pip install torch==2.2.2 torchvision==0.17.2 --index-url https://download.pytorch.org/whl/cu121 --no-cache-dir
 fi
 # Install all pinned dependencies
 pip install -r requirements.txt

--- a/install-heim-extras.sh
+++ b/install-heim-extras.sh
@@ -11,7 +11,7 @@ set -e
 # On Mac OS, skip installing pytorch with CUDA because CUDA is not supported
 if [[ $OSTYPE != 'darwin'* ]]; then
   # Manually install pytorch to avoid pip getting killed: https://stackoverflow.com/a/54329850
-  pip install torch==2.1.2 torchvision==0.16.2 --index-url https://download.pytorch.org/whl/cu121 --no-cache-dir
+  pip install torch==2.2.2 torchvision==0.17.2 --index-url https://download.pytorch.org/whl/cu121 --no-cache-dir
 
   # DALLE mini requires jax install
   pip install jax==0.3.25 jaxlib==0.3.25+cuda11.cudnn805 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html


### PR DESCRIPTION
- Install `torch==2.2.2` and `torchvision==0.17.2` in manual installation scripts
- Bump requested versions of `gunicorn`, `onnx` and `urllib3` to resolve Dependabot alerts