### PR TITLE
Clean up HEIM docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This repository contains code used to produce results for the following papers:
 - **Holistic Evaluation of Vision-Language Models (VHELM)** - paper (TBD), [leaderboard](https://crfm.stanford.edu/helm/vhelm/latest/), [documentation](https://crfm-helm.readthedocs.io/en/latest/vhelm/)
 - **Holistic Evaluation of Text-To-Image Models (HEIM)** - [paper](https://arxiv.org/abs/2311.04287), [leaderboard](https://crfm.stanford.edu/helm/heim/latest/), [documentation](https://crfm-helm.readthedocs.io/en/latest/heim/)
 
-The HELM Python package can be used to reproduce the published model evaluation results from these paper. To get started, refer to the documentation links above for the corresponding paper, or the [main Reproducing Leaderboards documentation](https://crfm-helm.readthedocs.io/en/latest/reproducing_leaderboards/).
+The HELM Python package can be used to reproduce the published model evaluation results from these papers. To get started, refer to the documentation links above for the corresponding paper, or the [main Reproducing Leaderboards documentation](https://crfm-helm.readthedocs.io/en/latest/reproducing_leaderboards/).
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -21,43 +21,10 @@ To get started, refer to [the documentation on Read the Docs](https://crfm-helm.
 
 This repository contains code used to produce results for the following papers:
 
-- Holistic Evaluation of Vision-Language Models (VHELM) - paper (TBD), [leaderboard](https://crfm.stanford.edu/helm/vhelm/latest/), [documentation](https://crfm-helm.readthedocs.io/en/latest/vhelm/)
-- Holistic Evaluation of Text-To-Image Models (HEIM) - [paper](https://arxiv.org/abs/2311.04287), [leaderboard](https://crfm.stanford.edu/helm/heim/latest/), [documentation](https://crfm-helm.readthedocs.io/en/latest/heim/)
+- **Holistic Evaluation of Vision-Language Models (VHELM)** - paper (TBD), [leaderboard](https://crfm.stanford.edu/helm/vhelm/latest/), [documentation](https://crfm-helm.readthedocs.io/en/latest/vhelm/)
+- **Holistic Evaluation of Text-To-Image Models (HEIM)** - [paper](https://arxiv.org/abs/2311.04287), [leaderboard](https://crfm.stanford.edu/helm/heim/latest/), [documentation](https://crfm-helm.readthedocs.io/en/latest/heim/)
 
 The HELM Python package can be used to reproduce the published model evaluation results from these paper. To get started, refer to the documentation links above for the corresponding paper, or the [main Reproducing Leaderboards documentation](https://crfm-helm.readthedocs.io/en/latest/reproducing_leaderboards/).
-
-## Holistic Evaluation of Text-To-Image Models
-
-<img src="https://github.com/stanford-crfm/helm/raw/heim/src/helm/benchmark/static/heim/images/heim-logo.png" alt=""  width="800"/>
-
-Significant effort has recently been made in developing text-to-image generation models, which take textual prompts as 
-input and generate images. As these models are widely used in real-world applications, there is an urgent need to 
-comprehensively understand their capabilities and risks. However, existing evaluations primarily focus on image-text 
-alignment and image quality. To address this limitation, we introduce a new benchmark, 
-**Holistic Evaluation of Text-To-Image Models (HEIM)**.
-
-We identify 12 different aspects that are important in real-world model deployment, including:
-
-- image-text alignment
-- image quality
-- aesthetics
-- originality
-- reasoning
-- knowledge
-- bias
-- toxicity
-- fairness
-- robustness
-- multilinguality
-- efficiency
-
-By curating scenarios encompassing these aspects, we evaluate state-of-the-art text-to-image models using this benchmark. 
-Unlike previous evaluations that focused on alignment and quality, HEIM significantly improves coverage by evaluating all 
-models across all aspects. Our results reveal that no single model excels in all aspects, with different models 
-demonstrating strengths in different aspects.
-
-This repository contains the code used to produce the [results on the website](https://crfm.stanford.edu/heim/latest/) 
-and [paper](https://arxiv.org/abs/2311.04287).
 
 ## Citation
 

--- a/docs/heim.md
+++ b/docs/heim.md
@@ -1,16 +1,68 @@
 # HEIM (Text-to-image Model Evaluation)
 
-To run HEIM, follow these steps:
+**Holistic Evaluation of Text-To-Image Models (HEIM)** is an extension of the HELM framework for evaluating **text-to-image models**.
 
-1. Create a run specs configuration file. For example, to evaluate 
-[Stable Diffusion v1.4](https://huggingface.co/CompVis/stable-diffusion-v1-4) against the 
-[MS-COCO scenario](https://github.com/stanford-crfm/heim/blob/main/src/helm/benchmark/scenarios/image_generation/mscoco_scenario.py), run:
-```
-echo 'entries: [{description: "mscoco:model=huggingface/stable-diffusion-v1-4", priority: 1}]' > run_entries.conf
-```
-2. Run the benchmark with certain number of instances (e.g., 10 instances): 
-`helm-run --conf-paths run_entries.conf --suite heim_v1 --max-eval-instances 10`
+## Holistic Evaluation of Text-To-Image Models
 
-Examples of run specs configuration files can be found [here](https://github.com/stanford-crfm/helm/tree/main/src/helm/benchmark/presentation).
-We used [this configuration file](https://github.com/stanford-crfm/helm/blob/main/src/helm/benchmark/presentation/run_entries_heim.conf) 
-to produce results of the paper.
+<img src="https://github.com/stanford-crfm/helm/raw/heim/src/helm/benchmark/static/heim/images/heim-logo.png" alt=""  width="800"/>
+
+Significant effort has recently been made in developing text-to-image generation models, which take textual prompts asmy-suite
+input and generate images. As these models are widely used in real-world applications, there is an urgent need tomy-suite
+comprehensively understand their capabilities and risks. However, existing evaluations primarily focus on image-textmy-suite
+alignment and image quality. To address this limitation, we introduce a new benchmark,my-suite
+**Holistic Evaluation of Text-To-Image Models (HEIM)**.
+
+We identify 12 different aspects that are important in real-world model deployment, including:
+
+- image-text alignment
+- image quality
+- aesthetics
+- originality
+- reasoning
+- knowledge
+- bias
+- toxicity
+- fairness
+- robustness
+- multilinguality
+- efficiency
+
+By curating scenarios encompassing these aspects, we evaluate state-of-the-art text-to-image models using this benchmark.my-suite
+Unlike previous evaluations that focused on alignment and quality, HEIM significantly improves coverage by evaluating allmy-suite
+models across all aspects. Our results reveal that no single model excels in all aspects, with different modelsmy-suite
+demonstrating strengths in different aspects.
+
+## References
+
+- [Leaderboard](https://crfm.stanford.edu/helm/heim/latest/)
+- Paper (TBD)
+
+## Installation
+
+First, follow the [installation instructions](installation.md) to install the base HELM Python page.
+
+To install the additional dependencies to run HEIM, run:
+
+```
+pip install "crfm-helm[heim]"
+```my-suite
+
+Some models (e.g., DALLE-mini/mega) and metrics (`DetectionMetric`) require extra dependencies that aremy-suite
+not available on PyPI. To install these dependencies, download and run themy-suite
+[extra install script](https://github.com/stanford-crfm/helm/blob/main/install-heim-extras.sh):
+
+```
+bash install-heim-extras.sh
+```
+
+## Getting Started
+
+The following is an example of evaluating [Stable Diffusion v1.4](https://huggingface.co/CompVis/stable-diffusion-v1-4) on the [MS-COCO scenario](https://github.com/stanford-crfm/heim/blob/main/src/helm/benchmark/scenarios/image_generation/mscoco_scenario.py) using 10 instances.
+
+```sh
+helm-run --run-entries mscoco:model=huggingface/stable-diffusion-v1-4 --suite heim_v1 --max-eval-instances 10
+```
+
+## Reproducing the Leaderboard
+
+To reproduce the [entire HEIM leaderboard](https://crfm.stanford.edu/helm/heim/latest/), refer to the instructions for HEIM on the [Reproducing Leaderboards](reproducing_leaderboards.md) documentation.

--- a/docs/heim.md
+++ b/docs/heim.md
@@ -60,7 +60,7 @@ bash install-heim-extras.sh
 The following is an example of evaluating [Stable Diffusion v1.4](https://huggingface.co/CompVis/stable-diffusion-v1-4) on the [MS-COCO scenario](https://github.com/stanford-crfm/heim/blob/main/src/helm/benchmark/scenarios/image_generation/mscoco_scenario.py) using 10 instances.
 
 ```sh
-helm-run --run-entries mscoco:model=huggingface/stable-diffusion-v1-4 --suite heim_v1 --max-eval-instances 10
+helm-run --run-entries mscoco:model=huggingface/stable-diffusion-v1-4 --suite my-heim-suite --max-eval-instances 10
 ```
 
 ## Reproducing the Leaderboard

--- a/docs/heim.md
+++ b/docs/heim.md
@@ -35,7 +35,7 @@ demonstrating strengths in different aspects.
 ## References
 
 - [Leaderboard](https://crfm.stanford.edu/helm/heim/latest/)
-- Paper (TBD)
+- [Paper](https://arxiv.org/abs/2311.04287)
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,4 +25,4 @@ This repository contains code used to produce results for the following papers:
 - **Holistic Evaluation of Vision-Language Models (VHELM)** - paper (TBD), [leaderboard](https://crfm.stanford.edu/helm/vhelm/latest/), [documentation](https://crfm-helm.readthedocs.io/en/latest/vhelm/)
 - **Holistic Evaluation of Text-To-Image Models (HEIM)** - [paper](https://arxiv.org/abs/2311.04287), [leaderboard](https://crfm.stanford.edu/helm/heim/latest/), [documentation](https://crfm-helm.readthedocs.io/en/latest/heim/)
 
-The HELM Python package can be used to reproduce the published model evaluation results from these paper. To get started, refer to the documentation links above for the corresponding paper, or the [main Reproducing Leaderboards documentation](https://crfm-helm.readthedocs.io/en/latest/reproducing_leaderboards/).
+The HELM Python package can be used to reproduce the published model evaluation results from these papers. To get started, refer to the documentation links above for the corresponding paper, or the [main Reproducing Leaderboards documentation](https://crfm-helm.readthedocs.io/en/latest/reproducing_leaderboards/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,11 @@ To add new models and scenarios, refer to the Developer Guide's chapters:
 - [Developer Setup](developer_setup.md)
 - [Code Structure](code.md)
 
+## Papers
 
-We also support evaluating text-to-image models as introduced in **Holistic Evaluation of Text-to-Image Models (HEIM)**
-([paper](https://arxiv.org/abs/2311.04287), [website](https://crfm.stanford.edu/heim/latest)).
+This repository contains code used to produce results for the following papers:
+
+- **Holistic Evaluation of Vision-Language Models (VHELM)** - paper (TBD), [leaderboard](https://crfm.stanford.edu/helm/vhelm/latest/), [documentation](https://crfm-helm.readthedocs.io/en/latest/vhelm/)
+- **Holistic Evaluation of Text-To-Image Models (HEIM)** - [paper](https://arxiv.org/abs/2311.04287), [leaderboard](https://crfm.stanford.edu/helm/heim/latest/), [documentation](https://crfm-helm.readthedocs.io/en/latest/heim/)
+
+The HELM Python package can be used to reproduce the published model evaluation results from these paper. To get started, refer to the documentation links above for the corresponding paper, or the [main Reproducing Leaderboards documentation](https://crfm-helm.readthedocs.io/en/latest/reproducing_leaderboards/).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -34,19 +34,3 @@ Within this virtual environment, run:
 ```
 pip install crfm-helm
 ```
-
-### For HEIM (text-to-image evaluation)
-
-To install the additional dependencies to run HEIM, run:
-
-```
-pip install "crfm-helm[heim]"
-``` 
-
-Some models (e.g., DALLE-mini/mega) and metrics (`DetectionMetric`) require extra dependencies that are 
-not available on PyPI. To install these dependencies, download and run the 
-[extra install script](https://github.com/stanford-crfm/helm/blob/main/install-heim-extras.sh):
-
-```
-bash install-heim-extras.sh
-```

--- a/docs/vhelm.md
+++ b/docs/vhelm.md
@@ -21,22 +21,23 @@ pip install "crfm-helm[vlm]"
 
 ## Quick Start
 
+The following is an example of evaluating `openai/gpt-4o-mini-2024-07-18` on 10 instance from the Accounting subset of MMMU.
+
 ```sh
 # Download schema_vhelm.yaml
 wget https://raw.githubusercontent.com/stanford-crfm/helm/refs/heads/main/src/helm/benchmark/static/schema_vhelm.yaml
 
 # Run benchmark
-helm-run --run-entries mmmu:subject=Accounting,model=openai/gpt-4o-mini-2024-07-18 --suite my-suite --max-eval-instances 10
+helm-run --run-entries mmmu:subject=Accounting,model=openai/gpt-4o-mini-2024-07-18 --suite my-vhelm-suite --max-eval-instances 10
 
 # Summarize benchmark results
-helm-summarize --suite my-suite --schema-path schema_vhelm.yaml
+helm-summarize --suite my-vhelm-suite --schema-path schema_vhelm.yaml
 
 # Start a web server to display benchmark results
-helm-server --suite my-suite
+helm-server --suite my-vhelm-suite
 ```
 
 Then go to http://localhost:8000/ in your browser.
-
 
 ## Reproducing the Leaderboard
 


### PR DESCRIPTION
Previous, references to HEIM were scattered throughout multiple documentation pages. This centralizes them to the HEIM page.