### PR TITLE
Add Air-Bench chat audio scenario

### DIFF
--- a/src/helm/benchmark/presentation/run_entries_speech.conf
+++ b/src/helm/benchmark/presentation/run_entries_speech.conf
@@ -6,6 +6,10 @@ entries: [
     {description: "vocal_sound:model=audiolm", priority: 1}
     {description: "audiocaps:model=audiolm", priority: 1}
     {description: "voxceleb2:model=audiolm", priority: 1}
+    {description: "air_bench_chat:subject=speech,model=audiolm", priority: 1}
+    {description: "air_bench_chat:subject=sound,model=audiolm", priority: 1}
+    {description: "air_bench_chat:subject=music,model=audiolm", priority: 1}
+    {description: "air_bench_chat:subject=mix,model=audiolm", priority: 1}
 
     ####################################################################################################################
     # Fairness

--- a/src/helm/benchmark/run_specs/audio_run_specs.py
+++ b/src/helm/benchmark/run_specs/audio_run_specs.py
@@ -373,3 +373,23 @@ def get_casual_conversations2_run_spec(subject: str) -> RunSpec:
         metric_specs=metric_specs,
         groups=[run_spec_name],
     )
+
+
+@run_spec_function("air_bench_chat")
+def get_air_bench_chat_run_spec(subject: str) -> RunSpec:
+    scenario_spec = ScenarioSpec(
+        class_name="helm.benchmark.scenarios.audio_language.air_bench_chat_scenario." "AirBenchChatScenario",
+        args={"subject": subject},
+    )
+    adapter_spec = _get_generation_adapter_spec(
+        max_tokens=50,
+    )
+    metric_specs: List[MetricSpec] = _get_open_ended_generation_metric_specs()
+    run_spec_name: str = "air_bench_chat"
+    return RunSpec(
+        name=f"{run_spec_name}:subject={subject}",
+        scenario_spec=scenario_spec,
+        adapter_spec=adapter_spec,
+        metric_specs=metric_specs,
+        groups=[run_spec_name],
+    )

--- a/src/helm/benchmark/scenarios/audio_language/air_bench_chat_scenario.py
+++ b/src/helm/benchmark/scenarios/audio_language/air_bench_chat_scenario.py
@@ -97,10 +97,10 @@ class AirBenchChatScenario(Scenario):
                 self.HF_DATA_PATH_PREFIX,
                 f'{audio_meda_data["task_name"]}_{audio_meda_data["dataset_name"]}/{audio_meda_data["path"]}',
             )
