### PR TITLE
Allow output_format_instructions to add instructions as suffix

### DIFF
--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -1437,6 +1437,8 @@ class OutputFormatInstructions(RunExpander):
                 instructions = "Answer with only 'generic', 'descriptive', 'suggestive', 'arbitrary' or 'fanciful'."
             elif self.scenario == "legalbench_function_of_decision_section":
                 instructions = "Answer with only 'Facts', 'Procedural History', 'Issue', 'Rule', 'Analysis', 'Conclusion' or 'Decree'."  # noqa: E501
+            elif self.scenario == "legalbench_yes_or_no":
+                instructions = "Answer with only 'yes' or 'no'."
             elif self.scenario == "wmt_14":
                 instructions = "Answer with the English translation."
             elif self.scenario == "wmt_14_only_last_sentence":


### PR DESCRIPTION
Some models such as Nemotron-4-Instruct require the instructions to be a suffix rather than a prefix.