### PR TITLE
Replace hardcoded "benchmark_output"

### DIFF
--- a/src/helm/benchmark/augmentations/cleva_perturbation.py
+++ b/src/helm/benchmark/augmentations/cleva_perturbation.py
@@ -11,6 +11,7 @@ from helm.common.optional_dependencies import handle_module_not_found_error
 from helm.benchmark.scenarios.scenario import Input, Instance, Reference, Output
 from helm.benchmark.augmentations.perturbation_description import PerturbationDescription
 from helm.benchmark.augmentations.perturbation import Perturbation, TextPerturbation
+from helm.benchmark.runner import get_benchmark_output_path
 
 
 ############################################################
@@ -69,7 +70,7 @@ class ChineseTyposPerturbation(TextPerturbation):
         self.word_level_perturb: bool = word_level_perturb  # Whether we perturb text on the character or word level
 
         # Ensure all necessary data are downloaded
-        output_dir = os.path.join("benchmark_output", "perturbations", self.name)
+        output_dir = os.path.join(get_benchmark_output_path(), "perturbations", self.name)
         ensure_directory_exists(output_dir)
         for filename in self.FILE_NAMES:
             target_path = os.path.join(output_dir, filename)
@@ -303,7 +304,7 @@ class ChineseSynonymPerturbation(TextPerturbation):
         self.prob: float = prob
         self.trial_num: int = trial_num  # Number of trial to get a 100% perturbed text
 
-        target_dir = os.path.join("benchmark_output", "perturbations", self.name, "synonyms.json")
+        target_dir = os.path.join(get_benchmark_output_path(), "perturbations", self.name, "synonyms.json")
         ensure_directory_exists(os.path.dirname(target_dir))
         ensure_file_downloaded(source_url=self.SOURCE_URL, target_path=target_dir)
         with open(os.path.join(target_dir)) as f:
@@ -433,7 +434,7 @@ class ChineseGenderPerturbation(TextPerturbation):
         if self.mode == self.GENDER_TERM:
             self.term_dict: Dict[Tuple[str, str], Dict[str, str]] = defaultdict(dict)
 
-            target_path = os.path.join("benchmark_output", "perturbations", self.name, "gender_term.txt")
+            target_path = os.path.join(get_benchmark_output_path(), "perturbations", self.name, "gender_term.txt")
             ensure_directory_exists(os.path.dirname(target_path))
             ensure_file_downloaded(source_url=self.SOURCE_URL, target_path=target_path)
             with open(target_path) as fin:
@@ -492,7 +493,7 @@ class ChinesePersonNamePerturbation(Perturbation):
 
     """ Resources """
     SOURCE_URL: str = "http://39.108.215.175/assets/chinese_name_gender.json"
-    OUTPUT_PATH = os.path.join("benchmark_output", "perturbations", name)
+    OUTPUT_PATH = os.path.join(get_benchmark_output_path(), "perturbations", name)
 
     """ Gender categories """
     GENDER_CATEGORY = "gender"
@@ -554,7 +555,7 @@ class ChinesePersonNamePerturbation(Perturbation):
 
         self.preserve_gender: bool = preserve_gender
 
-        target_path = os.path.join("benchmark_output", "perturbations", self.name, "chinese_name_gender.json")
+        target_path = os.path.join(get_benchmark_output_path(), "perturbations", self.name, "chinese_name_gender.json")
         ensure_directory_exists(os.path.dirname(target_path))
         ensure_file_downloaded(source_url=self.SOURCE_URL, target_path=target_path)
         with open(os.path.join(target_path), "r", encoding="utf-8") as f:
@@ -735,7 +736,7 @@ class MandarinToCantonesePerturbation(TextPerturbation):
             handle_module_not_found_error(e, ["cleva"])
         self.s2t_converter = opencc.OpenCC("s2t.json")
 
-        target_path = os.path.join("benchmark_output", "perturbations", self.name, "conversion.json")
+        target_path = os.path.join(get_benchmark_output_path(), "perturbations", self.name, "conversion.json")
         ensure_directory_exists(os.path.dirname(target_path))
         ensure_file_downloaded(source_url=self.SOURCE_URL, target_path=target_path)
         with open(target_path) as fin:

--- a/src/helm/benchmark/augmentations/dialect_perturbation.py
+++ b/src/helm/benchmark/augmentations/dialect_perturbation.py
@@ -75,8 +75,6 @@ class DialectPerturbation(TextPerturbation):
                 self.MAPPING_DICTS for the provided source and target classes
                 will be used, if available.
         """
-        # TODO: Update path so it is not hard-coded to benchmark_output
-        # https://github.com/stanford-crfm/benchmarking/issues/493
         self.output_path: str = self.OUTPUT_PATH
         Path(self.output_path).mkdir(parents=True, exist_ok=True)
 

--- a/src/helm/benchmark/augmentations/dialect_perturbation.py
+++ b/src/helm/benchmark/augmentations/dialect_perturbation.py
@@ -9,6 +9,7 @@ from typing import Dict, Optional, List
 from helm.common.general import match_case, ensure_file_downloaded
 from helm.benchmark.augmentations.perturbation_description import PerturbationDescription
 from helm.benchmark.augmentations.perturbation import TextPerturbation
+from helm.benchmark.runner import get_benchmark_output_path
 
 
 class DialectPerturbation(TextPerturbation):
@@ -20,7 +21,7 @@ class DialectPerturbation(TextPerturbation):
     should_perturb_references: bool = True
 
     """ Output path to store external files and folders """
-    OUTPUT_PATH = os.path.join("benchmark_output", "perturbations", name)
+    OUTPUT_PATH = os.path.join(get_benchmark_output_path(), "perturbations", name)
 
     """ Dictionary mapping dialects to one another """
     SAE = "SAE"

--- a/src/helm/benchmark/augmentations/person_name_perturbation.py
+++ b/src/helm/benchmark/augmentations/person_name_perturbation.py
@@ -11,6 +11,7 @@ from helm.benchmark.scenarios.scenario import Input, Instance, Reference, Output
 from helm.common.general import ensure_file_downloaded, ensure_directory_exists, match_case
 from helm.benchmark.augmentations.perturbation_description import PerturbationDescription
 from helm.benchmark.augmentations.perturbation import Perturbation
+from helm.benchmark.runner import get_benchmark_output_path
 
 
 # Pull this out so serialization works for multiprocessing
@@ -35,7 +36,7 @@ class PersonNamePerturbation(Perturbation):
         "https://storage.googleapis.com/crfm-helm-public/source_datasets/"
         "augmentations/person_name_perturbation/person_names.txt"
     )
-    OUTPUT_PATH = os.path.join("benchmark_output", "perturbations", name)
+    OUTPUT_PATH = os.path.join(get_benchmark_output_path(), "perturbations", name)
 
     """ Name types """
     FIRST_NAME = "first_name"
@@ -153,8 +154,6 @@ class PersonNamePerturbation(Perturbation):
                 find the gender association for a source_word, we randomly
                 pick from one of the target names.
         """
-        # TODO: Update path so it is not hard-coded to benchmark_output
-        # https://github.com/stanford-crfm/benchmarking/issues/493
         self.output_path: str = self.OUTPUT_PATH
         Path(self.output_path).mkdir(parents=True, exist_ok=True)
 

--- a/src/helm/benchmark/augmentations/synonym_perturbation.py
+++ b/src/helm/benchmark/augmentations/synonym_perturbation.py
@@ -12,6 +12,7 @@ import spacy
 from helm.common.general import match_case, ensure_file_downloaded
 from helm.benchmark.augmentations.perturbation_description import PerturbationDescription
 from helm.benchmark.augmentations.perturbation import TextPerturbation
+from helm.benchmark.runner import get_benchmark_output_path
 
 
 class SynonymPerturbation(TextPerturbation):
@@ -57,7 +58,7 @@ class SynonymPerturbation(TextPerturbation):
             spacy.cli.download("en_core_web_sm")  # type: ignore
             self.spacy_model = spacy.load("en_core_web_sm")
 
-        output_dir = os.path.join("benchmark_output", "perturbations", self.name)
+        output_dir = os.path.join(get_benchmark_output_path(), "perturbations", self.name)
         Path(output_dir).mkdir(parents=True, exist_ok=True)
         nltk.data.path.append(output_dir)
         try:

