### PR TITLE
Fix instance IDs for EWoK

### DIFF
--- a/src/helm/benchmark/presentation/run_entries_ewok.conf
+++ b/src/helm/benchmark/presentation/run_entries_ewok.conf
@@ -1,13 +1,13 @@
 entries: [
   {description: "ewok:domain=agent_properties,model=text", priority: 1}
   {description: "ewok:domain=material_dynamics,model=text", priority: 1}
-  {description: "ewok:domain=material_properties,model=text", priority: 1}
-  {description: "ewok:domain=physical_dynamics,model=text", priority: 1}
-  {description: "ewok:domain=physical_interactions,model=text", priority: 1}
-  {description: "ewok:domain=physical_relations,model=text", priority: 1}
-  {description: "ewok:domain=quantitative_properties,model=text", priority: 1}
-  {description: "ewok:domain=social_interactions,model=text", priority: 1}
-  {description: "ewok:domain=social_properties,model=text", priority: 1}
-  {description: "ewok:domain=social_relations,model=text", priority: 1}
-  {description: "ewok:domain=spatial_relations,model=text", priority: 1}
+#   {description: "ewok:domain=material_properties,model=text", priority: 1}
+#   {description: "ewok:domain=physical_dynamics,model=text", priority: 1}
+#   {description: "ewok:domain=physical_interactions,model=text", priority: 1}
+#   {description: "ewok:domain=physical_relations,model=text", priority: 1}
+#   {description: "ewok:domain=quantitative_properties,model=text", priority: 1}
+#   {description: "ewok:domain=social_interactions,model=text", priority: 1}
+#   {description: "ewok:domain=social_properties,model=text", priority: 1}
+#   {description: "ewok:domain=social_relations,model=text", priority: 1}
+#   {description: "ewok:domain=spatial_relations,model=text", priority: 1}
 ]

--- a/src/helm/benchmark/presentation/run_entries_ewok.conf
+++ b/src/helm/benchmark/presentation/run_entries_ewok.conf
@@ -1,13 +1,13 @@
 entries: [
   {description: "ewok:domain=agent_properties,model=text", priority: 1}
   {description: "ewok:domain=material_dynamics,model=text", priority: 1}
-#   {description: "ewok:domain=material_properties,model=text", priority: 1}
-#   {description: "ewok:domain=physical_dynamics,model=text", priority: 1}
-#   {description: "ewok:domain=physical_interactions,model=text", priority: 1}
-#   {description: "ewok:domain=physical_relations,model=text", priority: 1}
-#   {description: "ewok:domain=quantitative_properties,model=text", priority: 1}
-#   {description: "ewok:domain=social_interactions,model=text", priority: 1}
-#   {description: "ewok:domain=social_properties,model=text", priority: 1}
-#   {description: "ewok:domain=social_relations,model=text", priority: 1}
-#   {description: "ewok:domain=spatial_relations,model=text", priority: 1}
+  {description: "ewok:domain=material_properties,model=text", priority: 1}
+  {description: "ewok:domain=physical_dynamics,model=text", priority: 1}
+  {description: "ewok:domain=physical_interactions,model=text", priority: 1}
+  {description: "ewok:domain=physical_relations,model=text", priority: 1}
+  {description: "ewok:domain=quantitative_properties,model=text", priority: 1}
+  {description: "ewok:domain=social_interactions,model=text", priority: 1}
+  {description: "ewok:domain=social_properties,model=text", priority: 1}
+  {description: "ewok:domain=social_relations,model=text", priority: 1}
+  {description: "ewok:domain=spatial_relations,model=text", priority: 1}
 ]

--- a/src/helm/benchmark/scenarios/ewok_scenario.py
+++ b/src/helm/benchmark/scenarios/ewok_scenario.py
@@ -75,27 +75,7 @@ class EWoKScenario(Scenario):
             cache_dir=cache_dir,
         )
 
-        instances: List[Instance] = [
-            Instance(
-                id=generate_instance_id(),
-                input=Input(text="I drew a ball from the bag."),
-                references=[
-                    Reference(output=Output(text="The bag is full of blocks."), tags=[]),
-                    Reference(output=Output(text="The bag is full of balls."), tags=[CORRECT_TAG]),
-                ],
-                split=TRAIN_SPLIT,
-            ),
-            Instance(
-                id=generate_instance_id(),
-                input=Input(text="The boy chose to eat a cookie."),
-                references=[
-                    Reference(output=Output(text="The boy likes cookies."), tags=[CORRECT_TAG]),
-                    Reference(output=Output(text="The boy does not like cookies."), tags=[]),
-                ],
-                split=TRAIN_SPLIT,
-            ),
-        ]
-
+        instances: List[Instance] = []
         for row in dataset:
             contexts = [row["Context1"], row["Context2"]]
             targets = [row["Target1"], row["Target2"]]
