### PR TITLE
Add support for Granite 3.0 model family (IBM)

### DIFF
--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -2757,3 +2757,12 @@ model_deployments:
       class_name: "helm.clients.huggingface_client.HuggingFaceClient"
       args:
         pretrained_model_name_or_path: ibm-granite/granite-3.0-3b-a800m-base
+
+    - name: huggingface/granite-3.0-1b-a400m-instruct
+    model_name: ibm-granite/granite-3.0-1b-a400m-instruct
+    tokenizer_name: ibm-granite/granite-3.0-1b-a400m-instruct
+    max_sequence_length: 4096
+    client_spec:
+      class_name: "helm.clients.huggingface_client.HuggingFaceClient"
+      args:
+        pretrained_model_name_or_path: ibm-granite/granite-3.0-1b-a400m-instruct

--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -2703,7 +2703,7 @@ model_deployments:
     client_spec:
       class_name: "helm.clients.audio_language.llama_omni_client.LlamaOmniAudioLMClient"
 
-# IBM - GRANITE 2B BASE
+# IBM - Granite 3.0
   - name: huggingface/granite-3.0-2b-base
     model_name: ibm-granite/granite-3.0-2b-base
     tokenizer_name: ibm-granite/granite-3.0-2b-base
@@ -2712,8 +2712,16 @@ model_deployments:
       class_name: "helm.clients.huggingface_client.HuggingFaceClient"
       args:
         pretrained_model_name_or_path: ibm-granite/granite-3.0-2b-base 
+    
+  - name: huggingface/granite-3.0-2b-instruct
+    model_name: ibm-granite/granite-3.0-2b-instruct
+    tokenizer_name: ibm-granite/granite-3.0-2b-instruct
+    max_sequence_length: 4096
+    client_spec:
+      class_name: "helm.clients.huggingface_client.HuggingFaceClient"
+      args:
+        pretrained_model_name_or_path: ibm-granite/granite-3.0-2b-instruct
 
-# IBM - GRANITE 8B INSTRUCT
   - name: huggingface/granite-3.0-8b-instruct
     model_name: ibm-granite/granite-3.0-8b-instruct
     tokenizer_name: ibm-granite/granite-3.0-8b-instruct
@@ -2722,3 +2730,4 @@ model_deployments:
       class_name: "helm.clients.huggingface_client.HuggingFaceClient"
       args:
         pretrained_model_name_or_path: ibm-granite/granite-3.0-2b-base
+ 

--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -2766,3 +2766,12 @@ model_deployments:
       class_name: "helm.clients.huggingface_client.HuggingFaceClient"
       args:
         pretrained_model_name_or_path: ibm-granite/granite-3.0-1b-a400m-instruct
+
+    - name: huggingface/granite-3.0-1b-a400m-base
+    model_name: ibm-granite/granite-3.0-1b-a400m-base
+    tokenizer_name: ibm-granite/granite-3.0-1b-a400m-base
+    max_sequence_length: 4096
+    client_spec:
+      class_name: "helm.clients.huggingface_client.HuggingFaceClient"
+      args:
+        pretrained_model_name_or_path: ibm-granite/granite-3.0-1b-a400m-base

--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -2748,3 +2748,12 @@ model_deployments:
       class_name: "helm.clients.huggingface_client.HuggingFaceClient"
       args:
         pretrained_model_name_or_path: ibm-granite/granite-3.0-3b-a800m-instruct
+
+  - name: huggingface/granite-3.0-3b-a800m-base
+    model_name: ibm-granite/granite-3.0-3b-a800m-base
+    tokenizer_name: ibm-granite/granite-3.0-3b-a800m-base
+    max_sequence_length: 4096
+    client_spec:
+      class_name: "helm.clients.huggingface_client.HuggingFaceClient"
+      args:
+        pretrained_model_name_or_path: ibm-granite/granite-3.0-3b-a800m-base

--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -2712,3 +2712,13 @@ model_deployments:
       class_name: "helm.clients.huggingface_client.HuggingFaceClient"
       args:
         pretrained_model_name_or_path: ibm-granite/granite-3.0-2b-base 