-            loacal_audio_file_path = os.path.join(
+            local_audio_file_path = os.path.join(
                 data_dir, f'{audio_meda_data["task_name"]}_{audio_meda_data["dataset_name"]}_{audio_meda_data["path"]}'
             )
-            ensure_file_downloaded(source_url=hf_audio_file_path, target_path=loacal_audio_file_path)
+            ensure_file_downloaded(source_url=hf_audio_file_path, target_path=local_audio_file_path)
             input = Input(
                 multimedia_content=MultimediaObject(
                     [

--- a/src/helm/benchmark/scenarios/audio_language/air_bench_chat_scenario.py
+++ b/src/helm/benchmark/scenarios/audio_language/air_bench_chat_scenario.py
@@ -1,0 +1,117 @@
+from typing import List
+import os
+
+from helm.benchmark.scenarios.scenario import (
+    Scenario,
+    Instance,
+    Reference,
+    TEST_SPLIT,
+    CORRECT_TAG,
+    Input,
+    Output,
+)
+from tqdm import tqdm
+from helm.common.media_object import MediaObject, MultimediaObject
+from helm.common.general import ensure_file_downloaded
+import json
+
+
+class AirBenchChatScenario(Scenario):
+    """Air-Bench Chat
+
+    Air-Bench AIR-Bench (Audio InstRuction Benchmark) is a benchmark designed to evaluate the ability of audio language
+    models to understand various types of audio signals (including human speech, natural sounds and music), and
+    furthermore, to interact with humans in textual format. AIR-Bench encompasses two dimensions: foundation
+    and chat benchmarks. The former consists of 19 tasks with approximately 19k single-choice questions. The
+    latter one contains 2k instances of open-ended question-and-answer data. We consider the chat benchmark
+    in this scenario.
+
+    Paper: https://aclanthology.org/2024.acl-long.109.pdf
+    Code: https://github.com/OFA-Sys/AIR-Bench
+
+    Citation:
+    @inproceedings{yang-etal-2024-air,
+    title = "{AIR}-Bench: Benchmarking Large Audio-Language Models via Generative Comprehension",
+    author = "Yang, Qian  and
+      Xu, Jin  and
+      Liu, Wenrui  and
+      Chu, Yunfei  and
+      Jiang, Ziyue  and
+      Zhou, Xiaohuan  and
+      Leng, Yichong  and
+      Lv, Yuanjun  and
+      Zhao, Zhou  and
+      Zhou, Chang  and
+      Zhou, Jingren",
+    booktitle = "Proceedings of the 62nd Annual Meeting of the Association for Computational
+        Linguistics (Volume 1: Long Papers)",
+    year = "2024",}
+    """
+
+    HF_DATA_PATH_PREFIX = "https://huggingface.co/datasets/qyang1021/AIR-Bench-Dataset/resolve/main/Chat"
+    META_DATA_FILE_PATH = "https://huggingface.co/datasets/qyang1021/AIR-Bench-Dataset/resolve/main/Chat/Chat_meta.json"
+    SUJECTS = ["music", "sound", "speech", "mix"]
+
+    name = "air_bench_chat"
+    description = "A large-scale dataset of about 46K audio clips to human-written text pairs \
+        ([Yang et al, 2024](https://aclanthology.org/2024.acl-long.109.pdf))."
+    tags: List[str] = ["audio", "reasoning"]
+
+    def __init__(self, subject: str) -> None:
+        super().__init__()
+
+        if subject not in AirBenchChatScenario.SUJECTS:
+            raise ValueError(f"Invalid subject. Valid subjects are: {AirBenchChatScenario.SUJECTS}")
+
+        self._subject: str = subject
+
+    def _get_subject_indices(self, meta_data) -> List[int]:
+        subject_indices = []
+        for idx, line in enumerate(meta_data):
+            if self._subject == "mix":
+                if "_".join(line["task_name"].split("_")[:2]) == "speech_and":
+                    subject_indices.append(idx)
+            else:
+                if line["task_name"].split("_")[0] == self._subject and line["task_name"].split("_")[1] != "and":
+                    subject_indices.append(idx)
+        return subject_indices
+
+    def _get_content_type(self, audio_file_name) -> str:
+        if audio_file_name.endswith(".wav"):
+            return "audio/wav"
+        elif audio_file_name.endswith(".mp3"):
+            return "audio/mp3"
+        else:
+            raise ValueError(f"Unsupported audio file format: {audio_file_name}")
+
+    def get_instances(self, output_path: str) -> List[Instance]:
+        instances: List[Instance] = []
+        data_dir: str = os.path.join(output_path, "wav_files")
+        meta_data_path: str = os.path.join(output_path, "Chat_meta.json")
+        ensure_file_downloaded(source_url=AirBenchChatScenario.META_DATA_FILE_PATH, target_path=meta_data_path)
+        meta_data = json.load(open(meta_data_path))
+        subject_indices = self._get_subject_indices(meta_data)
+        for _, row in enumerate(tqdm(subject_indices)):
+            audio_meda_data = meta_data[row]
+            hf_audio_file_path = os.path.join(
+                self.HF_DATA_PATH_PREFIX,
+                f'{audio_meda_data["task_name"]}_{audio_meda_data["dataset_name"]}/{audio_meda_data["path"]}',
+            )
+            loacal_audio_file_path = os.path.join(
+                data_dir, f'{audio_meda_data["task_name"]}_{audio_meda_data["dataset_name"]}_{audio_meda_data["path"]}'
+            )
+            ensure_file_downloaded(source_url=hf_audio_file_path, target_path=loacal_audio_file_path)
+            input = Input(
+                multimedia_content=MultimediaObject(
+                    [
+                        MediaObject(
+                            content_type=self._get_content_type(audio_meda_data["path"]),
+                            location=loacal_audio_file_path,
+                        ),
+                        MediaObject(content_type="text/plain", text=audio_meda_data["question"]),
+                    ]
+                )
+            )
+            references = [Reference(Output(text=audio_meda_data["answer_gt"]), tags=[CORRECT_TAG])]
+            instances.append(Instance(input=input, references=references, split=TEST_SPLIT))
+        return instances

--- a/src/helm/benchmark/scenarios/audio_language/air_bench_chat_scenario.py
+++ b/src/helm/benchmark/scenarios/audio_language/air_bench_chat_scenario.py
@@ -106,7 +106,7 @@ class AirBenchChatScenario(Scenario):
                     [
                         MediaObject(
                             content_type=self._get_content_type(audio_meda_data["path"]),
-                            location=loacal_audio_file_path,
+                            location=local_audio_file_path,
                         ),
                         MediaObject(content_type="text/plain", text=audio_meda_data["question"]),
                     ]

--- a/src/helm/benchmark/static/schema_speech.yaml
+++ b/src/helm/benchmark/static/schema_speech.yaml
@@ -195,7 +195,6 @@ run_groups:
       audio sample ([Becker et al, 2023](https://arxiv.org/abs/1807.03418)).
     metric_groups:
       - accuracy
-      - efficiency
       - general_information
     environment:
       main_name: exact_match
@@ -219,7 +218,6 @@ run_groups:
       ([Wang et al, 2020](https://arxiv.org/abs/2007.10310)).
     metric_groups:
       - accuracy
-      - efficiency
       - general_information
     environment:
       main_name: bleu
@@ -241,7 +239,6 @@ run_groups:
       age, gender, native language, country, and health condition ([Gong et al, 2022](https://arxiv.org/abs/2205.03433)).
     metric_groups:
       - accuracy
-      - efficiency
       - general_information
     environment:
       main_name: exact_match
@@ -263,7 +260,6 @@ run_groups:
       Dutch, German, French, Spanish, Italian, Portuguese", Polish ([Pratap et al, 2022](https://arxiv.org/abs/2012.03411)).
     metric_groups:
       - accuracy
-      - efficiency
       - general_information
     environment:
       main_name: f1_score
@@ -288,7 +284,6 @@ run_groups:
       South Asian, South East Asian, Chinese Japanase Korean ([Conneau et al, 2022](https://arxiv.org/abs/2205.12446)).
     metric_groups:
       - accuracy
-      - efficiency
       - general_information
     environment:
       main_name: exact_match
@@ -353,7 +348,6 @@ run_groups:
       ([Ardila et al, 2020](https://arxiv.org/abs/1912.06670)).
     metric_groups:
       - accuracy
-      - efficiency
       - general_information
     environment:
       main_name: word_accuracy
@@ -378,7 +372,6 @@ run_groups:
       ([Shah et al, 2024](https://arxiv.org/abs/2403.07937)).
     metric_groups:
       - accuracy
-      - efficiency
       - general_information
     environment:
       main_name: word_accuracy
@@ -401,7 +394,6 @@ run_groups:
       The dataset contains the audio and question for three subsets: occupation, status, and potential_crime.
     metric_groups:
       - accuracy
-      - efficiency
       - general_information
     environment:
       main_name: exact_match
@@ -427,7 +419,6 @@ run_groups:
       questions answering task.
     metric_groups:
       - accuracy
-      - efficiency
       - general_information
     environment:
       main_name: exact_match
@@ -438,3 +429,26 @@ run_groups:
       who: real speakers
       when: "2023"
       language: 10 languages
+
+  - name: air_bench_chat
+    display_name: Air-Bench Chat
+    description: >
+      Air-Bench (Yang et al, 2024) encompasses two dimensions: foundation and chat benchmarks. The former consists of 19 tasks with 
+      approximately 19k single-choice questions. The latter one contains 2k instances of open-ended question-and-answer data. 
+      We consider the chat benchmark in this scenario.
+
+      The dataset contains the audio question answering task in four subjects: sound, speech, music, and mixed.
+      ([Yang et al, 2024](https://aclanthology.org/2024.acl-long.109.pdf)).
+    metric_groups:
+      - accuracy
+      - general_information
+      - reasoning
+    environment:
+      main_name: f1_score
+      main_split: test
+    taxonomy:
+      task: audio question answering
+      what: adio, question, and answer of audio samples
+      who: real speakers
+      when: "2024"
+      language: English


### PR DESCRIPTION
Add Air-Bench chat (https://arxiv.org/abs/2402.07729). This benchmark consists of four different aspects for evaluation: sound, speech, music and mixed, which was employed by the Qwen2-audio paper for eval.