@@ -111,4 +91,26 @@ class EWoKScenario(Scenario):
                 # so that instance IDs for an item is invariant regardless of domain filtering.
                 if self.domain == "all" or self.domain == row["Domain"]:
                     instances.append(instance)
+        instances.extend(
+            [
+                Instance(
+                    id=generate_instance_id(),
+                    input=Input(text="I drew a ball from the bag."),
+                    references=[
+                        Reference(output=Output(text="The bag is full of blocks."), tags=[]),
+                        Reference(output=Output(text="The bag is full of balls."), tags=[CORRECT_TAG]),
+                    ],
+                    split=TRAIN_SPLIT,
+                ),
+                Instance(
+                    id=generate_instance_id(),
+                    input=Input(text="The boy chose to eat a cookie."),
+                    references=[
+                        Reference(output=Output(text="The boy likes cookies."), tags=[CORRECT_TAG]),
+                        Reference(output=Output(text="The boy does not like cookies."), tags=[]),
+                    ],
+                    split=TRAIN_SPLIT,
+                ),
+            ]
+        )
         return instances

--- a/src/helm/benchmark/scenarios/ewok_scenario.py
+++ b/src/helm/benchmark/scenarios/ewok_scenario.py
@@ -30,7 +30,7 @@ class EWoKScenario(Scenario):
 
     name = "ewok"
     description = (
-        "EWoK is a benchmark for evaluating world modeling by testing their ability to "
+        "Elements of World Knowledge (EWoK) is a benchmark for evaluating world modeling by testing their ability to "
         "use knowledge of a concept to match a target text with a plausible/implausible context."
     )
     tags = ["world knowledge"]
@@ -75,7 +75,6 @@ class EWoKScenario(Scenario):
             cache_dir=cache_dir,
         )
 
-        # TODO: Allow users to filter by category
         instances: List[Instance] = [
             Instance(
                 id=generate_instance_id(),
@@ -97,7 +96,7 @@ class EWoKScenario(Scenario):
             ),
         ]
 
-        for row_index, row in enumerate(dataset):
+        for row in dataset:
             contexts = [row["Context1"], row["Context2"]]
             targets = [row["Target1"], row["Target2"]]
             # References are category ID, followed by level 2, 3 and 4 category names.

--- a/src/helm/benchmark/scenarios/ewok_scenario.py
+++ b/src/helm/benchmark/scenarios/ewok_scenario.py
@@ -76,7 +76,27 @@ class EWoKScenario(Scenario):
         )
 
         # TODO: Allow users to filter by category
-        instances: List[Instance] = []
+        instances: List[Instance] = [
+            Instance(
+                id=generate_instance_id(),
+                input=Input(text="I drew a ball from the bag."),
+                references=[
+                    Reference(output=Output(text="The bag is full of blocks."), tags=[]),
+                    Reference(output=Output(text="The bag is full of balls."), tags=[CORRECT_TAG]),
+                ],
+                split=TRAIN_SPLIT,
+            ),
+            Instance(
+                id=generate_instance_id(),
+                input=Input(text="The boy chose to eat a cookie."),
+                references=[
+                    Reference(output=Output(text="The boy likes cookies."), tags=[CORRECT_TAG]),
+                    Reference(output=Output(text="The boy does not like cookies."), tags=[]),
+                ],
+                split=TRAIN_SPLIT,
+            ),
+        ]
+
         for row_index, row in enumerate(dataset):
             contexts = [row["Context1"], row["Context2"]]
             targets = [row["Target1"], row["Target2"]]
@@ -92,26 +112,4 @@ class EWoKScenario(Scenario):
                 # so that instance IDs for an item is invariant regardless of domain filtering.
                 if self.domain == "all" or self.domain == row["Domain"]:
                     instances.append(instance)
-        instances.extend(
-            [
-                Instance(
-                    id=generate_instance_id(),
-                    input=Input(text="I drew a ball from the bag."),
-                    references=[
-                        Reference(output=Output(text="The bag is full of blocks."), tags=[]),
-                        Reference(output=Output(text="The bag is full of balls."), tags=[CORRECT_TAG]),
-                    ],
-                    split=TRAIN_SPLIT,
-                ),
-                Instance(
-                    id=generate_instance_id(),
-                    input=Input(text="The boy chose to eat a cookie."),
-                    references=[
-                        Reference(output=Output(text="The boy likes cookies."), tags=[CORRECT_TAG]),
-                        Reference(output=Output(text="The boy does not like cookies."), tags=[]),
-                    ],
-                    split=TRAIN_SPLIT,
-                ),
-            ]
-        )
         return instances


### PR DESCRIPTION
Fix a bug in which the same instance ID was used for both instances (each of two possible targets) generated from the same row in the source dataset.