### PR TITLE
Default to win rate column if no aggregation strategies are specified

### DIFF
--- a/src/helm/benchmark/presentation/create_plots.py
+++ b/src/helm/benchmark/presentation/create_plots.py
@@ -14,7 +14,6 @@ from helm.benchmark.config_registry import register_builtin_configs_from_helm_pa
 from helm.common.hierarchical_logger import hlog
 from helm.common.optional_dependencies import handle_module_not_found_error
 from helm.benchmark.model_metadata_registry import MODEL_NAME_TO_MODEL_METADATA
-from helm.benchmark.presentation.summarize import AGGREGATE_WIN_RATE_COLUMN
 
 try:
     import colorcet
@@ -39,6 +38,7 @@ metric_group_to_label = {
     "Efficiency": f"Inference time (s) {DOWN_ARROW}",
 }
 all_metric_groups = list(metric_group_to_label.keys())
+AGGREGATE_WIN_RATE_COLUMN = 1
 
 
 @dataclass

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -1139,7 +1139,7 @@ class Summarizer:
                 aggregate_row_values.append(means)
             else:
                 raise Exception(
-                    f"Unknown aggregation strategy found: {strategy}. Please use one of: {AGGREGATION_STRATEGIES}"
+                    f"Unknown aggregation strategy found: {strategy}. Please use one of: {ALL_AGGREGATION_STRATEGIES}"
                 )
 
         for i in range(len(aggregate_header_cells)):

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -292,8 +292,13 @@ def compute_aggregate_row_means(table: Table) -> List[Optional[float]]:
     return row_means
 
 
-AGGREGATE_WIN_RATE_COLUMN = 1
-AGGREGATION_STRATEGIES = ["mean", "win_rate"]
+class AggregationStrategy:
+    # TODO: Convert to StrEnum after upgrading to Python 3.11
+    WIN_RATE = "win_rate"
+    MEAN = "mean"
+
+
+ALL_AGGREGATION_STRATEGIES = [AggregationStrategy.WIN_RATE, AggregationStrategy.MEAN]
 
 
 class Summarizer:
@@ -1109,7 +1114,7 @@ class Summarizer:
         aggregate_row_values: List[List[Optional[float]]] = []
 
         for strategy in aggregation_strategies:
-            if strategy == "win_rate":
+            if strategy == AggregationStrategy.WIN_RATE:
                 WIN_RATE_AGGREGATION = "mean"
                 win_rates = compute_aggregate_row_win_rates(table, aggregation=WIN_RATE_AGGREGATION)
                 description = "How many models this model outperforms on average (over columns)."
@@ -1121,7 +1126,7 @@ class Summarizer:
                     )
                 )
                 aggregate_row_values.append(win_rates)
-            elif strategy == "mean":
+            elif strategy == AggregationStrategy.MEAN:
                 means = compute_aggregate_row_means(table)
                 description = "An average over columns representing the mean performance."
                 aggregate_header_cells.append(
@@ -1198,7 +1203,7 @@ class Summarizer:
                 elif metric_group_config.hide_win_rates:
                     aggregate_strategies = []
                 else:
-                    aggregate_strategies = ["win_rate"]
+                    aggregate_strategies = [AggregationStrategy.WIN_RATE]
                 table = self.create_group_table(
                     name=metric_group,
                     title=display_name,

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -1190,11 +1190,12 @@ class Summarizer:
 
         if len(adapter_to_runs) > 0:
             for metric_group in all_metric_groups:
-                display_name = self.schema.name_to_metric_group[metric_group].get_short_display_name()
+                metric_group_config = self.schema.name_to_metric_group[metric_group]
+                display_name = metric_group_config.get_short_display_name()
                 aggregate_strategies: List[str]
-                if self.schema.name_to_metric_group[metric_group].aggregation_strategies is not None:
-                    aggregate_strategies = self.schema.name_to_metric_group[metric_group].aggregation_strategies
-                elif self.schema.name_to_metric_group[metric_group].hide_win_rates:
+                if metric_group_config.aggregation_strategies is not None:
+                    aggregate_strategies = metric_group_config.aggregation_strategies
+                elif metric_group_config.hide_win_rates:
                     aggregate_strategies = []
                 else:
                     aggregate_strategies = ["win_rate"]


### PR DESCRIPTION
#2997 broke reverse compatibility by defaulting to no win-rate or mean columns, rather than defaulting to a win-rate column. This restores the original behavior by defaulting to a win-rate column.