### PR TITLE
Update developer setup instructions

### DIFF
--- a/docs/developer_setup.md
+++ b/docs/developer_setup.md
@@ -56,7 +56,27 @@ pyenv activate crfm-helm
 To install any dependencies:
 
 ```bash
-pip install -e .[dev]
+pip install --force-reinstall -e .[dev]
+```
+
+## Run Python tests
+
+Currently, running all the unit tests takes about 10 minutes. To run all unit tests:
+
+```bash
+python -m pytest
+```
+
+Append `-vv` to output the full diff and results:
+
+```bash
+python -m pytest -vv
+```
+
+When modifying the Python code, you usually want to only run certain relevant tests. To run a specific test file, specify the file path as follows:
+
+```bash
+python -m pytest path/to/test_file.py -vv
 ```
 
 ## Run linter and type-checker
@@ -84,24 +104,4 @@ flake8 src scripts
 
 # Type checker
 mypy src scripts
-```
-
-## Run Python tests
-
-Currently, running all the unit tests takes about 10 minutes. To run all unit tests:
-
-```bash
-python -m pytest
-```
-
-Append `-vv` to output the full diff and results:
-
-```bash
-python -m pytest -vv
-```
-
-When modifying the Python code, you usually want to only run certain relevant tests. To run a specific test file, specify the file path as follows:
-
-```bash
-python -m pytest path/to/test_file.py -vv
 ```

--- a/docs/developer_setup.md
+++ b/docs/developer_setup.md
@@ -4,30 +4,56 @@
 
 First, create a Python virtual environment with Python version >= 3.9 and activate it.
 
+Check your system verison of Python:
+
+```bash
+python --version
+```
+
+If your version of Python is older than 3.9, you _must_ use either the **pyenv** or **Anaconda** methods below.
+
 Using [Virtualenv](https://docs.python.org/3/library/venv.html#creating-virtual-environments):
 
-    # Create a virtual environment.
-    # Only run this the first time.
-    python3 -m pip install virtualenv
-    python3 -m virtualenv -p python3 venv
+```bash
+# Create a virtual environment.
+# Only run this the first time.
+python3 -m pip install virtualenv
+python3 -m virtualenv -p python3 venv
 
-    # Activate the virtual environment.
-    source venv/bin/activate
+# Activate the virtual environment.
+# Run this every time you open your shell.
+source venv/bin/activate
+```
 
 Using [Anaconda](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html):
 
-    # Create a virtual environment.
-    # Only run this the first time.
-    conda create -n crfm-helm python=3.9 pip
+```bash
+# Create a virtual environment.
+# Only run this the first time.
+conda create -n crfm-helm python=3.10 pip
 
-    # Activate the virtual environment.
-    conda activate crfm-helm
+# Activate the virtual environment.
+# Run this every time you open your shell.
+conda activate crfm-helm
+```
 
-## Install dependencies
+Using [pyenv](https://github.com/pyenv/pyenv) and [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv):
+
+```bash
+# Create a virtual environment.
+# Only run this the first time.
+pyenv virtualenv 3.10 crfm-helm
+
+# Activate the virtual environment.
+# Run this every time you open your shell.
+pyenv activate crfm-helm
+```
+
+## Install Python dependencies
 
 To install any dependencies:
 
-    ./install-dev.sh
+    pip install -e .[all]
 
 If you run into errors when installing dependencies, please create a new Python virtual environment using the previous instructions, and then try installing the dependencies again.
 
@@ -55,6 +81,6 @@ To run a specific file, simply specify the path:
 
 To run the linter and type-checker:
 
-    ./pre-commit.sh
+    pre-commit run
 
-If you previously installed the Git commit hooks using `pre-commit install`, then the linter and type-checker will be run whenever you run `git commit`. To skip running the linter and type checker when making a commit, use the `--no-verify` flag with `git commit`.
+If you previously installed the Git commit hooks using `pre-commit install`, then the linter and type-checker will be run whenever you run `git push`. To skip running the linter and type checker when pushing a branch, use the `--no-verify` flag with `git push`.

--- a/docs/developer_setup.md
+++ b/docs/developer_setup.md
@@ -1,18 +1,20 @@
 # Developer Setup
 
-## Set up the Python virtual environment
+## Check your system Python version
 
-First, create a Python virtual environment with Python version >= 3.9 and activate it.
-
-Check your system verison of Python:
+Check your system verison of Python by running:
 
 ```bash
 python --version
 ```
 
-If your version of Python is older than 3.9, you _must_ use either the **pyenv** or **Anaconda** methods below.
+If your version of Python is older than 3.9, you _must_ use either **Conda** or **pyenv** to install a version of Python >=3.9 when setting up your virtual environment.
 
-Using [Virtualenv](https://docs.python.org/3/library/venv.html#creating-virtual-environments):
+## Set up the Python virtual environment
+
+First, create a Python virtual environment with Python version >= 3.9 and activate it.
+
+Using [**Virtualenv**](https://docs.python.org/3/library/venv.html#creating-virtual-environments) (*requires* system Python version >=3.9):
 
 ```bash
 # Create a virtual environment.
