### PR TITLE
Simplify credential management for Bedrock client

### DIFF
--- a/src/helm/clients/bedrock_client.py
+++ b/src/helm/clients/bedrock_client.py
@@ -47,7 +47,7 @@ class BedrockClient(CachingClient):
         self.tokenizer_name = tokenizer_name
         self.bedrock_client = get_bedrock_client(
             assumed_role=assumed_role or os.environ.get("BEDROCK_ASSUME_ROLE", None),
-            region=region or os.environ.get("AWS_DEFAULT_REGION", None),
+            region=region,
         )
 
     def make_request(self, request: Request) -> RequestResult:

--- a/src/helm/clients/bedrock_client.py
+++ b/src/helm/clients/bedrock_client.py
@@ -113,7 +113,7 @@ class BedrockNovaClient(CachingClient):
         self.tokenizer = tokenizer
         self.tokenizer_name = tokenizer_name
         self.bedrock_client = get_bedrock_client_v1(
-            assumed_role=assumed_role,
+            assumed_role=assumed_role or os.environ.get("BEDROCK_ASSUME_ROLE", None),
             region=region,
         )
 

--- a/src/helm/clients/bedrock_client.py
+++ b/src/helm/clients/bedrock_client.py
@@ -39,14 +39,12 @@ class BedrockClient(CachingClient):
         cache_config: CacheConfig,
         tokenizer: Tokenizer,
         tokenizer_name: str,
-        bedrock_model_id: Optional[str] = None,
         assumed_role: Optional[str] = None,
         region: Optional[str] = None,
     ):
         super().__init__(cache_config=cache_config)
         self.tokenizer = tokenizer
         self.tokenizer_name = tokenizer_name
-        self.bedrock_model_id = bedrock_model_id
         self.bedrock_client = get_bedrock_client(
             assumed_role=assumed_role or os.environ.get("BEDROCK_ASSUME_ROLE", None),
             region=region or os.environ.get("AWS_DEFAULT_REGION", None),
@@ -108,17 +106,15 @@ class BedrockNovaClient(CachingClient):
         cache_config: CacheConfig,
         tokenizer: Tokenizer,
         tokenizer_name: str,
-        bedrock_model_id: Optional[str] = None,
         assumed_role: Optional[str] = None,
         region: Optional[str] = None,
     ):
         super().__init__(cache_config=cache_config)
         self.tokenizer = tokenizer
         self.tokenizer_name = tokenizer_name
-        self.bedrock_model_id = bedrock_model_id
         self.bedrock_client = get_bedrock_client_v1(
-            assumed_role=assumed_role or os.environ.get("BEDROCK_ASSUME_ROLE", None),
-            region=region or os.environ.get("AWS_DEFAULT_REGION", None),
+            assumed_role=assumed_role,
+            region=region,
         )
 
     def convert_request_to_raw_request(self, request: Request) -> Dict:

--- a/src/helm/clients/bedrock_utils.py
+++ b/src/helm/clients/bedrock_utils.py
@@ -81,7 +81,9 @@ def get_bedrock_client_v1(
     connect_timeout: int = 5000,
     max_attempts: int = 10,
 ):
-    boto_config = Config(read_timeout=read_timeout, connect_timeout=connect_timeout, retries={"max_attempts": max_attempts})
+    boto_config = Config(
+        read_timeout=read_timeout, connect_timeout=connect_timeout, retries={"max_attempts": max_attempts}
+    )
 
     if assumed_role:
         session = boto3.Session(region_name=region)

--- a/src/helm/clients/bedrock_utils.py
+++ b/src/helm/clients/bedrock_utils.py
@@ -1,7 +1,7 @@
 """Helper utilities for working with Amazon Bedrock."""
 
 import os
-from typing import Optional, Dict
+from typing import Optional
 
 from helm.common.hierarchical_logger import hlog
 from helm.common.optional_dependencies import handle_module_not_found_error

--- a/src/helm/clients/bedrock_utils.py
+++ b/src/helm/clients/bedrock_utils.py
@@ -74,9 +74,9 @@ def get_bedrock_client(
 
 
 def get_bedrock_client_v1(
-    assumed_role: Optional[str] = None,
-    service_name: str = "bedrock-runtime",
     region: Optional[str] = None,
+    service_name: str = "bedrock-runtime",
+    assumed_role: Optional[str] = None,
     read_timeout: int = 5000,
     connect_timeout: int = 5000,
     max_attempts: int = 10,

--- a/src/helm/clients/bedrock_utils.py
+++ b/src/helm/clients/bedrock_utils.py
@@ -93,6 +93,7 @@ def get_bedrock_client_v1(
         session = Session(
             aws_access_key_id=creds["AccessKeyId"],
             aws_secret_access_key=creds["SecretAccessKey"],
+            aws_session_token=creds["SessionToken"],
         )
         return session.client(
             service_name=service_name,


### PR DESCRIPTION
HELM should not fetch the region from the OS environment variables, since overrides other configuration sources that should have precedence (e.g. config files set by `aws configure`), and boto3 already falls back to the OS environment variables internally.