### PR TITLE
Fix spelling of SCBX

### DIFF
--- a/helm-frontend/src/components/Landing/ThaiExamLanding.tsx
+++ b/helm-frontend/src/components/Landing/ThaiExamLanding.tsx
@@ -23,7 +23,7 @@ export default function ThaiExamLanding() {
               href="https://www.scbx.com/"
               className="font-bold underline text-blue-600 hover:text-blue-800 visited:text-purple-600"
             >
-              SCB X
+              SCBX
             </a>{" "}
             and{" "}
             <a


### PR DESCRIPTION
SCBX should be spelled as SCBX rather than SCB X.