### PR TITLE
Limit anthropic to <0.39

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -135,7 +135,7 @@ amazon =
     botocore~=1.31.57
 
 anthropic =
-    anthropic~=0.17
+    anthropic~=0.17,<0.39  # TODO(#3212): Limit anthropic to >=0.39 after resolving #3212.
     websocket-client~=1.3.2  # For legacy stanford-online-all-v4-s3
 
 cohere =


### PR DESCRIPTION
Workaround to avoid breaking API changes in version of 0.39.0 `anthropic`.

Addresses #3212