@@ -25,7 +27,7 @@ python3 -m virtualenv -p python3 venv
 source venv/bin/activate
 ```
 
-Using [Anaconda](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html):
+Using [**Conda**](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html):
 
 ```bash
 # Create a virtual environment.
@@ -37,7 +39,7 @@ conda create -n crfm-helm python=3.10 pip
 conda activate crfm-helm
 ```
 
-Using [pyenv](https://github.com/pyenv/pyenv) and [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv):
+Using [**pyenv**](https://github.com/pyenv/pyenv) and [**pyenv-virtualenv**](https://github.com/pyenv/pyenv-virtualenv):
 
 ```bash
 # Create a virtual environment.
@@ -53,34 +55,53 @@ pyenv activate crfm-helm
 
 To install any dependencies:
 
-    pip install -e .[all]
+```bash
+pip install -e .[dev]
+```
 
-If you run into errors when installing dependencies, please create a new Python virtual environment using the previous instructions, and then try installing the dependencies again.
+## Run linter and type-checker
 
-Optionally, install Git commit hooks:
+You should always ensure that your code is linted and type-checked before creating a pull request. This is typically enforced by our git pre-commit hooks. Install the pre-commit hooks by running:
 
-    pre-commit install
+```bash
+pre-commit install
+```
 
-## Run tests
+This will automatically run the linter and type-checker whenever you run `git push` to push a branch. To skip running the linter and type checker when pushing a branch, use the `--no-verify` flag with `git push`.
 
-First, follow the earlier instructions to activate the virtual environment.
+To run the linter and type-checker manually:
 
-To run all unit tests:
+```bash
+./pre-commit.sh
+```
 
-    python -m pytest
+Alternatively, you can run only the linter or only the type checker separately:
+
+```bash
+# Linters
+black src scripts
+flake8 src scripts
+
+# Type checker
+mypy src scripts
+```
+
+## Run Python tests
+
+Currently, running all the unit tests takes about 10 minutes. To run all unit tests:
+
+```bash
+python -m pytest
+```
 
 Append `-vv` to output the full diff and results:
 
-    python -m pytest -vv
+```bash
+python -m pytest -vv
+```
 
-To run a specific file, simply specify the path:
+When modifying the Python code, you usually want to only run certain relevant tests. To run a specific test file, specify the file path as follows:
 
-    python -m pytest <path/to/file> -vv
-
-# Run linter and type-checker
-
-To run the linter and type-checker:
-
-    pre-commit run
-
-If you previously installed the Git commit hooks using `pre-commit install`, then the linter and type-checker will be run whenever you run `git push`. To skip running the linter and type checker when pushing a branch, use the `--no-verify` flag with `git push`.
+```bash
+python -m pytest path/to/test_file.py -vv
+```


### PR DESCRIPTION
Changes:

- Recommend `pip install -e .[dev]` over `pip install -e .[all]` or `pip install -r requirements.txt`, because this takes way too long and requires too much disk space.
- Add `--force-reinstall` to replace any previous PyPI install with a local editable install.
- Recommend Python 3.10 over 3.9, because 3.10 is the version provided by Ubuntu 22.04 LTS and is more recent.
- Add instructions for using `pyenv`
- Clarified how the linter, type-checker, and git hooks work