### PR TITLE
Add mean row aggregation to HELM summarize

### DIFF
--- a/src/helm/benchmark/presentation/schema.py
+++ b/src/helm/benchmark/presentation/schema.py
@@ -119,6 +119,8 @@ class MetricGroup(Field):
     hide_win_rates: Optional[bool] = None
     """If set to true, do not compute win rates."""
 
+    add_mean_col: Optional[bool] = None
+
 
 BY_METRIC = "by_metric"
 BY_GROUP = "by_group"

--- a/src/helm/benchmark/presentation/schema.py
+++ b/src/helm/benchmark/presentation/schema.py
@@ -120,6 +120,7 @@ class MetricGroup(Field):
     """If set to true, do not compute win rates."""
 
     aggregation_strategies: Optional[List[str]] = field(default_factory=list)
+    """List with values in {'win_rate','mean'} that correspond to aggregations"""
 
 
 BY_METRIC = "by_metric"

--- a/src/helm/benchmark/presentation/schema.py
+++ b/src/helm/benchmark/presentation/schema.py
@@ -110,14 +110,6 @@ class MetricNameMatcher:
 
 
 @dataclass(frozen=True)
-class AggregationStrategy(IntEnum):
-    USE_NONE = 0
-    USE_MWR = 1
-    USE_MEAN = 2
-    USE_BOTH = 3
-
-
-@dataclass(frozen=True)
 class MetricGroup(Field):
     """
     A list of metrics (which are presumably logically grouped).
@@ -128,7 +120,7 @@ class MetricGroup(Field):
     hide_win_rates: Optional[bool] = None
     """If set to true, do not compute win rates."""
 
-    aggregation_strategy: Optional[Union[AggregationStrategy, int]] = 1
+    aggregation_strategies: Optional[List[str]] = field(default_factory=list)
 
 
 BY_METRIC = "by_metric"

--- a/src/helm/benchmark/presentation/schema.py
+++ b/src/helm/benchmark/presentation/schema.py
@@ -119,7 +119,7 @@ class MetricGroup(Field):
     hide_win_rates: Optional[bool] = None
     """If set to true, do not compute win rates."""
 
-    aggregation_strategies: Optional[List[str]] = field(default_factory=list)
+    aggregation_strategies: Optional[List[str]] = None
     """List with values in {'win_rate','mean'} that correspond to aggregations"""
 
 

--- a/src/helm/benchmark/presentation/schema.py
+++ b/src/helm/benchmark/presentation/schema.py
@@ -1,8 +1,7 @@
 import ast
 import dataclasses
 from dataclasses import dataclass, field
-from enum import IntEnum
-from typing import List, Optional, Dict, Union
+from typing import List, Optional, Dict
 import dacite
 from inspect import cleandoc
 import mako.template

--- a/src/helm/benchmark/presentation/schema.py
+++ b/src/helm/benchmark/presentation/schema.py
@@ -1,7 +1,8 @@
 import ast
 import dataclasses
 from dataclasses import dataclass, field
-from typing import List, Optional, Dict
+from enum import IntEnum
+from typing import List, Optional, Dict, Union
 import dacite
 from inspect import cleandoc
 import mako.template
@@ -109,6 +110,14 @@ class MetricNameMatcher:
 
 
 @dataclass(frozen=True)
+class AggregationStrategy(IntEnum):
+    USE_NONE = 0
+    USE_MWR = 1
+    USE_MEAN = 2
+    USE_BOTH = 3
+
+
+@dataclass(frozen=True)
 class MetricGroup(Field):
     """
     A list of metrics (which are presumably logically grouped).
@@ -119,7 +128,7 @@ class MetricGroup(Field):
     hide_win_rates: Optional[bool] = None
     """If set to true, do not compute win rates."""
 
-    add_mean_col: Optional[bool] = None
+    aggregation_strategy: Optional[Union[AggregationStrategy, int]] = 1
 
 
 BY_METRIC = "by_metric"

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -907,7 +907,7 @@ class Summarizer:
         sub_split: Optional[str] = None,
         bold_columns: bool = True,
         add_win_rate: bool = False,
