### PR TITLE
Add MMLU instructions suffix run expander

### DIFF
--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -1408,6 +1408,17 @@ class OutputFormatInstructions(RunExpander):
                 instructions = "Answer only the last question with only a single letter."
             elif self.scenario == "mmlu":
                 instructions = "Answer with only a single letter."
+            elif self.scenario == "mmlu_suffix":
+                instructions = "Answer with only a single letter."
+                return [
+                    replace(
+                        run_spec,
+                        adapter_spec=replace(
+                            run_spec.adapter_spec,
+                            global_suffix=f"{run_spec.adapter_spec.global_suffix}\n\n{instructions}",
+                        ),
+                    ),
+                ]
             elif self.scenario == "mcqa":
                 instructions = "Answer with only a single letter."
             else:


### PR DESCRIPTION
Fixes an issue with Nemotron-4 Instruct - on MMLU, for only certain subjects (High School US History, High School World History, High School Mathematics), the model responds with the reasoning for the answer instead of a single letter.

This can be fixed by appending "Answer with only a single letter." to the prompt as a suffix. Prepending this instruction to the prompt as a prefix, which we've done with other instruction-tuned models, does not work.