### PR TITLE
Add WMT instructions suffix to output_format_instructions run expander

### DIFF
--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -1449,6 +1449,17 @@ class OutputFormatInstructions(RunExpander):
                 instructions = "Answer with the English translation."
             elif self.scenario == "wmt_14_only_last_sentence":
                 instructions = "Answer with only the English translation for the last sentence."
+            elif self.scenario == "wmt_14_only_last_sentence_suffix":
+                instructions = "Answer with only the English translation for the last sentence."
+                return [
+                    replace(
+                        run_spec,
+                        adapter_spec=replace(
+                            run_spec.adapter_spec,
+                            global_suffix=f"{run_spec.adapter_spec.global_suffix}\n\n{instructions}",
+                        ),
+                    ),
+                ]
             elif self.scenario == "math":
                 instructions = "Wrap the final answer with the \\boxed{} command."
             elif self.scenario == "numeric_nlg":


### PR DESCRIPTION
`nvidia/nemotron-4-340b-instruct` always translates the first in context learning example rather than the evaluation example. It can be instructed to translate the evaluation example, but the instruction seems to work more reliably if provided at the end of the prompt, rather than the start of the prompt.