### PR TITLE
Remove type parameter from AbstractContextManager for KeyValueStore

### DIFF
--- a/src/helm/common/key_value_store.py
+++ b/src/helm/common/key_value_store.py
@@ -11,7 +11,7 @@ def request_to_key(request: Mapping) -> str:
     return json.dumps(request, sort_keys=True)
 
 
-class KeyValueStore(contextlib.AbstractContextManager["KeyValueStore"]):
+class KeyValueStore(contextlib.AbstractContextManager):
     """Key value store that persists writes."""
 
     @abstractmethod


### PR DESCRIPTION
Apparently this was causing an error for some users: 

```
File "/path/to/helm/common/key_value_store.py", line 14, in <module>
    class KeyValueStore(contextlib.AbstractContextManager["KeyValueStore"]):
TypeError: 'ABCMeta' object is not subscriptable
```