### PR TITLE
LLaMA-3 8B Together model name

### DIFF
--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -1846,7 +1846,7 @@ model_deployments:
     client_spec:
       class_name: "helm.clients.together_client.TogetherClient"
       args:
-        together_model: meta-llama/Meta-Llama-3-8B
+        together_model: meta-llama/Llama-3-8b-hf
 
   - name: together/llama-3-70b
     model_name: meta/llama-3-70b


### PR DESCRIPTION
The original model name in the config file for LLaMA 3 8B was `meta-llama/Meta-Llama-3-8B`, which is not in the Together API documentation [https://docs.together.ai/docs/inference-models](https://docs.together.ai/docs/inference-models).

Instead, the language model version of LLaMA 3 8B has the name `meta-llama/Llama-3-8b-hf` on Together. 

Note that LLaMA 3 **70B** has the correct name `meta-llama/Meta-Llama-3-70B`, and thus does not need changes. There seems to be some inconsistency in the naming convention of Together.