### PR TITLE
Use standard library importlib.resources

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -117,7 +117,6 @@ identify==2.6.1
 idna==3.10
 ImageHash==4.3.1
 imageio==2.35.1
-importlib-resources==5.13.0
 importlib_metadata==8.5.0
 iniconfig==2.0.0
 jax==0.4.30

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,9 +29,8 @@ install_requires=
     # Common
     cattrs~=22.2
     dacite~=1.6
-    importlib-resources~=5.10
     Mako~=1.2
-    numpy~=1.26,<3
+    numpy>=1.26,<3
     pandas~=2.0
     pyhocon~=0.3.59
     retrying~=1.3

--- a/src/helm/benchmark/config_registry.py
+++ b/src/helm/benchmark/config_registry.py
@@ -1,5 +1,5 @@
 import os
-from importib import resources
+from importlib import resources
 
 from helm.benchmark.model_deployment_registry import register_model_deployments_from_path
 from helm.benchmark.model_metadata_registry import register_model_metadata_from_path

--- a/src/helm/benchmark/config_registry.py
+++ b/src/helm/benchmark/config_registry.py
@@ -1,5 +1,5 @@
 import os
-import importlib_resources as resources
+import importib.resources as resources
 
 from helm.benchmark.model_deployment_registry import register_model_deployments_from_path
 from helm.benchmark.model_metadata_registry import register_model_metadata_from_path

--- a/src/helm/benchmark/config_registry.py
+++ b/src/helm/benchmark/config_registry.py
@@ -1,5 +1,5 @@
 import os
-import importib.resources as resources
+from importib import resources
 
 from helm.benchmark.model_deployment_registry import register_model_deployments_from_path
 from helm.benchmark.model_metadata_registry import register_model_metadata_from_path

--- a/src/helm/benchmark/metrics/efficiency_metrics.py
+++ b/src/helm/benchmark/metrics/efficiency_metrics.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Optional
 
 import json
-import importib.resources as resources
+from importib import resources
 
 from helm.common.hierarchical_logger import hlog
 from helm.benchmark.adaptation.request_state import RequestState

--- a/src/helm/benchmark/metrics/efficiency_metrics.py
+++ b/src/helm/benchmark/metrics/efficiency_metrics.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Optional
 
 import json
-from importib import resources
+from importlib import resources
 
 from helm.common.hierarchical_logger import hlog
 from helm.benchmark.adaptation.request_state import RequestState

--- a/src/helm/benchmark/metrics/efficiency_metrics.py
+++ b/src/helm/benchmark/metrics/efficiency_metrics.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Optional
 
 import json
-import importlib_resources as resources
+import importib.resources as resources
 
 from helm.common.hierarchical_logger import hlog
 from helm.benchmark.adaptation.request_state import RequestState

--- a/src/helm/benchmark/presentation/contamination.py
+++ b/src/helm/benchmark/presentation/contamination.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import List, Optional
 import dacite
-from importib import resources
+from importlib import resources
 import yaml
 
 from helm.common.hierarchical_logger import htrack, hlog

--- a/src/helm/benchmark/presentation/contamination.py
+++ b/src/helm/benchmark/presentation/contamination.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import List, Optional
 import dacite
-import importib.resources as resources
+from importib import resources
 import yaml
 
 from helm.common.hierarchical_logger import htrack, hlog

--- a/src/helm/benchmark/presentation/contamination.py
+++ b/src/helm/benchmark/presentation/contamination.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import List, Optional
 import dacite
-import importlib_resources as resources
+import importib.resources as resources
 import yaml
 
 from helm.common.hierarchical_logger import htrack, hlog

--- a/src/helm/benchmark/presentation/schema.py
+++ b/src/helm/benchmark/presentation/schema.py
@@ -6,7 +6,7 @@ import dacite
 from inspect import cleandoc
 import mako.template
 import yaml
-import importlib_resources as resources
+import importib.resources as resources
 
 from helm.common.general import hlog
 from helm.benchmark.metrics.metric_name import MetricName

