### PR TITLE
Few-shot run_specs for GPQA, CoT not included yet

### DIFF
--- a/src/helm/benchmark/run_specs/lite_run_specs.py
+++ b/src/helm/benchmark/run_specs/lite_run_specs.py
@@ -305,3 +305,26 @@ def get_wmt_14_spec(language_pair: str, max_train_instances: int = 1) -> RunSpec
         metric_specs=get_open_ended_generation_metric_specs(),
         groups=["wmt_14"],
     )
+
+
+@run_spec_function("gpqa")
+def get_gpqa_spec(subset: str, method: str = ADAPT_MULTIPLE_CHOICE_JOINT) -> RunSpec:
+
+    scenario_spec = ScenarioSpec(
+        class_name="helm.benchmark.scenarios.gpqa_scenario.GPQAScenario", args={"subset": subset}
+    )
+
+    adapter_spec = get_multiple_choice_adapter_spec(
+        method=method,
+        instructions="The following are multiple choice questions (with answers).",
+        input_noun="Question",
+        output_noun="Answer",
+    )
+
+    return RunSpec(
+        name=f"gpqa:subset={subset},method={method}",
+        scenario_spec=scenario_spec,
+        adapter_spec=adapter_spec,
+        metric_specs=get_exact_match_metric_specs(),
+        groups=["gpqa"],
+    )

--- a/src/helm/benchmark/scenarios/gpqa_scenario.py
+++ b/src/helm/benchmark/scenarios/gpqa_scenario.py
@@ -6,6 +6,7 @@ from helm.benchmark.scenarios.scenario import (
     Scenario,
     Instance,
     Reference,
+    TRAIN_SPLIT,
     TEST_SPLIT,
     CORRECT_TAG,
     Input,
@@ -54,8 +55,6 @@ class GPQAScenario(Scenario):
         random.seed(self.random_seed)
         instances: List[Instance] = []
         for idx, row in enumerate(dataset):
-            if idx in EXCLUDED_TRAIN_EXAMPLES[self.subset]:
-                continue
             input = Input(text=row["Question"].strip())
             references = [
                 Reference(Output(text=row["Correct Answer"].strip()), tags=[CORRECT_TAG]),
@@ -64,7 +63,8 @@ class GPQAScenario(Scenario):
                 Reference(Output(text=row["Incorrect Answer 3"].strip()), tags=[]),
             ]
             random.shuffle(references)
-            instance = Instance(input=input, references=references, split=TEST_SPLIT)
+            split = TRAIN_SPLIT if idx in EXCLUDED_TRAIN_EXAMPLES[self.subset] else TEST_SPLIT
+            instance = Instance(input=input, references=references, split=split)
             instances.append(instance)
 
         return instances

--- a/src/helm/benchmark/scenarios/test_gpqa_scenario.py
+++ b/src/helm/benchmark/scenarios/test_gpqa_scenario.py
@@ -9,7 +9,7 @@ def test_gpqa_scenario():
     with TemporaryDirectory() as tmpdir:
         scenario = GPQAScenario(subset="gpqa_main")
         instances = scenario.get_instances(tmpdir)
-        assert len(instances) == 446
+        assert len(instances) == 448
         assert instances[0].split == "test"
         assert len(instances[0].input.text) == 689
         references = instances[0].references
@@ -21,7 +21,7 @@ def test_gpqa_scenario():
 
         scenario = GPQAScenario(subset="gpqa_diamond")
         instances = scenario.get_instances(tmpdir)
-        assert len(instances) == 196
+        assert len(instances) == 198
         assert instances[0].split == "test"
         assert len(instances[0].input.text) == 262
         references = instances[0].references
@@ -33,7 +33,7 @@ def test_gpqa_scenario():
 
         scenario = GPQAScenario(subset="gpqa_extended")
         instances = scenario.get_instances(tmpdir)
-        assert len(instances) == 543
+        assert len(instances) == 546
         assert instances[0].split == "test"
         assert len(instances[0].input.text) == 689
         references = instances[0].references


### PR DESCRIPTION
Added the basic few-shot run_specs for GPQA (using the excluded train examples). 

Due to the need for train examples, this PR is depending on the previous #3078.