-        aggregation_strategy: Union[int, None] = 0,
+        aggregation_strategy: int = 0,
     ) -> Table:
         """
         Create a table for where each row is an adapter (for which we have a set of runs) and columns are pairs of
@@ -1176,7 +1176,7 @@ class Summarizer:
         if len(adapter_to_runs) > 0:
             for metric_group in all_metric_groups:
                 display_name = self.schema.name_to_metric_group[metric_group].get_short_display_name()
-                agg_strat: int = (
+                agg_strat: int = int(
                     self.schema.name_to_metric_group[metric_group].aggregation_strategy
                     if self.schema.name_to_metric_group[metric_group].aggregation_strategy != None
                     else 1

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -1104,42 +1104,45 @@ class Summarizer:
         hide_aggregation = not add_win_rate
         if hide_aggregation:
             aggregation_strategies = []
-        insertion_column = AGGREGATE_WIN_RATE_COLUMN
+
+        aggregate_header_cells: List[HeaderCell] = []
+        aggregate_row_values: List[List[float]] = []
+
         for strategy in aggregation_strategies:
             if strategy == "win_rate":
-                # add overall win rate as the second column
                 WIN_RATE_AGGREGATION = "mean"
                 win_rates = compute_aggregate_row_win_rates(table, aggregation=WIN_RATE_AGGREGATION)
                 description = "How many models this model outperform on average (over columns)."
-                table.header.insert(
-                    insertion_column,
+                aggregate_header_cells.append(
                     HeaderCell(
                         f"{WIN_RATE_AGGREGATION.capitalize()} win rate",
                         description=description,
                         lower_is_better=False,
-                    ),
+                    )
                 )
-                for row, win_rate in zip(table.rows, win_rates):
-                    row.insert(insertion_column, Cell(win_rate))
-                insertion_column += 1
+                aggregate_row_values.append(win_rates)
             elif strategy == "mean":
                 means = compute_aggregate_row_means(table)
-                description = "An average over columns representing the mean performance"
-                table.header.insert(
-                    insertion_column,
+                description = "An average over columns representing the mean performance."
+                aggregate_header_cells.append(
                     HeaderCell(
-                        "Mean Performance",
+                        "Mean performance",
                         description=description,
                         lower_is_better=table.header[0].lower_is_better,
-                    ),
+                    )
                 )
-                for row, row_mean in zip(table.rows, means):
-                    row.insert(insertion_column, Cell(row_mean))
-                insertion_column += 1
+                aggregate_row_values.append(means)
             else:
                 raise Exception(
                     f"Unknown aggregation strategy found: {strategy}. Please use one of: {AGGREGATION_STRATEGIES}"
                 )
+
+        for i in range(len(aggregate_header_cells)):
+            aggregate_header_cell = aggregate_header_cells[i]
+            aggregate_rows = aggregate_row_values[i]
+            table.header.insert(i + 1, aggregate_header_cell)
+            for row, row_val in zip(table.rows, aggregate_rows):
+                row.insert(i + 1, Cell(row_val))
 
         if bold_columns:
             for i, header_cell in enumerate(table.header):

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -907,7 +907,7 @@ class Summarizer:
         sub_split: Optional[str] = None,
         bold_columns: bool = True,
         add_win_rate: bool = False,
-        aggregation_strategy: Union[int,None] = 0,
+        aggregation_strategy: Union[int, None] = 0,
     ) -> Table:
         """
         Create a table for where each row is an adapter (for which we have a set of runs) and columns are pairs of

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -262,7 +262,7 @@ def compute_aggregate_row_means(table: Table) -> List[Optional[float]]:
     for row in table.rows:
         total = 0
         count = 0
-        for cell in enumerate(row):
+        for cell in row:
             if cell.value:
                 total += cell.value
                 count += 1

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -1090,8 +1090,12 @@ class Summarizer:
 
         table = Table(title=title, header=header, rows=rows, links=links, name=name)
 
