### PR TITLE
Skip models column when summarizing mean

### DIFF
--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -266,7 +266,7 @@ def compute_aggregate_row_means(table: Table) -> List[Optional[float]]:
 
     row_means: List[Optional[float]] = []
     # if the first column contains the names of models, do not treat it like a value column
-    skip_first_column = table.header and table.header[0] == MODEL_HEADER_CELL_VALUE
+    skip_first_column = table.header and table.header[0].value == MODEL_HEADER_CELL_VALUE
 
     # check for all header cells where specified, that lower_is_better is consistent
     orderings = []


### PR DESCRIPTION
Fixes an error when trying to use `aggregation_strategies: ["mean"]` in `schema.yaml` with `helm-summarize`:

```
Traceback (most recent call last):
  File "/path/to/crfm-helm/bin/helm-summarize", line 8, in <module>
    sys.exit(main())
  File "/path/to/crfm-helm/lib/python3.10/site-packages/helm/common/hierarchical_logger.py", line 104, in wrapper
    return fn(*args, **kwargs)
  File "/path/to/crfm-helm/lib/python3.10/site-packages/helm/benchmark/presentation/summarize.py", line 1315, in main
    summarizer.run_pipeline(skip_completed=args.skip_completed_run_display_json)
  File "/path/to/crfm-helm/lib/python3.10/site-packages/helm/benchmark/presentation/summarize.py", line 1223, in run_pipeline
    self.write_groups()
  File "/path/to/crfm-helm/lib/python3.10/site-packages/helm/benchmark/presentation/summarize.py", line 1167, in write_groups
    tables: List[Table] = self.create_group_tables_by_metric_group(group)
  File "/path/to/crfm-helm/lib/python3.10/site-packages/helm/benchmark/presentation/summarize.py", line 1060, in create_group_tables_by_metric_group
    table = self.create_group_table(
  File "/path/to/crfm-helm/lib/python3.10/site-packages/helm/benchmark/presentation/summarize.py", line 983, in create_group_table
    means = compute_aggregate_row_means(table)
  File "/path/to/crfm-helm/lib/python3.10/site-packages/helm/benchmark/presentation/summarize.py", line 279, in compute_aggregate_row_means
    total += float(cell.value)
ValueError: could not convert string to float: 'DBRX Instruct'
```

If the first column contains the names of models, `helm-summarize` should skip it instead of treating it like a value column when computing the mean.