### PR TITLE
Update BBQ to be zero shot for consistency with Safety results

### DIFF
--- a/src/helm/benchmark/run_specs/classic_run_specs.py
+++ b/src/helm/benchmark/run_specs/classic_run_specs.py
@@ -59,6 +59,7 @@ def get_bbq_spec(subject: str, method: str = ADAPT_MULTIPLE_CHOICE_JOINT) -> Run
         instructions="The following are multiple choice questions (with answers).",
         input_noun="Passage",
         output_noun="Answer",
+        max_train_instances=0,
     )
     metric_specs = [
         MetricSpec(class_name="helm.benchmark.metrics.bbq_metrics.BBQMetric", args={})


### PR DESCRIPTION
Since we decided to do zero shot for bbq, I made this change for safety runs to be consistent with that. Perhaps there is a better way to do this than retroactively updating the classic run specs?