### PR TITLE
Add BANKING77 scenario

### DIFF
--- a/src/helm/benchmark/scenarios/banking77_scenario.py
+++ b/src/helm/benchmark/scenarios/banking77_scenario.py
@@ -1,0 +1,51 @@
+import datasets
+import os
+from typing import List
+
+from helm.benchmark.scenarios.scenario import (
+    CORRECT_TAG,
+    TEST_SPLIT,
+    TRAIN_SPLIT,
+    Scenario,
+    Instance,
+    Reference,
+    Input,
+    Output,
+)
+from helm.common.general import ensure_directory_exists
+
+
+class Banking77Scenario(Scenario):
+    """BANKING77
+
+    BANKING77 is an intent classification scenario using a very fine-grained
+    set of intents in a banking domain. It comprises 13,083 customer service
+    queries labeled with 77 intents.
+
+    Paper: https://arxiv.org/abs/2003.04807"""
+
+    name = "banking77"
+    description = (
+        "BANKING77 is an intent classification scenario using a very fine-grained "
+        "set of intents in a banking domain. It comprises 13,083 customer service "
+        "queries labeled with 77 intents."
+    )
+    tags = ["finance", "classification"]
+
+    def get_instances(self, output_path: str) -> List[Instance]:
+        cache_dir = os.path.join(output_path, "data")
+        ensure_directory_exists(cache_dir)
+
+        # TODO: Switch this to the production dataset when available.
+        dataset = datasets.load_dataset("PolyAI/banking77", cache_dir=cache_dir)
+
+        instances: List[Instance] = []
+        for split_name in [TRAIN_SPLIT, TEST_SPLIT]:
+            dataset_split = dataset[split_name]
+            label_feature = dataset_split.features["label"]
+            for row in dataset_split:
+                input = Input(text=row["text"])
+                references = [Reference(output=Output(text=label_feature.int2str(row["label"])), tags=[CORRECT_TAG])]
+                instance = Instance(input=input, references=references, split=split_name)
+                instances.append(instance)
+        return instances

--- a/src/helm/benchmark/static/schema_finance.yaml
+++ b/src/helm/benchmark/static/schema_finance.yaml
@@ -124,7 +124,7 @@ run_groups:
     subgroups:
       - fin_qa
       - financebench
-      - raft
+      - banking77
 
   - name: fin_qa
     display_name: FinQA
@@ -160,10 +160,10 @@ run_groups:
       when: 2015 to 2023
       language: English
 
-  - name: raft
+  - name: banking77
     display_name: BANKING77
     short_display_name: BANKING77
-    description: BANKING77 is a benchmark for intent classification of customer service queries in the banking domain [(Casanueva et al., 2020)](https://aclanthology.org/2020.nlp4convai-1.5/)). We use the implementation from the the Real-world annotated few-shot (RAFT) meta-benchmark [(Alex et al., 2021)](https://datasets-benchmarks-proceedings.neurips.cc/paper/2021/hash/ca46c1b9512a7a8315fa3c5a946e8265-Abstract-round2.html).
+    description: BANKING77 is a benchmark for intent classification of customer service queries in the banking domain [(Casanueva et al., 2020)](https://aclanthology.org/2020.nlp4convai-1.5/)).
     metric_groups:
       - accuracy
       - efficiency


### PR DESCRIPTION
BANKING77 is a benchmark for intent classification of customer service queries in the banking domain.

While BANKING77 was already included in the RAFT meta-benchmark, the RAFT version does not contain all the examples from the original dataset. This version uses the original dataset so that we can use all ~3k labeled rows in the test split.