### PR TITLE
Move pre-commit to pre-push

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_install_hook_types: [pre-push]
+default_stages: [push]
 repos:
 - repo: local
   hooks:


### PR DESCRIPTION
Run the checks when pushing rather than when committing. This should make the developer workflow much faster.