-        add_mean_col = aggregation_strategy >= 2
-        add_mwr = aggregation_strategy % 2 != 0 or add_win_rate  # values 1 or 3 say to include mwr
+        add_mean_col = (
+            aggregation_strategy >= 2
+        )  # values 2 or 3 indicate we should include mean (see AggregationStrategy enum)
+        add_mwr = (
+            aggregation_strategy % 2 != 0 or add_win_rate
+        )  # values 1 or 3 say to include mwr (see AggregationStrategy enum)
 
         if add_mwr:
             # add overall win rate as the second column

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -1178,7 +1178,7 @@ class Summarizer:
                 display_name = self.schema.name_to_metric_group[metric_group].get_short_display_name()
                 agg_strat: int = (
                     self.schema.name_to_metric_group[metric_group].aggregation_strategy
-                    if self.schema.name_to_metric_group[metric_group].aggregation_strategy != None
+                    if self.schema.name_to_metric_group[metric_group].aggregation_strategy is not None
                     else 1
                 )
                 table = self.create_group_table(

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -1176,7 +1176,7 @@ class Summarizer:
         if len(adapter_to_runs) > 0:
             for metric_group in all_metric_groups:
                 display_name = self.schema.name_to_metric_group[metric_group].get_short_display_name()
-                agg_strat = (
+                agg_strat: int = (
                     self.schema.name_to_metric_group[metric_group].aggregation_strategy
                     if self.schema.name_to_metric_group[metric_group].aggregation_strategy != None
                     else 1

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -1176,11 +1176,7 @@ class Summarizer:
         if len(adapter_to_runs) > 0:
             for metric_group in all_metric_groups:
                 display_name = self.schema.name_to_metric_group[metric_group].get_short_display_name()
-                agg_strat: int = (
-                    self.schema.name_to_metric_group[metric_group].aggregation_strategy
-                    if self.schema.name_to_metric_group[metric_group].aggregation_strategy is not None
-                    else 1
-                )
+                agg_strat = self.schema.name_to_metric_group[metric_group].aggregation_strategy or 1
                 table = self.create_group_table(
                     name=metric_group,
                     title=display_name,

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -18,7 +18,7 @@ import yaml
 from collections import defaultdict
 from dataclasses import dataclass, replace
 from statistics import mean, median
-from typing import List, Optional, Dict, Any, Tuple, Set, Union
+from typing import List, Optional, Dict, Any, Tuple, Set
 
 from tqdm import tqdm
 from helm.benchmark.model_deployment_registry import get_model_deployment

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -258,7 +258,7 @@ def compute_aggregate_row_means(table: Table) -> List[Optional[float]]:
     non-null values of the row are in columns we skip).
     """
 
-    means_per_row: List[List[float]] = [[] for _ in table.rows]
+    means_per_row: List[Optional[float]] = []
     for row in table.rows:
         total = 0
         count = 0

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -260,7 +260,7 @@ def compute_aggregate_row_means(table: Table) -> List[Optional[float]]:
 
     means_per_row: List[Optional[float]] = []
     for row in table.rows:
-        total = 0
+        total: float = 0.0
         count = 0
         for cell in row:
             try:
@@ -907,7 +907,7 @@ class Summarizer:
         sub_split: Optional[str] = None,
         bold_columns: bool = True,
         add_win_rate: bool = False,
-        aggregation_strategy: int = 0,
+        selected_agg_strat: int = 0,
     ) -> Table:
         """
         Create a table for where each row is an adapter (for which we have a set of runs) and columns are pairs of
@@ -1091,10 +1091,10 @@ class Summarizer:
         table = Table(title=title, header=header, rows=rows, links=links, name=name)
 
         add_mean_col = (
-            aggregation_strategy >= 2
+            selected_agg_strat >= 2
         )  # values 2 or 3 indicate we should include mean (see AggregationStrategy enum)
         add_mwr = (
-            aggregation_strategy % 2 != 0 or add_win_rate
+            selected_agg_strat % 2 != 0 or add_win_rate
         )  # values 1 or 3 say to include mwr (see AggregationStrategy enum)
 
         if add_mwr:
@@ -1176,7 +1176,7 @@ class Summarizer:
         if len(adapter_to_runs) > 0:
             for metric_group in all_metric_groups:
                 display_name = self.schema.name_to_metric_group[metric_group].get_short_display_name()
-                agg_strat: int = int(
+                agg_strat: int = (
                     self.schema.name_to_metric_group[metric_group].aggregation_strategy
                     if self.schema.name_to_metric_group[metric_group].aggregation_strategy != None
                     else 1
@@ -1188,7 +1188,7 @@ class Summarizer:
                     columns=[(subgroup, metric_group) for subgroup in subgroups],
                     is_scenario_table=False,
                     add_win_rate=not self.schema.name_to_metric_group[metric_group].hide_win_rates,
-                    aggregation_strategy=agg_strat,
+                    selected_agg_strat=int(agg_strat),
                 )
                 tables.append(table)
         return tables

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -1130,7 +1130,7 @@ class Summarizer:
                     HeaderCell(
                         "Mean Performance",
                         description=description,
-                        lower_is_better=False,
+                        lower_is_better=table.header[0].lower_is_better,
                     ),
                 )
                 for row, row_mean in zip(table.rows, means):
@@ -1138,7 +1138,7 @@ class Summarizer:
                 insertion_column += 1
             else:
                 raise Exception(
-                    f"Improper aggregation strategy found: {strategy}. Please use one of: {AGGREGATION_STRATEGIES}"
+                    f"Unknown aggregation strategy found: {strategy}. Please use one of: {AGGREGATION_STRATEGIES}"
                 )
 
         if bold_columns:

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -18,7 +18,7 @@ import yaml
 from collections import defaultdict
 from dataclasses import dataclass, replace
 from statistics import mean, median
-from typing import List, Optional, Dict, Any, Tuple, Set
+from typing import List, Optional, Dict, Any, Tuple, Set, Union
 
 from tqdm import tqdm
 from helm.benchmark.model_deployment_registry import get_model_deployment
@@ -907,7 +907,7 @@ class Summarizer:
         sub_split: Optional[str] = None,
         bold_columns: bool = True,
         add_win_rate: bool = False,
-        aggregation_strategy: int = 0,
+        aggregation_strategy: Union[int,None] = 0,
     ) -> Table:
         """
         Create a table for where each row is an adapter (for which we have a set of runs) and columns are pairs of

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -1176,6 +1176,11 @@ class Summarizer:
         if len(adapter_to_runs) > 0:
             for metric_group in all_metric_groups:
                 display_name = self.schema.name_to_metric_group[metric_group].get_short_display_name()
+                agg_strat = (
+                    self.schema.name_to_metric_group[metric_group].aggregation_strategy
+                    if self.schema.name_to_metric_group[metric_group].aggregation_strategy != None
+                    else 1
+                )
                 table = self.create_group_table(
                     name=metric_group,
                     title=display_name,
@@ -1183,7 +1188,7 @@ class Summarizer:
                     columns=[(subgroup, metric_group) for subgroup in subgroups],
                     is_scenario_table=False,
                     add_win_rate=not self.schema.name_to_metric_group[metric_group].hide_win_rates,
-                    aggregation_strategy=self.schema.name_to_metric_group[metric_group].aggregation_strategy,
+                    aggregation_strategy=agg_strat,
                 )
                 tables.append(table)
         return tables

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -1088,18 +1088,18 @@ class Summarizer:
         table = Table(title=title, header=header, rows=rows, links=links, name=name)
 
         if add_mean_col:
-            means = compute_aggregate_row_means(table, aggregation=WIN_RATE_AGGREGATION)
+            means = compute_aggregate_row_means(table)
             description = "An average over columns representing the mean performance"
             table.header.insert(
                 AGGREGATE_WIN_RATE_COLUMN,
                 HeaderCell(
-                    f"Mean Performance",
+                    "Mean Performance",
                     description=description,
                     lower_is_better=False,
                 ),
             )
-            for row, win_rate in zip(table.rows, win_rates):
-                row.insert(AGGREGATE_WIN_RATE_COLUMN, Cell(win_rate))
+            for row, row_mean in zip(table.rows, means):
+                row.insert(AGGREGATE_WIN_RATE_COLUMN, Cell(row_mean))
         elif add_win_rate:
             # add overall win rate as the second column
             WIN_RATE_AGGREGATION = "mean"

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -1112,7 +1112,7 @@ class Summarizer:
             if strategy == "win_rate":
                 WIN_RATE_AGGREGATION = "mean"
                 win_rates = compute_aggregate_row_win_rates(table, aggregation=WIN_RATE_AGGREGATION)
-                description = "How many models this model outperform on average (over columns)."
+                description = "How many models this model outperforms on average (over columns)."
                 aggregate_header_cells.append(
                     HeaderCell(
                         f"{WIN_RATE_AGGREGATION.capitalize()} win rate",

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -1106,7 +1106,7 @@ class Summarizer:
             aggregation_strategies = []
 
         aggregate_header_cells: List[HeaderCell] = []
-        aggregate_row_values: List[List[float]] = []
+        aggregate_row_values: List[List[Optional[float]]] = []
 
         for strategy in aggregation_strategies:
             if strategy == "win_rate":

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -1170,7 +1170,7 @@ class Summarizer:
                     columns=[(subgroup, metric_group) for subgroup in subgroups],
                     is_scenario_table=False,
                     add_win_rate=not self.schema.name_to_metric_group[metric_group].hide_win_rates,
-                    add_mean_col=self.schema.name_to_metric_group[metric_group].add_mean_col,
+                    add_mean_col=bool(self.schema.name_to_metric_group[metric_group].add_mean_col),
                 )
                 tables.append(table)
         return tables

--- a/src/helm/benchmark/static/schema_safety.yaml
+++ b/src/helm/benchmark/static/schema_safety.yaml
@@ -106,6 +106,7 @@ perturbations: []
 metric_groups:
   - name: accuracy
     display_name: Accuracy
+    aggregation_strategy: 3
     metrics:
       - name: ${main_name}
         split: ${main_split}

--- a/src/helm/benchmark/static/schema_safety.yaml
+++ b/src/helm/benchmark/static/schema_safety.yaml
@@ -106,7 +106,9 @@ perturbations: []
 metric_groups:
   - name: accuracy
     display_name: Accuracy
-    aggregation_strategy: 3
+    aggregation_strategies: 
+      - win_rate
+      - mean
     metrics:
       - name: ${main_name}
         split: ${main_split}


### PR DESCRIPTION
Adds the option for users to do mean metric aggregation as opposed to mean win rate within helm summarize.

In addition it allows for mutliple types of aggregation in parallel (as opposed to just one).