+
+# IBM - GRANITE 8B INSTRUCT
+  - name: huggingface/granite-3.0-8b-instruct
+    model_name: ibm-granite/granite-3.0-8b-instruct
+    tokenizer_name: ibm-granite/granite-3.0-8b-instruct
+    max_sequence_length: 4096
+    client_spec:
+      class_name: "helm.clients.huggingface_client.HuggingFaceClient"
+      args:
+        pretrained_model_name_or_path: ibm-granite/granite-3.0-2b-base

--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -2758,7 +2758,7 @@ model_deployments:
       args:
         pretrained_model_name_or_path: ibm-granite/granite-3.0-3b-a800m-base
 
-    - name: huggingface/granite-3.0-1b-a400m-instruct
+  - name: huggingface/granite-3.0-1b-a400m-instruct
     model_name: ibm-granite/granite-3.0-1b-a400m-instruct
     tokenizer_name: ibm-granite/granite-3.0-1b-a400m-instruct
     max_sequence_length: 4096
@@ -2767,7 +2767,7 @@ model_deployments:
       args:
         pretrained_model_name_or_path: ibm-granite/granite-3.0-1b-a400m-instruct
 
-    - name: huggingface/granite-3.0-1b-a400m-base
+  - name: huggingface/granite-3.0-1b-a400m-base
     model_name: ibm-granite/granite-3.0-1b-a400m-base
     tokenizer_name: ibm-granite/granite-3.0-1b-a400m-base
     max_sequence_length: 4096

--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -2729,5 +2729,13 @@ model_deployments:
     client_spec:
       class_name: "helm.clients.huggingface_client.HuggingFaceClient"
       args:
-        pretrained_model_name_or_path: ibm-granite/granite-3.0-2b-base
- 
+        pretrained_model_name_or_path: ibm-granite/granite-3.0-8b-instruct
+  
+  - name: huggingface/granite-3.0-8b-base
+    model_name: ibm-granite/granite-3.0-8b-base
+    tokenizer_name: ibm-granite/granite-3.0-8b-base
+    max_sequence_length: 4096
+    client_spec:
+      class_name: "helm.clients.huggingface_client.HuggingFaceClient"
+      args:
+        pretrained_model_name_or_path: ibm-granite/granite-3.0-8b-base

--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -2702,3 +2702,13 @@ model_deployments:
     max_sequence_length: 8192
     client_spec:
       class_name: "helm.clients.audio_language.llama_omni_client.LlamaOmniAudioLMClient"
+
+# IBM - GRANITE 2B BASE
+  - name: huggingface/granite-3.0-2b-base
+    model_name: ibm-granite/granite-3.0-2b-base
+    tokenizer_name: ibm-granite/granite-3.0-2b-base
+    max_sequence_length: 4096
+    client_spec:
+      class_name: "helm.clients.huggingface_client.HuggingFaceClient"
+      args:
+        pretrained_model_name_or_path: ibm-granite/granite-3.0-2b-base 

--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -2739,3 +2739,12 @@ model_deployments:
       class_name: "helm.clients.huggingface_client.HuggingFaceClient"
       args:
         pretrained_model_name_or_path: ibm-granite/granite-3.0-8b-base
+
+  - name: huggingface/granite-3.0-3b-a800m-instruct
+    model_name: ibm-granite/granite-3.0-3b-a800m-instruct
+    tokenizer_name: ibm-granite/granite-3.0-3b-a800m-instruct
+    max_sequence_length: 4096
+    client_spec:
+      class_name: "helm.clients.huggingface_client.HuggingFaceClient"
+      args:
+        pretrained_model_name_or_path: ibm-granite/granite-3.0-3b-a800m-instruct

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -3329,7 +3329,7 @@ models:
     access: open
     num_parameters: 2530000000
     release: 2024-10-21
