### PR TITLE
Fix padding around mini leaderboard for Classic and Lite

### DIFF
--- a/helm-frontend/src/components/Hero.tsx
+++ b/helm-frontend/src/components/Hero.tsx
@@ -17,33 +17,28 @@ export default function Hero() {
       {/* Container for Image and Leaderboard */}
       <div
         className="flex flex-col md:flex-col lg:flex-row lg:justify-center"
-        style={{ height: "525px", transform: "scale(0.9)" }} // Reduced height by 10%
       >
         {/* Image section */}
         <div className="w-full lg:w-1/2 flex justify-center mb-4 lg:mb-0 h-full py-10">
           <img
             src={helmHero}
             alt="HELM Hero"
-            className="object-cover h-full" // Stretched to full height
-            style={{ maxWidth: "100%" }}
+            className="object-contain w-96" // Stretched to full height
           />
         </div>
 
         {/* Leaderboard section */}
-        <div className="w-full lg:w-1/2 flex justify-center h-full py-10">
           <div
-            className="py-2 pb-6 rounded-3xl bg-gray-100 h-full" // Stretched to full height
-            style={{ maxWidth: "100%" }}
+            className="py-2 rounded-xl bg-gray-100 h-full"
           >
             <MiniLeaderboard />
             <div className="flex justify-end">
               <Link to="leaderboard">
-                <button className="px-4 mx-3 mt-1 btn bg-white rounded-md">
+                <button className="px-4 mx-3 mt-2 btn bg-white rounded-md">
                   <span>See More</span>
                 </button>
               </Link>
             </div>
-          </div>
         </div>
       </div>
     </div>

--- a/helm-frontend/src/components/Hero.tsx
+++ b/helm-frontend/src/components/Hero.tsx
@@ -15,9 +15,7 @@ export default function Hero() {
       </div>
 
       {/* Container for Image and Leaderboard */}
-      <div
-        className="flex flex-col md:flex-col lg:flex-row lg:justify-center"
-      >
+      <div className="flex flex-col md:flex-col lg:flex-row lg:justify-center">
         {/* Image section */}
         <div className="w-full lg:w-1/2 flex justify-center mb-4 lg:mb-0 h-full py-10">
           <img
@@ -28,17 +26,15 @@ export default function Hero() {
         </div>
 
         {/* Leaderboard section */}
-          <div
-            className="py-2 rounded-xl bg-gray-100 h-full"
-          >
-            <MiniLeaderboard />
-            <div className="flex justify-end">
-              <Link to="leaderboard">
-                <button className="px-4 mx-3 mt-2 btn bg-white rounded-md">
-                  <span>See More</span>
-                </button>
-              </Link>
-            </div>
+        <div className="py-2 rounded-xl bg-gray-100 h-full">
+          <MiniLeaderboard />
+          <div className="flex justify-end">
+            <Link to="leaderboard">
+              <button className="px-4 mx-3 mt-2 btn bg-white rounded-md">
+                <span>See More</span>
+              </button>
+            </Link>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixes #2933

Before:

![Screenshot 2024-10-30 134719](https://github.com/user-attachments/assets/6d8ea269-730f-4f13-a203-65569e9769f4)

After:

![Screenshot 2024-10-30 134715](https://github.com/user-attachments/assets/62c9e6c6-71b3-4a69-bdb7-11896460e40b)
