### PR TITLE
Delete WindowServiceInfo

### DIFF
--- a/src/helm/benchmark/window_services/tokenizer_service.py
+++ b/src/helm/benchmark/window_services/tokenizer_service.py
@@ -1,6 +1,5 @@
 from helm.common.authentication import Authentication
 from helm.common.tokenization_request import (
-    WindowServiceInfo,
     TokenizationRequest,
     TokenizationRequestResult,
     DecodeRequest,

--- a/src/helm/benchmark/window_services/tokenizer_service.py
+++ b/src/helm/benchmark/window_services/tokenizer_service.py
@@ -25,7 +25,3 @@ class TokenizerService:
     def decode(self, request: DecodeRequest) -> DecodeRequestResult:
         """Decode via an API."""
         return self._service.decode(self._auth, request)
-
-    def get_info(self, model_name: str) -> WindowServiceInfo:
-        """Get info via an API."""
-        return self._service.get_window_service_info(model_name)

--- a/src/helm/common/tokenization_request.py
+++ b/src/helm/common/tokenization_request.py
@@ -3,15 +3,6 @@ from typing import List, Optional, Union
 
 
 @dataclass(frozen=True)
-class WindowServiceInfo:
-    tokenizer_name: str
-    max_sequence_length: int
-    max_request_length: int
-    end_of_text_token: str
-    prefix_token: str
-
-
-@dataclass(frozen=True)
 class TokenizationRequest:
     """A `TokenizationRequest` specifies how to tokenize some text."""
 

--- a/src/helm/proxy/server.py
+++ b/src/helm/proxy/server.py
@@ -106,15 +106,6 @@ def handle_get_general_info():
     return safe_call(perform)
 
 
-@app.get("/api/window_service_info")
-def handle_get_window_service_info():
-    def perform(args):
-        global service
-        return dataclasses.asdict(service.get_window_service_info(args["model_name"]))
-
-    return safe_call(perform)
-
-
 @app.post("/api/account")
 def handle_create_account():
     def perform(args):

--- a/src/helm/proxy/services/remote_service.py
+++ b/src/helm/proxy/services/remote_service.py
@@ -51,11 +51,6 @@ class RemoteService(Service):
         response = requests.get(f"{self.base_url}/api/general_info").json()
         return from_dict(GeneralInfo, response)
 
-    def get_window_service_info(self, model_name) -> WindowServiceInfo:
-        params = {"model_name": model_name}
-        response = requests.get(f"{self.base_url}/api/window_service_info?{urllib.parse.urlencode(params)}").json()
-        return from_dict(WindowServiceInfo, response)
-
     def expand_query(self, query: Query) -> QueryResult:
         params = asdict(query)
         response = requests.get(f"{self.base_url}/api/query?{urllib.parse.urlencode(params)}").json()

--- a/src/helm/proxy/services/remote_service.py
+++ b/src/helm/proxy/services/remote_service.py
@@ -15,7 +15,6 @@ from helm.common.file_upload_request import FileUploadRequest, FileUploadResult
 from helm.common.perspective_api_request import PerspectiveAPIRequest, PerspectiveAPIRequestResult
 from helm.common.clip_score_request import CLIPScoreRequest, CLIPScoreResult
 from helm.common.tokenization_request import (
-    WindowServiceInfo,
     TokenizationRequest,
     TokenizationRequestResult,
     DecodeRequestResult,

--- a/src/helm/proxy/services/server_service.py
+++ b/src/helm/proxy/services/server_service.py
@@ -85,21 +85,6 @@ class ServerService(Service):
         all_models = [dataclasses.replace(model_metadata, release_date=None) for model_metadata in ALL_MODELS_METADATA]
         return GeneralInfo(version=VERSION, example_queries=example_queries, all_models=all_models)
 
-    def get_window_service_info(self, model_name) -> WindowServiceInfo:
-        # The import statement is placed here to avoid two problems, please refer to the link for details
-        # https://github.com/stanford-crfm/helm/pull/1430#discussion_r1156686624
-        from helm.benchmark.window_services.tokenizer_service import TokenizerService
-        from helm.benchmark.window_services.window_service_factory import WindowServiceFactory
-
-        token_service = TokenizerService(self, Authentication(""))
-        window_service = WindowServiceFactory.get_window_service(model_name, token_service)
-        return WindowServiceInfo(
-            tokenizer_name=window_service.tokenizer_name,
-            max_sequence_length=window_service.max_sequence_length,
-            max_request_length=window_service.max_request_length,
-            end_of_text_token=window_service.end_of_text_token,
-            prefix_token=window_service.prefix_token,
-        )
 
     def expand_query(self, query: Query) -> QueryResult:
         """Turn the `query` into requests."""

--- a/src/helm/proxy/services/server_service.py
+++ b/src/helm/proxy/services/server_service.py
@@ -85,7 +85,6 @@ class ServerService(Service):
         all_models = [dataclasses.replace(model_metadata, release_date=None) for model_metadata in ALL_MODELS_METADATA]
         return GeneralInfo(version=VERSION, example_queries=example_queries, all_models=all_models)
 
-
     def expand_query(self, query: Query) -> QueryResult:
         """Turn the `query` into requests."""
         prompt = query.prompt

--- a/src/helm/proxy/services/server_service.py
+++ b/src/helm/proxy/services/server_service.py
@@ -14,7 +14,6 @@ from helm.common.file_upload_request import FileUploadRequest, FileUploadResult
 from helm.common.general import ensure_directory_exists, parse_hocon, get_credentials
 from helm.common.perspective_api_request import PerspectiveAPIRequest, PerspectiveAPIRequestResult
 from helm.common.tokenization_request import (
-    WindowServiceInfo,
     TokenizationRequest,
     TokenizationRequestResult,
     DecodeRequest,

--- a/src/helm/proxy/services/service.py
+++ b/src/helm/proxy/services/service.py
@@ -11,7 +11,6 @@ from helm.common.nudity_check_request import NudityCheckRequest, NudityCheckResu
 from helm.common.perspective_api_request import PerspectiveAPIRequestResult, PerspectiveAPIRequest
 from helm.common.moderations_api_request import ModerationAPIRequest, ModerationAPIRequestResult
 from helm.common.tokenization_request import (
-    WindowServiceInfo,
     TokenizationRequest,
     TokenizationRequestResult,
     DecodeRequest,

--- a/src/helm/proxy/services/service.py
+++ b/src/helm/proxy/services/service.py
@@ -86,11 +86,6 @@ class Service(ABC):
         pass
 
     @abstractmethod
-    def get_window_service_info(self, model_name: str) -> WindowServiceInfo:
-        """Get window service info."""
-        pass
-
-    @abstractmethod
     def expand_query(self, query: Query) -> QueryResult:
         """Turn the `query` into requests."""
         pass


### PR DESCRIPTION
The `WindowServiceInfo` class and `window_service_info()` method are unused and can be deleted.