### PR TITLE
Run yarn build in frontend CI

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -33,6 +33,9 @@ jobs:
     - name: Run check format
       working-directory: ./helm-frontend
       run: yarn format:check
+    - name: Build
+      working-directory: ./helm-frontend
+      run: yarn build
     - name: Run tests
       working-directory: ./helm-frontend
       run: yarn test


### PR DESCRIPTION
Run `yarn build` in the GitHub Action that runs frontend tests on pull requests. This detects errors such as type checking errors and missing imports.

This fixes a problem where pull requests would pass the checks, but merging the pull request would cause the main branch to fail checks. Example: pull request #2929, commit ad8873425d29b711c03237d173b739ce37676d1e.