### PR TITLE
Allow setting device for Hugging Face models

### DIFF
--- a/docs/adding_new_models.md
+++ b/docs/adding_new_models.md
@@ -60,7 +60,8 @@ Examples of common arguments within `args`:
 - Revision: `revision: my_revision`
 - Quantization: `load_in_8bit: true`
 - Model precision: `torch_dtype: torch.float16`
-- Running remote code: `trust_remote_code: true`
+- Model device: `device: cpu` or `device: cuda:0`
+- Allow running remote code: `trust_remote_code: true`
 - Multi-GPU: `device_map: auto`
 
 

--- a/src/helm/clients/huggingface_client.py
+++ b/src/helm/clients/huggingface_client.py
@@ -76,7 +76,7 @@ class HuggingFaceServer:
             if "device_map" in kwargs:
                 raise ValueError("At most one of one of `device` and `device_map` may be specified.")
             hlog(f'Hugging Face device set to "{kwargs["device"]}" from kwargs.')
-            self.device = kwargs["device"]
+            self.device = kwargs.pop("device")
         elif torch.cuda.is_available():
             hlog('Hugging Face device set to "cuda:0" because CUDA is available.')
             self.device = "cuda:0"

--- a/src/helm/clients/huggingface_client.py
+++ b/src/helm/clients/huggingface_client.py
@@ -64,12 +64,19 @@ class HuggingFaceServer:
     ):
         self.device: Optional[str]
         if "device_map" in kwargs:
+            if "device" in kwargs:
+                raise ValueError("At most one of one of `device` and `device_map` may be specified.")
             try:
                 import accelerate  # noqa: F401
             except ModuleNotFoundError as e:
                 handle_module_not_found_error(e, ["accelerate"])
-            hlog(f'Hugging Face device_map set to "{kwargs["device_map"]}".')
+            hlog(f'Hugging Face device_map set to "{kwargs["device_map"]}" from kwargs.')
             self.device = None
+        elif "device" in kwargs:
+            if "device_map" in kwargs:
+                raise ValueError("At most one of one of `device` and `device_map` may be specified.")
+            hlog(f'Hugging Face device set to "{kwargs["device"]}" from kwargs.')
+            self.device = kwargs["device"]
         elif torch.cuda.is_available():
             hlog('Hugging Face device set to "cuda:0" because CUDA is available.')
             self.device = "cuda:0"


### PR DESCRIPTION
Allow setting `device` inside `args` for `HuggingFaceClient` to override the device of the Hugging Face model.

Fixes #1683.