### PR TITLE
Add more WMT-14 instructions to output_format_instructions run expander

### DIFF
--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -1436,6 +1436,8 @@ class OutputFormatInstructions(RunExpander):
                     instructions = "Answer yes or no."
             elif self.scenario == "wmt_14":
                 instructions = "Answer with the English translation."
+            elif self.scenario == "wmt_14_only_last_sentence":
+                instructions = "Answer with only the English translation for the last sentence."
             elif self.scenario == "math":
                 instructions = "Wrap the final answer with the \\boxed{} command."
             elif self.scenario == "numeric_nlg":


### PR DESCRIPTION
Add instructions to only translate the last sentence. This addresses problems with Llama 3.1 (8B) which will otherwise output the translations for every sentence.