### PR TITLE
Deprecate OpenAI legacy completions API

### DIFF
--- a/src/helm/clients/nvidia_nim_client.py
+++ b/src/helm/clients/nvidia_nim_client.py
@@ -30,6 +30,3 @@ class NvidiaNimClient(OpenAIClient):
 
     def _get_model_for_request(self, request: Request) -> str:
         return request.model
-
-    def _is_chat_model_engine(self, model_engine: str) -> bool:
-        return True

--- a/src/helm/clients/openai_client.py
+++ b/src/helm/clients/openai_client.py
@@ -49,13 +49,6 @@ class OpenAIClient(CachingClient):
         self.tokenizer_name = tokenizer_name
         self.client = OpenAI(api_key=api_key, organization=org_id, base_url=base_url)
 
-    def _is_chat_model_engine(self, model_engine: str) -> bool:
-        if model_engine == "gpt-3.5-turbo-instruct":
-            return False
-        elif model_engine.startswith("gpt-3.5") or model_engine.startswith("gpt-4") or model_engine.startswith("o1"):
-            return True
-        return False
-
     def _get_model_for_request(self, request: Request) -> str:
         return request.model_engine
 
@@ -340,7 +333,10 @@ class OpenAIClient(CachingClient):
     def make_request(self, request: Request) -> RequestResult:
         if request.embedding:
             return self._make_embedding_request(request)
-        elif self._is_chat_model_engine(request.model_engine):
-            return self._make_chat_request(request)
         else:
-            return self._make_completion_request(request)
+            return self._make_chat_request(request)
+
+
+class OpenAILegacyCompletionsClient(OpenAIClient):
+    def make_request(self, request: Request) -> RequestResult:
+        return self._make_completion_request(request)

--- a/src/helm/clients/palmyra_client.py
+++ b/src/helm/clients/palmyra_client.py
@@ -163,6 +163,3 @@ class PalmyraChatClient(OpenAIClient):
             org_id=None,
             base_url="https://api.writer.com/v1/chat",
         )
-
-    def _is_chat_model_engine(self, model_engine: str) -> bool:
-        return True

--- a/src/helm/clients/vllm_client.py
+++ b/src/helm/clients/vllm_client.py
@@ -2,12 +2,14 @@ from typing import Any, Dict, Optional
 
 from helm.common.cache import CacheConfig
 from helm.common.request import Request
-from helm.clients.openai_client import OpenAIClient
+from helm.clients.openai_client import OpenAILegacyCompletionsClient
 from helm.tokenizers.tokenizer import Tokenizer
 
 
-class VLLMClient(OpenAIClient):
+class VLLMClient(OpenAILegacyCompletionsClient):
     """Sends request to a vLLM server using the OpenAI-compatible API.
+
+    Only supports the legacy Text Completions API, rather than the Chat Completions API.
 
     See: https://docs.vllm.ai/en/latest/getting_started/quickstart.html#openai-compatible-server"""
 
@@ -28,10 +30,6 @@ class VLLMClient(OpenAIClient):
         )
         self.tokenizer = tokenizer
         self.tokenizer_name = tokenizer_name
-
-    def _is_chat_model_engine(self, model_engine: str) -> bool:
-        # Only support vLLM completion models for now.
-        return False
 
     def _get_model_for_request(self, request: Request) -> str:
         # The `model` parameter for vLLM should be the whole model name including the creator organization,

--- a/src/helm/clients/yi_client.py
+++ b/src/helm/clients/yi_client.py
@@ -26,6 +26,3 @@ class YiChatClient(OpenAIClient):
             org_id=None,
             base_url=YiChatClient.BASE_URL,
         )
-
-    def _is_chat_model_engine(self, model_engine: str) -> bool:
-        return True

--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -1596,7 +1596,7 @@ model_deployments:
     # to provide a margin of error.
     max_sequence_length: 16000
     client_spec:
-      class_name: "helm.clients.openai_client.OpenAIClient"
+      class_name: "helm.clients.openai_client.OpenAILegacyCompletionsClient"
 
   - name: openai/babbage-002
     model_name: openai/babbage-002
@@ -1605,7 +1605,7 @@ model_deployments:
     # to provide a margin of error.
     max_sequence_length: 16000
     client_spec:
-      class_name: "helm.clients.openai_client.OpenAIClient"
+      class_name: "helm.clients.openai_client.OpenAILegacyCompletionsClient"
 
   ## GPT 3.5 Turbo Models
   # ChatGPT: https://openai.com/blog/chatgpt
@@ -1616,7 +1616,7 @@ model_deployments:
     max_sequence_length: 4096
     max_request_length: 4097
     client_spec:
-      class_name: "helm.clients.openai_client.OpenAIClient"
+      class_name: "helm.clients.openai_client.OpenAILegacyCompletionsClient"
 
   # The claimed sequence length is 4096, but as of 2023-03-07, the empirical usable
   # sequence length is smaller at 4087 with one user input message and one assistant


### PR DESCRIPTION
- Make `OpenAIClient` use the chat completion API by default
- Require users of the legacy completions API to use the new `OpenAILegacyCompletionsClient` class instead
- Move known users of the legacy completions API to `OpenAILegacyCompletionsClient` i.e. `babbage-002`, `davinci-002`, `gpt-3.5-turbo-instruct` and `VLLMClient`