### PR TITLE
Add wmt_14_no_prefix to output_format_instructions run expander

### DIFF
--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -1469,6 +1469,8 @@ class OutputFormatInstructions(RunExpander):
                 instructions = "Answer with the English translation."
             elif self.scenario == "wmt_14_only_last_sentence":
                 instructions = "Answer with only the English translation for the last sentence."
+            elif self.scenario == "wmt_14_no_prefix":
+                instructions = "Answer with the English translation. Do not include 'English:' in your answer."
             elif self.scenario == "math":
                 instructions = "Wrap the final answer with the \\boxed{} command."
             elif self.scenario == "numeric_nlg":


### PR DESCRIPTION
Adds an extra instruction to not include the 'English:' prefix in the answer, because Claude 3.5 Sonnet likes to do this.