### PR TITLE
Update project titles and descriptions

### DIFF
--- a/helm-frontend/project_metadata.json
+++ b/helm-frontend/project_metadata.json
@@ -37,7 +37,7 @@
 	},
 	{
 		"title": "Image2Struct",
-		"description": "A benchmark for evaluating vision-language models in practical tasks of extracting structured information (LaTeX, webpage, music sheet) from images.",
+		"description": "Evaluations of Vision-Language Models on extracting structured information (LaTeX, webpages, sheet music) from images",
 		"id": "image2struct",
 		"releases": ["v1.0.1", "v1.0.0"]
 	},

--- a/helm-frontend/src/components/ProjectCard.tsx
+++ b/helm-frontend/src/components/ProjectCard.tsx
@@ -8,7 +8,7 @@ interface CardProps {
 }
 
 const ProjectCard: React.FC<CardProps> = ({ id, title, text }) => {
-  if (!title.includes("HE")) {
+  if (title === "Classic" || title === "Lite" || title === "Instruct") {
     title = "HELM " + title;
   }
   return (


### PR DESCRIPTION
- Shorten the menu entry description for Image2Struct
- Only add "HELM" prefix to Lite, Classic and Instruct in project card titles