### PR TITLE
Add o1 models

### DIFF
--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -1271,6 +1271,30 @@ class IncreaseMaxTokensRunExpander(RunExpander):
         ]
 
 
+class TemperatureRunExpander(RunExpander):
+    """
+    Run expander for setting the temperature.
+    """
+
+    name = "temperature"
+
+    def __init__(self, value: float):
+        """
+        Args:
+            value (float): The amount to set temperature to
+        """
+        self.value = value
+
+    def expand(self, run_spec: RunSpec) -> List[RunSpec]:
+        adapter_spec = replace(run_spec.adapter_spec, temperature=self.value)
+        return [
+            replace(
+                run_spec,
+                adapter_spec=adapter_spec,
+            ),
+        ]
+
+
 class IncreaseTemperatureRunExpander(RunExpander):
     """
     Run expander for increasing the temperature.
@@ -1505,6 +1529,9 @@ RUN_EXPANDER_SUBCLASSES: List[Type[RunExpander]] = [
     ChatMLRunExpander,
     EvalSplitRunExpander,
     OutputFormatInstructions,
+    TemperatureRunExpander,
+    IncreaseTemperatureRunExpander,
+    IncreaseMaxTokensRunExpander,
 ]
 
 

--- a/src/helm/clients/openai_client.py
+++ b/src/helm/clients/openai_client.py
@@ -51,7 +51,7 @@ class OpenAIClient(CachingClient):
     def _is_chat_model_engine(self, model_engine: str) -> bool:
         if model_engine == "gpt-3.5-turbo-instruct":
             return False
-        elif model_engine.startswith("gpt-3.5") or model_engine.startswith("gpt-4"):
+        elif model_engine.startswith("gpt-3.5") or model_engine.startswith("gpt-4") or model_engine.startswith("o1"):
             return True
         return False
 
@@ -168,6 +168,19 @@ class OpenAIClient(CachingClient):
         # Fails with "body -> stop: none is not an allowed value" if None is passed.
         if is_vlm(request.model) and raw_request["stop"] is None:
             raw_request.pop("stop")
+
+        # Special handling for o1 models
+        if request.model_engine.startswith("o1"):
+            # Avoid error:
+            # "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."  # noqa: E501
+            # Note that openai>=1.45 is needed for this
+            if raw_request["max_tokens"]:
+                raw_request["max_completion_tokens"] = raw_request["max_tokens"]
+                raw_request.pop("max_tokens")
+            # Avoid error:
+            # "Invalid type for 'stop': expected an unsupported value, but got null instead."
+            if raw_request["stop"] is None:
+                raw_request.pop("stop")
 
         def do_it() -> Dict[str, Any]:
             return self.client.chat.completions.create(**raw_request).model_dump(mode="json")

--- a/src/helm/clients/openai_client.py
+++ b/src/helm/clients/openai_client.py
@@ -169,7 +169,9 @@ class OpenAIClient(CachingClient):
         if is_vlm(request.model) and raw_request["stop"] is None:
             raw_request.pop("stop")
 
-        # Special handling for o1 models
+        # Special handling for o1 models.
+        # Refer to the "Reasoning models" documentation further discussion of o1 model limitations:
+        # https://platform.openai.com/docs/guides/reasoning
         if request.model_engine.startswith("o1"):
             # Avoid error:
             # "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."  # noqa: E501

--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -1641,6 +1641,21 @@ model_deployments:
     client_spec:
       class_name: "helm.clients.openai_client.OpenAIClient"
 
+  ## o1 Models
+  - name: openai/o1-preview-2024-09-12
+    model_name: openai/o1-preview-2024-09-12
+    tokenizer_name: openai/cl100k_base
+    max_sequence_length: 128000
+    client_spec:
+      class_name: "helm.clients.openai_client.OpenAIClient"
+
+  - name: openai/o1-mini-2024-09-12
+    model_name: openai/o1-mini-2024-09-12
+    tokenizer_name: openai/cl100k_base
+    max_sequence_length: 128000
+    client_spec:
+      class_name: "helm.clients.openai_client.OpenAIClient"
+
   ## Text Similarity Models
   # OpenAI similarity embedding models: https://beta.openai.com/docs/guides/embeddings
   # The number of parameters is guessed based on the number of parameters of the

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -2218,6 +2218,23 @@ models:
     release_date: 2023-11-06
     tags: [VISION_LANGUAGE_MODEL_TAG, OPENAI_CHATGPT_MODEL_TAG, FULL_FUNCTIONALITY_VLM_TAG]
 
+  ## o1 Models
+  - name: openai/o1-preview-2024-09-12
+    display_name: o1-preview (2024-09-12)
+    description: o1-preview is a language model trained with reinforcement learning to perform complex reasoning that can produce a long internal chain of thought before responding to the user. ([model card](https://openai.com/index/openai-o1-system-card/), [blog post](https://openai.com/index/learning-to-reason-with-llms/))
+    creator_organization_name: OpenAI
+    access: limited
+    release_date: 2024-09-12
+    tags: [TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
+
+  - name: openai/o1-mini-2024-09-12
+    display_name: o1-mini (2024-09-12)
+    description: o1-mini is a cost-effective reasoning model for applications that require reasoning without broad world knowledge. ([model card](https://openai.com/index/openai-o1-system-card/), [blog post](https://openai.com/index/openai-o1-mini-advancing-cost-efficient-reasoning/))
+    creator_organization_name: OpenAI
+    access: limited
+    release_date: 2024-09-12
+    tags: [TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
+
   ## Codex Models
   # DEPRECATED: Codex models have been shut down on March 23 2023.
 

--- a/src/helm/proxy/services/server_service.py
+++ b/src/helm/proxy/services/server_service.py
@@ -120,8 +120,12 @@ class ServerService(Service):
                 return "dall_e"
             elif model_deployment.startswith("openai/gpt-4"):
                 return "gpt4"
-            else:
+            elif model_deployment.startswith("openai/gpt-3"):
                 return "gpt3"
+            elif model_deployment.startswith("openai/o1"):
+                return "o1"
+            else:
+                return "openai"
         elif model_deployment.startswith("ai21/"):
             return "jurassic"
         else:


### PR DESCRIPTION
- Add `openai/o1-preview-2024-09-12` and `openai/o1-mini-2024-09-12`
- Update OpenAIClient to handle API changes for o1
- Add temperature and max token run expanders, because o1 needs a temperature of 1.0 and many more max tokens for reasoning
- Add a new crfm-models proxy API quota group `o1`