### PR TITLE
Upgrade requirements using Python 3.8

### DIFF
--- a/.github/workflows/upgrade-requirements.yml
+++ b/.github/workflows/upgrade-requirements.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.8"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Upgrading requirements using Python 3.10 results in a number of Python 3.8-incompatible dependencies being selected.