### PR TITLE
Add LLM as judge metrics to HELM Tables

### DIFF
--- a/src/helm/benchmark/presentation/run_entries_tables.conf
+++ b/src/helm/benchmark/presentation/run_entries_tables.conf
@@ -1,14 +1,21 @@
 "entries": [
     # NumericNLG
-    {description: "unitxt:card=cards.numeric_nlg,template=templates.generation.from_pair.default,demos_pool_size=10,num_demos=5,model=text", priority: 1},
+    {description: "unitxt:card=cards.numeric_nlg,template_card_index=0,demos_pool_size=10,num_demos=5,eval_split=test,model=text", priority: 1},
 
     # TabFact
-    {description: "unitxt:card=cards.tab_fact,template=templates.classification.multi_class.relation.default,demos_pool_size=10,num_demos=5,output_format_instructions=tab_fact,model=text", priority: 1},
+    {description: "unitxt:card=cards.tab_fact,template_card_index=0,demos_pool_size=10,num_demos=5,eval_split=test,model=text", priority: 1},
 
     # WikiTableQuestions
-    {description: "unitxt:card=cards.wikitq,template=templates.qa.with_context.simple,demos_pool_size=10,num_demos=5,output_format_instructions=wikitq,model=text", priority: 1},
+    {description: "unitxt:card=cards.wikitq,template_card_index=0,demos_pool_size=10,num_demos=5,eval_split=test,model=text", priority: 1},
 
     # FinQA
-    {description: "unitxt:card=cards.fin_qa,template_card_index=0,demos_pool_size=10,num_demos=5,model=text", priority: 1},
+    {description: "unitxt:card=cards.fin_qa,template_card_index=0,demos_pool_size=10,num_demos=5,eval_split=test,model=text", priority: 1},
+
+    # SciGen
+    {description: "unitxt:card=cards.scigen,template_card_index=0,demos_pool_size=10,num_demos=5,eval_split=test,model=text", priority: 1},
+
+
+    # TURL column type annotation
+    # {description: "unitxt:card=cards.turl_col_type,template_card_index=0,demos_pool_size=10,num_demos=5,eval_split=test,model=text", priority: 1},
 
 ]

--- a/src/helm/benchmark/static/schema_tables.yaml
+++ b/src/helm/benchmark/static/schema_tables.yaml
@@ -173,6 +173,13 @@ metrics:
     description: Execution Accuracy
     lower_is_better: false
 
+  # SciGen Accuracy
+  - name: llama_3_8b_chat_hf_together_ai_template_table2text_single_turn_with_reference
+    display_name: Rating
+    short_display_name: Rating
+    description: Rating by Llama 3 (8B) LLM as judge
+    lower_is_better: false
+
 perturbations: []
 
 metric_groups:
@@ -233,14 +240,14 @@ metric_groups:
 
 run_groups:
   - name: table_scenarios
-    display_name: Table  Scenarios
+    display_name: Table Scenarios
     description: Table Scenarios
     category: All Scenarios
     subgroups:
       - unitxt_cards.numeric_nlg
       - unitxt_cards.tab_fact
       - unitxt_cards.wikitq
-      - unitxt_cards.fin_qa
+      - unitxt_cards.scigen
 
   - name: unitxt_cards.numeric_nlg
     display_name: NumericNLG
@@ -314,4 +321,21 @@ run_groups:
       what: financial reports
       who: financial experts
       when: 1999 to 2019
+      language: English
+
+  - name: unitxt_cards.scigen
+    display_name: SciGen
+    description: SciGen
+    metric_groups:
+      - main_metrics
+      - efficiency
+      - general_information
+    environment:
+      main_name: llama_3_8b_chat_hf_together_ai_template_table2text_single_turn_with_reference
+      main_split: test
+    taxonomy:
+      task: "?"
+      what: "?"
+      who: "?"
+      when: "?"
       language: English


### PR DESCRIPTION
LLM as judge in Unitxt can produce metrics that are strings rather than numbers, so we have to handle them correctly in `UnitxtMetric` in HELM.