### PR TITLE
Updating request time (inference time) to report in seconds instead of ms

### DIFF
--- a/src/helm/clients/bedrock_client.py
+++ b/src/helm/clients/bedrock_client.py
@@ -140,7 +140,7 @@ class BedrockNovaClient(CachingClient):
         return RequestResult(
             success=True,
             cached=False,
-            request_time=response["metrics"]["latencyMs"],
+            request_time=(response["metrics"]["latencyMs"]/1000),
             request_datetime=int(dt.timestamp()),
             completions=completions,
             embedding=[],


### PR DESCRIPTION
Currently Amazon Nova models are reporting inference time in ms unit, which is not consistent with other models, changing it to report in seconds instead.