### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -225,7 +225,7 @@ pydantic==2.8.2
 pydantic_core==2.20.1
 pydload==1.0.9
 pydot==2.0.0
-pyext==0.7
+pyext==0.6
 pyflakes==2.5.0
 Pygments==2.18.0
 pyhocon==0.3.61

--- a/requirements.txt
+++ b/requirements.txt
@@ -225,7 +225,6 @@ pydantic==2.8.2
 pydantic_core==2.20.1
 pydload==1.0.9
 pydot==2.0.0
-pyext==0.6
 pyflakes==2.5.0
 Pygments==2.18.0
 pyhocon==0.3.61


### PR DESCRIPTION
I had issues installing helm because of the pyext dependency. 

In the requirements.txt, pyext is required in version 0.7. However, the latest version on pypi seems to be 0.6 (https://pypi.org/project/pyext/#history)

Feel free to ignore if this is only an issue I faced!

Thanks,
Benedikt