### PR TITLE
Remove pyext from dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,6 @@ install_requires=
 
     # Basic metrics
     nltk~=3.7
-    pyext~=0.7
     rouge-score~=0.1.2
     scipy~=1.10
     uncertainty-calibration~=0.1.4

--- a/src/helm/benchmark/metrics/code_metrics_helper.py
+++ b/src/helm/benchmark/metrics/code_metrics_helper.py
@@ -27,12 +27,22 @@ import signal
 import sys
 import tempfile
 from typing import List, Union, Dict, Optional
+from types import ModuleType
 from unittest.mock import patch, mock_open
 
 import numpy as np
-from pyext import RuntimeModule
 
 from helm.common.hierarchical_logger import hlog
+
+
+class RuntimeModule(ModuleType):
+    """crfm-helm's replacement for pyext.RuntimeModule, since pyext is not supported by Python >=3.11"""
+
+    @staticmethod
+    def from_string(module_name: str, module_doc: str, module_contents: str) -> "RuntimeModule":
+        module = RuntimeModule(module_name, module_doc)
+        exec(module_contents, module.__dict__)
+        return module
 
 
 # === APPS evaluation below ===


### PR DESCRIPTION
`pyext` is not supported in Python >=3.11, and its only usage is in APPS.