--- a/src/helm/benchmark/presentation/schema.py
+++ b/src/helm/benchmark/presentation/schema.py
@@ -6,7 +6,7 @@ import dacite
 from inspect import cleandoc
 import mako.template
 import yaml
-from importib import resources
+from importlib import resources
 
 from helm.common.general import hlog
 from helm.benchmark.metrics.metric_name import MetricName
@@ -238,7 +238,7 @@ def get_adapter_fields() -> List[Field]:
     # Unfortunately there is no standard library support for getting docstrings of class fields,
     # so we have to do the parsing outselves. Fortunately, the parsing is quite straightforward.
     adapter_spec_path = resources.files(_ADAPTER_SPEC_PACKAGE).joinpath(_ADAPTER_SPEC_FILENAME)
-    with open(adapter_spec_path, "r") as f:
+    with adapter_spec_path.open("r") as f:
         contents = f.read()
     module_node = ast.parse(contents)
     adapter_spec_node = [
@@ -271,7 +271,7 @@ def get_adapter_fields() -> List[Field]:
 
 
 def get_default_schema_path() -> str:
-    return resources.files(SCHEMA_YAML_PACKAGE).joinpath(SCHEMA_CLASSIC_YAML_FILENAME)
+    return str(resources.files(SCHEMA_YAML_PACKAGE).joinpath(SCHEMA_CLASSIC_YAML_FILENAME))
 
 
 def read_schema(schema_path: str) -> Schema:

--- a/src/helm/benchmark/presentation/schema.py
+++ b/src/helm/benchmark/presentation/schema.py
@@ -6,7 +6,7 @@ import dacite
 from inspect import cleandoc
 import mako.template
 import yaml
-import importib.resources as resources
+from importib import resources
 
 from helm.common.general import hlog
 from helm.benchmark.metrics.metric_name import MetricName

--- a/src/helm/benchmark/server.py
+++ b/src/helm/benchmark/server.py
@@ -4,7 +4,7 @@ Starts a local HTTP server to display benchmarking assets.
 """
 
 import argparse
-from importib import resources
+from importlib import resources
 import json
 from os import path
 import urllib

--- a/src/helm/benchmark/server.py
+++ b/src/helm/benchmark/server.py
@@ -4,7 +4,7 @@ Starts a local HTTP server to display benchmarking assets.
 """
 
 import argparse
-import importib.resources as resources
+from importib import resources
 import json
 from os import path
 import urllib

--- a/src/helm/benchmark/server.py
+++ b/src/helm/benchmark/server.py
@@ -4,7 +4,7 @@ Starts a local HTTP server to display benchmarking assets.
 """
 
 import argparse
-import importlib_resources as resources
+import importib.resources as resources
 import json
 from os import path
 import urllib

--- a/src/helm/tokenizers/yalm_tokenizer_data/yalm_tokenizer.py
+++ b/src/helm/tokenizers/yalm_tokenizer_data/yalm_tokenizer.py
@@ -1,5 +1,5 @@
 # mypy: check_untyped_defs = False
-import importib.resources as resources
+from importib import resources
 
 from helm.common.optional_dependencies import handle_module_not_found_error
 

--- a/src/helm/tokenizers/yalm_tokenizer_data/yalm_tokenizer.py
+++ b/src/helm/tokenizers/yalm_tokenizer_data/yalm_tokenizer.py
@@ -1,5 +1,5 @@
 # mypy: check_untyped_defs = False
-from importib import resources
+from importlib import resources
 
 from helm.common.optional_dependencies import handle_module_not_found_error
 

--- a/src/helm/tokenizers/yalm_tokenizer_data/yalm_tokenizer.py
+++ b/src/helm/tokenizers/yalm_tokenizer_data/yalm_tokenizer.py
@@ -1,5 +1,5 @@
 # mypy: check_untyped_defs = False
-import importlib_resources as resources
+import importib.resources as resources
 
 from helm.common.optional_dependencies import handle_module_not_found_error
 


### PR DESCRIPTION
We previously used `importlib-resources` as a backport of the standard library `importlib.resources` to earlier versions of Python. We now use >=Python 3.9, so we can replace all uses with the standard library `importlib.resources` instead.