--- a/src/helm/benchmark/metrics/cleva_harms_metrics.py
+++ b/src/helm/benchmark/metrics/cleva_harms_metrics.py
@@ -20,6 +20,7 @@ from helm.benchmark.metrics.copyright_metrics import BasicCopyrightMetric
 from helm.benchmark.metrics.metric_name import MetricName
 from helm.benchmark.metrics.metric_service import MetricService
 from helm.benchmark.metrics.statistic import Stat
+from helm.benchmark.runner import get_benchmark_output_path
 
 try:
     import jieba
@@ -71,7 +72,7 @@ class CLEVABiasMetric(BiasMetric):
                   "demographic_category". One of "adjective" or "profession".
         """
         # Ensure all necessary data are downloaded
-        self.output_dir = os.path.join("benchmark_output", "metrics", self.name)
+        self.output_dir = os.path.join(get_benchmark_output_path(), "metrics", self.name)
         ensure_directory_exists(self.output_dir)
         for filename in self.FILE_NAMES:
             target_path = os.path.join(self.output_dir, filename)

--- a/src/helm/benchmark/scenarios/code_scenario.py
+++ b/src/helm/benchmark/scenarios/code_scenario.py
@@ -302,7 +302,10 @@ class CodeScenario(Scenario):
         self.human_eval_hparams = dict(num_train_instances=0, num_val_instances=0, num_test_instances=164)
 
     def get_instances(self, output_path: str) -> List[Instance]:
-        # By construction, output_path == 'benchmark_output/scenarios/code'.
+        # By construction, output_path == args.output_path + '/scenarios/code'
+        # where args.output_path is parsed from the command line argument.
+        # The default self.output_path here is '/benchmark_output/scenarios/ice'.
+        # See helm.benchmark.runner for more details about args.output_path.
         if self.dataset == "humaneval":
             target_path = os.path.join(output_path, "HumanEval.jsonl")
             ensure_file_downloaded(

--- a/src/helm/benchmark/scenarios/dialogue_scenarios.py
+++ b/src/helm/benchmark/scenarios/dialogue_scenarios.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional
 
 from helm.common.general import ensure_file_downloaded
 from helm.common.hierarchical_logger import hlog
+from helm.benchmark.runner import get_benchmark_output_path
 from helm.benchmark.scenarios.scenario import (
     Scenario,
     Instance,
@@ -148,5 +149,5 @@ class EmpatheticDialoguesScenario(Scenario):
 
 if __name__ == "__main__":
     scenario = EmpatheticDialoguesScenario()
-    instances = scenario.get_instances("./benchmark_output/scenarios/empatheticdialogues")
+    instances = scenario.get_instances(os.path.join(get_benchmark_output_path(), "scenarios/empatheticdialogues"))
     print(instances[100])

--- a/src/helm/benchmark/scenarios/ice_scenario.py
+++ b/src/helm/benchmark/scenarios/ice_scenario.py
@@ -114,8 +114,12 @@ class ICEScenario(Scenario):
     """
     The International Corpus of English (ICE).
 
-    NOTE: This text cannot be downloaded
-    automatically. You must extract each subset zip file into /benchmark_output/scenarios/ice.
+    NOTE: This text cannot be downloaded automatically.
+    You must extract each subset zip file into args.output_path + '/scenarios/ice',
+    which is by default '/benchmark_output/scenarios/ice',
+    where args.output_path is parsed from the command line argument.
+    See helm.benchmark.runner for more details about args.output_path.
+
     The archives should extract into folders named according to the dictionary SUBSET_TO_DIRECTORY
     below.
 


### PR DESCRIPTION
Replace hardcoded "benchmark_output" In 
- `person_name_perturbation`, `cleva_perturbation`, `synonym_perturbation`, `cleva_harms_metrics`, `dialogue_scenarios`, `dialect_perturbation` 
- as well as comments in `ice_scenario` and `code_scenario`

Related (#493 )(#1918)

Found hardcoded "benchmark_output" by
```shell
find ./src/helm -type f -name "*.py" -exec grep -n "benchmark_output" {} + | grep -v "benchmark_output_path"
```

There could be a similar issue in `./benchmark/server.py`, but haven't investigated further about it.
```shell
./benchmark/server.py:138:        # Output path is a location on disk, so set the output path base URL to /benchmark_output
./benchmark/server.py:142:        app.config["helm.outputurl"] = "benchmark_output"
```