### PR TITLE
Shorten run spec names for Unitxt runs

### DIFF
--- a/src/helm/benchmark/run_specs/unitxt_run_specs.py
+++ b/src/helm/benchmark/run_specs/unitxt_run_specs.py
@@ -1,3 +1,5 @@
+import os
+
 from helm.benchmark.adaptation.adapter_spec import ADAPT_GENERATION, AdapterSpec
 from helm.benchmark.metrics.metric import MetricSpec
 from helm.benchmark.metrics.common_metric_specs import get_basic_metric_specs
@@ -10,7 +12,12 @@ def get_unitxt_spec(**kwargs) -> RunSpec:
     card = kwargs.get("card")
     if not card:
         raise Exception("Unitxt card must be specified")
-    name_suffix = ",".join([f"{key}={value}" for key, value in kwargs.items()])
+    if os.environ.get("HELM_UNITXT_SHORTEN_RUN_SPEC_NAMES", "").lower() == "true":
+        name_suffix = ",".join(
+            [f"{key}={value}" for key, value in kwargs.items() if key not in ["template_card_index", "loader_limit"]]
+        )
+    else:
+        name_suffix = ",".join([f"{key}={value}" for key, value in kwargs.items()])
     name = f"unitxt:{name_suffix}"
     scenario_spec = ScenarioSpec(class_name="helm.benchmark.scenarios.unitxt_scenario.UnitxtScenario", args=kwargs)
     adapter_spec = AdapterSpec(


### PR DESCRIPTION
Unitxt run spec names can be so long that they cause "File name too long" errors (since the output subdirectory is named after the run spec name). To work around this, if the `HELM_UNITXT_SHORTEN_RUN_SPEC_NAMES` environment variable is set, we drop some unneeded key-value pairs from the run spec name.