-    tags: [TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
+    tags: [TEXT_MODEL_TAG]
 
   - name: ibm-granite/granite-3.0-2b-instruct
     display_name: Granite 3.0 Instruct (2B)
@@ -3356,7 +3356,7 @@ models:
     access: open
     num_parameters: 8170000000
     release: 2024-10-21
-    tags: [TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
+    tags: [TEXT_MODEL_TAG]
 
   - name: ibm-granite/granite-3.0-3b-a800m-instruct
     display_name: Granite 3.0 A800M instruct (3B)
@@ -3374,7 +3374,7 @@ models:
     access: open
     num_parameters: 3370000000
     release: 2024-10-21
-    tags: [TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
+    tags: [TEXT_MODEL_TAG]
 
   - name: ibm-granite/granite-3.0-1b-a400m-instruct
     display_name: Granite 3.0 A400M instruct (1B)
@@ -3392,4 +3392,4 @@ models:
     access: open
     num_parameters: 1380000000
     release: 2024-10-21
-    tags: [TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
+    tags: [TEXT_MODEL_TAG]

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -3374,9 +3374,17 @@ models:
     tags: [TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
 
     - name: ibm-granite/granite-3.0-1b-a400m-instruct
-    display_name: Granite 3.0 A400M base (1B)
+    display_name: Granite 3.0 A400M instruct (1B)
     description: Granite-3.0-1B-A400M-Instruct is an 1B parameter model finetuned from Granite-3.0-1B-A400M-Base using a combination of open source instruction datasets with permissive license and internally collected synthetic datasets.
     access: open
     num_parameters: 1330000000
+    release: 2024-10-21
+    tags: [TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
+
+    - name: ibm-granite/granite-3.0-1b-a400m-base
+    display_name: Granite 3.0 A400M base (1B)
+    description: Granite-3.0-1B-A400M-Base is a decoder-only language model to support a variety of text-to-text generation tasks. It is trained from scratch following a two-stage training strategy.
+    access: open
+    num_parameters: 1380000000
     release: 2024-10-21
     tags: [TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -3348,3 +3348,11 @@ models:
     num_parameters: 8170000000
     release: 2024-10-21
     tags: [TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
+
+    - name: ibm-granite/granite-3.0-8b-base
+    display_name: Granite 3.0 base (8B)
+    description: Granite-3.0-8B-Base is a decoder-only language model to support a variety of text-to-text generation tasks. 
+    access: open
+    num_parameters: 8170000000
+    release: 2024-10-21
+    tags: [TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -3349,41 +3349,46 @@ models:
     release: 2024-10-21
     tags: [TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
 
-    - name: ibm-granite/granite-3.0-8b-base
+  - name: ibm-granite/granite-3.0-8b-base
     display_name: Granite 3.0 base (8B)
-    description: Granite-3.0-8B-Base is a decoder-only language model to support a variety of text-to-text generation tasks. 
+    description: Granite-3.0-8B-Base is a decoder-only language model to support a variety of text-to-text generation tasks.
+    creator_organization_name: IBM 
     access: open
     num_parameters: 8170000000
     release: 2024-10-21
     tags: [TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
 
-    - name: ibm-granite/granite-3.0-3b-a800m-instruct
+  - name: ibm-granite/granite-3.0-3b-a800m-instruct
     display_name: Granite 3.0 A800M instruct (3B)
     description: Granite-3.0-3B-A800M-Instruct is a 3B parameter model finetuned from Granite-3.0-3B-A800M-Base-4K using a combination of open source instruction datasets with permissive license and internally collected synthetic datasets.
+    creator_organization_name: IBM
     access: open
     num_parameters: 3370000000
     release: 2024-10-21
     tags: [TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
 
-    - name: ibm-granite/granite-3.0-3b-a800m-base
+  - name: ibm-granite/granite-3.0-3b-a800m-base
     display_name: Granite 3.0 A800M base (3B)
     description: Granite-3.0-3B-A800M-Base is a decoder-only language model to support a variety of text-to-text generation tasks.
+    creator_organization_name: IBM
     access: open
     num_parameters: 3370000000
     release: 2024-10-21
     tags: [TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
 
-    - name: ibm-granite/granite-3.0-1b-a400m-instruct
+  - name: ibm-granite/granite-3.0-1b-a400m-instruct
     display_name: Granite 3.0 A400M instruct (1B)
     description: Granite-3.0-1B-A400M-Instruct is an 1B parameter model finetuned from Granite-3.0-1B-A400M-Base using a combination of open source instruction datasets with permissive license and internally collected synthetic datasets.
+    creator_organization_name: IBM
     access: open
     num_parameters: 1330000000
     release: 2024-10-21
     tags: [TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
 
-    - name: ibm-granite/granite-3.0-1b-a400m-base
+  - name: ibm-granite/granite-3.0-1b-a400m-base
     display_name: Granite 3.0 A400M base (1B)
     description: Granite-3.0-1B-A400M-Base is a decoder-only language model to support a variety of text-to-text generation tasks. It is trained from scratch following a two-stage training strategy.
+    creator_organization_name: IBM
     access: open
     num_parameters: 1380000000
     release: 2024-10-21

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -3329,3 +3329,14 @@ models:
     num_parameters: 2530000000
     release: 2024-10-21
     tags: [TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
+
+# Granite3.0 8B Instruct
+
+  - name: ibm-granite/granite-3.0-8b-instruct
+    display_name: Granite 3.0 instruct (8B)
+    description:  Granite-3.0-8B-Instruct is a 8B parameter model finetuned from Granite-3.0-8B-Base using a combination of open source instruction datasets with permissive license and internally collected synthetic datasets.
+    creator_organization_name: IBM
+    access: open
+    num_parameters: 8170000000
+    release: 2024-10-21
+    tags: [TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -3321,6 +3321,7 @@ models:
 # Granite - IBM
 # https://www.ibm.com/granite
 # https://github.com/ibm-granite/granite-3.0-language-models
+
   - name: ibm-granite/granite-3.0-2b-base
     display_name: Granite 3.0 base (2B)
     description: Granite-3.0-2B-Base is a decoder-only language model to support a variety of text-to-text generation tasks.
@@ -3330,7 +3331,14 @@ models:
     release: 2024-10-21
     tags: [TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
 
-# Granite3.0 8B Instruct
+  - name: ibm-granite/granite-3.0-2b-instruct
+    display_name: Granite 3.0 Instruct (2B)
+    description:  Granite-3.0-2B-Instruct is a 2B parameter model finetuned from Granite-3.0-2B-Base using a combination of open source instruction datasets with permissive license and internally collected synthetic datasets. 
+    creator_organization_name: IBM
+    access: open
+    num_parameters: 2630000000
+    release: 2024-10-21
+    tags: [TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
 
   - name: ibm-granite/granite-3.0-8b-instruct
     display_name: Granite 3.0 instruct (8B)

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -3372,3 +3372,11 @@ models:
     num_parameters: 3370000000
     release: 2024-10-21
     tags: [TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
+
+    - name: ibm-granite/granite-3.0-1b-a400m-instruct
+    display_name: Granite 3.0 A400M base (1B)
+    description: Granite-3.0-1B-A400M-Instruct is an 1B parameter model finetuned from Granite-3.0-1B-A400M-Base using a combination of open source instruction datasets with permissive license and internally collected synthetic datasets.
+    access: open
+    num_parameters: 1330000000
+    release: 2024-10-21
+    tags: [TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -224,7 +224,7 @@ models:
   # References for Amazon Titan models:
   # - https://aws.amazon.com/bedrock/titan/
   # - https://community.aws/content/2ZUVD3fkNtqEOYIa2iUJAFArS7c/family-of-titan-text-models---cli-demo
-  # - https://aws.amazon.com/about-aws/whats-new/2023/11/amazon-titan-models-express-lite-bedrock/
+  # - https://aws.amazon.com/about-aws/whats-new/2023/11/amamodelszon-titan-models-express-lite-bedrock/
   - name: amazon/titan-text-lite-v1
     display_name: Amazon Titan Text Lite
     description: Amazon Titan Text Lite is a lightweight, efficient model perfect for fine-tuning English-language tasks like summarization and copywriting. It caters to customers seeking a smaller, cost-effective, and highly customizable model. It supports various formats, including text generation, code generation, rich text formatting, and orchestration (agents). Key model attributes encompass fine-tuning, text generation, code generation, and rich text formatting.
@@ -3317,3 +3317,15 @@ models:
     num_parameters: 8000000000
     release_date: 2024-09-10
     tags: [AUDIO_LANGUAGE_MODEL_TAG]
+
+# Granite - IBM
+# https://www.ibm.com/granite
+# https://github.com/ibm-granite/granite-3.0-language-models
+  - name: ibm-granite/granite-3.0-2b-base
+    display_name: Granite 3.0 base (2B)
+    description: Granite-3.0-2B-Base is a decoder-only language model to support a variety of text-to-text generation tasks.
+    creator_organization_name: IBM
+    access: open
+    num_parameters: 2530000000
+    release: 2024-10-21
+    tags: [TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -224,7 +224,7 @@ models:
   # References for Amazon Titan models:
   # - https://aws.amazon.com/bedrock/titan/
   # - https://community.aws/content/2ZUVD3fkNtqEOYIa2iUJAFArS7c/family-of-titan-text-models---cli-demo
-  # - https://aws.amazon.com/about-aws/whats-new/2023/11/amamodelszon-titan-models-express-lite-bedrock/
+  # - https://aws.amazon.com/about-aws/whats-new/2023/11/amazon-titan-models-express-lite-bedrock/
   - name: amazon/titan-text-lite-v1
     display_name: Amazon Titan Text Lite
     description: Amazon Titan Text Lite is a lightweight, efficient model perfect for fine-tuning English-language tasks like summarization and copywriting. It caters to customers seeking a smaller, cost-effective, and highly customizable model. It supports various formats, including text generation, code generation, rich text formatting, and orchestration (agents). Key model attributes encompass fine-tuning, text generation, code generation, and rich text formatting.
@@ -3360,6 +3360,14 @@ models:
     - name: ibm-granite/granite-3.0-3b-a800m-instruct
     display_name: Granite 3.0 A800M instruct (3B)
     description: Granite-3.0-3B-A800M-Instruct is a 3B parameter model finetuned from Granite-3.0-3B-A800M-Base-4K using a combination of open source instruction datasets with permissive license and internally collected synthetic datasets.
+    access: open
+    num_parameters: 3370000000
+    release: 2024-10-21
+    tags: [TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
+
+    - name: ibm-granite/granite-3.0-3b-a800m-base
+    display_name: Granite 3.0 A800M base (3B)
+    description: Granite-3.0-3B-A800M-Base is a decoder-only language model to support a variety of text-to-text generation tasks.
     access: open
     num_parameters: 3370000000
     release: 2024-10-21

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -3356,3 +3356,11 @@ models:
     num_parameters: 8170000000
     release: 2024-10-21
     tags: [TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
+
+    - name: ibm-granite/granite-3.0-3b-a800m-instruct
+    display_name: Granite 3.0 A800M instruct (3B)
+    description: Granite-3.0-3B-A800M-Instruct is a 3B parameter model finetuned from Granite-3.0-3B-A800M-Base-4K using a combination of open source instruction datasets with permissive license and internally collected synthetic datasets.
+    access: open
+    num_parameters: 3370000000
+    release: 2024-10-21
+    tags: [TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]

--- a/src/helm/config/tokenizer_configs.yaml
+++ b/src/helm/config/tokenizer_configs.yaml
@@ -632,16 +632,24 @@ tokenizer_configs:
     end_of_text_token: "<|eot_id|>"
     prefix_token: "<|begin_of_text|>"
 
-  # Huggingface IBM
+  # IBM - Granite 3.0
   - name: ibm-granite/granite-3.0-2b-base
     tokenizer_spec:
       class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
       args:
         pretrained_model_name_or_path: ibm-granite/granite-3.0-2b-base
-    end_of_text_token: "<|endoftext|>"
-    prefix_token: "<|endoftext|>"
+    end_of_text_token: ""
+    prefix_token: ""
+
   
-  # Hugginface IBM - Granite 3.0 instruct (8B)
+  - name: ibm-granite/granite-3.0-2b-instruct
+    tokenizer_spec:
+      class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
+      args:
+        pretrained_model_name_or_path: ibm-granite/granite-3.0-2b-instruct
+    end_of_text_token: ""
+    prefix_token: ""
+  
   - name: ibm-granite/granite-3.0-8b-instruct
     tokenizer_spec:
       class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"

--- a/src/helm/config/tokenizer_configs.yaml
+++ b/src/helm/config/tokenizer_configs.yaml
@@ -631,3 +631,12 @@ tokenizer_configs:
         trust_remote_code: false
     end_of_text_token: "<|eot_id|>"
     prefix_token: "<|begin_of_text|>"
+
+  # Huggingface IBM
+  - name: ibm-granite/granite-3.0-2b-base
+    tokenizer_spec:
+      class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
+      args:
+        pretrained_model_name_or_path: ibm-granite/granite-3.0-2b-base
+    end_of_text_token: "<|endoftext|>"
+    prefix_token: "<|endoftext|>"

--- a/src/helm/config/tokenizer_configs.yaml
+++ b/src/helm/config/tokenizer_configs.yaml
@@ -673,3 +673,11 @@ tokenizer_configs:
         pretrained_model_name_or_path: ibm-granite/granite-3.0-3b-a800m-instruct
     end_of_text_token: ""
     prefix_token: ""
+
+    - name: ibm-granite/granite-3.0-3b-a800m-base
+    tokenizer_spec:
+      class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
+      args:
+        pretrained_model_name_or_path: ibm-granite/granite-3.0-3b-a800m-base
+    end_of_text_token: ""
+    prefix_token: ""

--- a/src/helm/config/tokenizer_configs.yaml
+++ b/src/helm/config/tokenizer_configs.yaml
@@ -657,3 +657,11 @@ tokenizer_configs:
         pretrained_model_name_or_path: ibm-granite/granite-3.0-8b-instruct
     end_of_text_token: ""
     prefix_token: ""
+
+    - name: ibm-granite/granite-3.0-8b-base
+    tokenizer_spec:
+      class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
+      args:
+        pretrained_model_name_or_path: ibm-granite/granite-3.0-8b-base
+    end_of_text_token: ""
+    prefix_token: ""

--- a/src/helm/config/tokenizer_configs.yaml
+++ b/src/helm/config/tokenizer_configs.yaml
@@ -647,5 +647,5 @@ tokenizer_configs:
       class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
       args:
         pretrained_model_name_or_path: ibm-granite/granite-3.0-8b-instruct
-    end_of_text_token: "<|endoftext|>"
-    prefix_token: "<|endoftext|>"
+    end_of_text_token: ""
+    prefix_token: ""

--- a/src/helm/config/tokenizer_configs.yaml
+++ b/src/helm/config/tokenizer_configs.yaml
@@ -640,3 +640,12 @@ tokenizer_configs:
         pretrained_model_name_or_path: ibm-granite/granite-3.0-2b-base
     end_of_text_token: "<|endoftext|>"
     prefix_token: "<|endoftext|>"
+  
+  # Hugginface IBM - Granite 3.0 instruct (8B)
+  - name: ibm-granite/granite-3.0-8b-instruct
+    tokenizer_spec:
+      class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
+      args:
+        pretrained_model_name_or_path: ibm-granite/granite-3.0-8b-instruct
+    end_of_text_token: "<|endoftext|>"
+    prefix_token: "<|endoftext|>"

--- a/src/helm/config/tokenizer_configs.yaml
+++ b/src/helm/config/tokenizer_configs.yaml
@@ -641,7 +641,6 @@ tokenizer_configs:
     end_of_text_token: ""
     prefix_token: ""
 
-  
   - name: ibm-granite/granite-3.0-2b-instruct
     tokenizer_spec:
       class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
@@ -658,7 +657,7 @@ tokenizer_configs:
     end_of_text_token: ""
     prefix_token: ""
 
-    - name: ibm-granite/granite-3.0-8b-base
+  - name: ibm-granite/granite-3.0-8b-base
     tokenizer_spec:
       class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
       args:
@@ -666,7 +665,7 @@ tokenizer_configs:
     end_of_text_token: ""
     prefix_token: ""
 
-    - name: ibm-granite/granite-3.0-3b-a800m-instruct
+  - name: ibm-granite/granite-3.0-3b-a800m-instruct
     tokenizer_spec:
       class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
       args:
@@ -674,7 +673,7 @@ tokenizer_configs:
     end_of_text_token: ""
     prefix_token: ""
 
-    - name: ibm-granite/granite-3.0-3b-a800m-base
+  - name: ibm-granite/granite-3.0-3b-a800m-base
     tokenizer_spec:
       class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
       args:
@@ -682,7 +681,7 @@ tokenizer_configs:
     end_of_text_token: ""
     prefix_token: ""
 
-    - name: ibm-granite/granite-3.0-1b-a400m-instruct
+  - name: ibm-granite/granite-3.0-1b-a400m-instruct
     tokenizer_spec:
       class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
       args:
@@ -690,7 +689,7 @@ tokenizer_configs:
     end_of_text_token: ""
     prefix_token: ""
 
-    - name: ibm-granite/granite-3.0-1b-a400m-base
+  - name: ibm-granite/granite-3.0-1b-a400m-base
     tokenizer_spec:
       class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
       args:

--- a/src/helm/config/tokenizer_configs.yaml
+++ b/src/helm/config/tokenizer_configs.yaml
@@ -681,3 +681,11 @@ tokenizer_configs:
         pretrained_model_name_or_path: ibm-granite/granite-3.0-3b-a800m-base
     end_of_text_token: ""
     prefix_token: ""
+
+    - name: ibm-granite/granite-3.0-1b-a400m-instruct
+    tokenizer_spec:
+      class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
+      args:
+        pretrained_model_name_or_path: ibm-granite/granite-3.0-1b-a400m-instruct
+    end_of_text_token: ""
+    prefix_token: ""

--- a/src/helm/config/tokenizer_configs.yaml
+++ b/src/helm/config/tokenizer_configs.yaml
@@ -689,3 +689,11 @@ tokenizer_configs:
         pretrained_model_name_or_path: ibm-granite/granite-3.0-1b-a400m-instruct
     end_of_text_token: ""
     prefix_token: ""
+
+    - name: ibm-granite/granite-3.0-1b-a400m-base
+    tokenizer_spec:
+      class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
+      args:
+        pretrained_model_name_or_path: ibm-granite/granite-3.0-1b-a400m-base
+    end_of_text_token: ""
+    prefix_token: ""

--- a/src/helm/config/tokenizer_configs.yaml
+++ b/src/helm/config/tokenizer_configs.yaml
@@ -665,3 +665,11 @@ tokenizer_configs:
         pretrained_model_name_or_path: ibm-granite/granite-3.0-8b-base
     end_of_text_token: ""
     prefix_token: ""
+
+    - name: ibm-granite/granite-3.0-3b-a800m-instruct
+    tokenizer_spec:
+      class_name: "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer"
+      args:
+        pretrained_model_name_or_path: ibm-granite/granite-3.0-3b-a800m-instruct
+    end_of_text_token: ""
+    prefix_token: ""


### PR DESCRIPTION
# Description
This Pull Request adds support for both the base and instruct versions of the Granite 3.0 model family developed by IBM, which are released as open-source on the Hugging Face platform. These additions expand the options available for various NLP tasks and text generation scenarios.
# Main Changes
Added both base and instruct models from the Granite 3.0 family (open-source) to the list of supported models.
Adjusted configuration files to accommodate the specific parameters for these new models.
# Benchmarks Conducted
Benchmarks executed: The Granite 3.0 models, including both the base and instruct versions, were tested on various benchmarks, including MMLU (Massive Multitask Language Understanding), where they demonstrated competitive performance compared to other models of similar scale.