### PR TITLE
Link to VHELM and HEIM from the installation doc

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -34,3 +34,10 @@ Within this virtual environment, run:
 ```
 pip install crfm-helm
 ```
+
+## Install Multimodal Support
+
+Additional steps are required for multimodal evaluations:
+
+- **HEIM (Text-to-image Model Evaluation)** - to install the additional dependencies to run HEIM (text-to-image evaluation), refer to the [HEIM documentation](heim.md).
+- **VHELM (Vision-Language Models)** - To install the additional dependencies to run VHELM (Vision-Language Models), refer to the [VHELM documentation](vhelm.md).


### PR DESCRIPTION
These links were removed in #3050, but the resulting docs were confusing for users. This pull request adds the links back.