### PR TITLE
Update Llama 3.1 Instruct Turbo sequence lengths

### DIFF
--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -1823,7 +1823,7 @@ model_deployments:
   - name: together/llama-3.1-8b-instruct-turbo
     model_name: meta/llama-3.1-8b-instruct-turbo
     tokenizer_name: meta/llama-3.1-8b
-    max_sequence_length: 8192
+    max_sequence_length: 128000
     client_spec:
       class_name: "helm.clients.together_client.TogetherChatClient"
       args:
@@ -1832,7 +1832,7 @@ model_deployments:
   - name: together/llama-3.1-70b-instruct-turbo
     model_name: meta/llama-3.1-70b-instruct-turbo
     tokenizer_name: meta/llama-3.1-8b
-    max_sequence_length: 8192
+    max_sequence_length: 128000
     client_spec:
       class_name: "helm.clients.together_client.TogetherChatClient"
       args:


### PR DESCRIPTION
Together has increased the sequence lengths for the 8B and 70B models.