### PR TITLE
Use BLOCK_NONE by default for gemini-1.5-flash-002

### DIFF
--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -510,8 +510,6 @@ model_deployments:
     # TODO: Max output tokens: 8192
     client_spec:
       class_name: "helm.clients.vertexai_client.VertexAIChatClient"
-      args:
-        safety_settings_preset: default
 
   ## Gemma
   - name: together/gemma-2b


### PR DESCRIPTION
This makes the behavior consistent with the other Gemini models in HELM.