### PR TITLE
Improve classification metrics

### DIFF
--- a/src/helm/benchmark/metrics/classification_metrics.py
+++ b/src/helm/benchmark/metrics/classification_metrics.py
@@ -40,7 +40,7 @@ class ClassificationMetric(EvaluateInstancesMetric):
     - Currently, multi-label classification is not supported.
     """
 
-    AVERAGE_OPTIONS = ["micro", "macro", "weighted"]
+    AVERAGE_OPTIONS = ["micro", "macro", "weighted", None]
     SCORE_OPTIONS = ["f1", "precision", "recall"]
 
     def __init__(
@@ -119,7 +119,11 @@ class ClassificationMetric(EvaluateInstancesMetric):
                     raise ValueError(
                         f"Unknown score name: '{score_name}' - expected one of ['f1', 'precision', 'recall']"
                     )
-                stats.append(Stat(MetricName(f"classification_{average}_{score_name}")).add(score_value))
+                if average is None:
+                    for mlb_class, class_score_value in zip(mlb.classes_, score_value):
+                        stats.append(Stat(MetricName(f"classification_{mlb_class}_{score_name}")).add(class_score_value))
+                else:
+                    stats.append(Stat(MetricName(f"classification_{average}_{score_name}")).add(score_value))
         return stats
 
 

--- a/src/helm/benchmark/metrics/classification_metrics.py
+++ b/src/helm/benchmark/metrics/classification_metrics.py
@@ -109,12 +109,8 @@ class ClassificationMetric(EvaluateInstancesMetric):
             predictions = input_text.split(self.delimiter) if self.is_multi_label() else [input_text]
             y_pred.append([_normalize_label_text(pred) for pred in predictions if pred])
         mlb = MultiLabelBinarizer().fit([self.labels] if self.labels else y_true)
-        print(y_true)
         y_true = mlb.transform(y_true)
-        print(y_true)
-        print(y_pred)
         y_pred = mlb.transform(y_pred)
-        print(y_pred)
         stats: List[Stat] = []
         for average in self.averages:
             for score_name in self.scores:

--- a/src/helm/benchmark/metrics/classification_metrics.py
+++ b/src/helm/benchmark/metrics/classification_metrics.py
@@ -121,7 +121,9 @@ class ClassificationMetric(EvaluateInstancesMetric):
                     )
                 if average is None:
                     for mlb_class, class_score_value in zip(mlb.classes_, score_value):
-                        stats.append(Stat(MetricName(f"classification_{mlb_class}_{score_name}")).add(class_score_value))
+                        stats.append(
+                            Stat(MetricName(f"classification_{mlb_class}_{score_name}")).add(class_score_value)
+                        )
                 else:
                     stats.append(Stat(MetricName(f"classification_{average}_{score_name}")).add(score_value))
         return stats

--- a/src/helm/benchmark/metrics/classification_metrics.py
+++ b/src/helm/benchmark/metrics/classification_metrics.py
@@ -54,8 +54,10 @@ class ClassificationMetric(EvaluateInstancesMetric):
 
         :param delimiter: For multi-label classification, the string delimiter between classes in the model's output.
         :param average: The list of scores to compute (e.g. "f1", "precision", "recall").
+          Defaults to ["f1"].
         :param average: The averaging methods (e.g. "micro", "macro", "weighted") to be used.
           It has the same meaning `average` as in scikit-learn.
+          Defaults to ["macro", "micro"].
         :param labels: The set of labels.
         :return: A list of `Stat` objects.
         """

--- a/src/helm/benchmark/metrics/common_metric_specs.py
+++ b/src/helm/benchmark/metrics/common_metric_specs.py
@@ -44,12 +44,23 @@ def get_language_modeling_metric_specs(names: List[str]) -> List[MetricSpec]:
     ]
 
 
-def get_classification_metric_specs(delimiter: Optional[str] = None) -> List[MetricSpec]:
+def get_classification_metric_specs(
+    labels: Optional[List[str]] = None, delimiter: Optional[str] = None
+) -> List[MetricSpec]:
+    extra_args: Dict[str, Any] = {}
+    if labels:
+        extra_args["labels"] = labels
+    if delimiter:
+        extra_args["delimiter"] = delimiter
     return [
         MetricSpec(
             class_name="helm.benchmark.metrics.classification_metrics.ClassificationMetric",
-            args={"delimiter": delimiter},
-        )
+            args={"average": "macro"} | extra_args,
+        ),
+        MetricSpec(
+            class_name="helm.benchmark.metrics.classification_metrics.ClassificationMetric",
+            args={"average": "micro"} | extra_args,
+        ),
     ]
 
 

--- a/src/helm/benchmark/metrics/common_metric_specs.py
+++ b/src/helm/benchmark/metrics/common_metric_specs.py
@@ -55,12 +55,8 @@ def get_classification_metric_specs(
     return [
         MetricSpec(
             class_name="helm.benchmark.metrics.classification_metrics.ClassificationMetric",
-            args={"average": "macro"} | extra_args,
-        ),
-        MetricSpec(
-            class_name="helm.benchmark.metrics.classification_metrics.ClassificationMetric",
-            args={"average": "micro"} | extra_args,
-        ),
+            args=extra_args,
+        )
     ]
 
 

--- a/src/helm/benchmark/metrics/test_classification_metrics.py
+++ b/src/helm/benchmark/metrics/test_classification_metrics.py
@@ -73,7 +73,7 @@ def compute_stats(all_classes_counts: Dict[str, Dict[str, int]]):
         "weighted_f1": weighted_f1,
     }
     for class_name, class_f1_score in class_f1.items():
-        stats[class_name] = class_f1_score
+        stats[f"{class_name}_f1"] = class_f1_score
     return stats
 
 
@@ -97,14 +97,19 @@ def test_evaluate_instances_yes_and_no():
     )
 
     actual_stats = ClassificationMetric(
-        scores=["f1"], averages=["macro", "micro", "weighted"], labels=labels
+        scores=["f1"], averages=["macro", "micro", "weighted", None], labels=labels
     ).evaluate_instances(request_states, "")
+    print(actual_stats)
     actual_macro_f1 = get_stat_value(actual_stats, "classification_macro_f1")
     assert actual_macro_f1 == approx(expected_stats["macro_f1"])
     actual_micro_f1 = get_stat_value(actual_stats, "classification_micro_f1")
     assert actual_micro_f1 == approx(expected_stats["micro_f1"])
     actual_weighted_f1 = get_stat_value(actual_stats, "classification_weighted_f1")
     assert actual_weighted_f1 == approx(expected_stats["weighted_f1"])
+    actual_yes_f1 = get_stat_value(actual_stats, "classification_yes_f1")
+    assert actual_yes_f1 == approx(expected_stats["yes_f1"])
+    actual_no_f1 = get_stat_value(actual_stats, "classification_no_f1")
+    assert actual_no_f1 == approx(expected_stats["no_f1"])
 
 
 def test_evaluate_instances_multi_class():
@@ -135,7 +140,7 @@ def test_evaluate_instances_multi_class():
     )
 
     actual_stats = ClassificationMetric(
-        scores=["f1"], averages=["macro", "micro", "weighted"], labels=labels
+        scores=["f1"], averages=["macro", "micro", "weighted", None], labels=labels
     ).evaluate_instances(request_states, "")
     actual_macro_f1 = get_stat_value(actual_stats, "classification_macro_f1")
     assert actual_macro_f1 == approx(expected_stats["macro_f1"])
@@ -143,6 +148,12 @@ def test_evaluate_instances_multi_class():
     assert actual_micro_f1 == approx(expected_stats["micro_f1"])
     actual_weighted_f1 = get_stat_value(actual_stats, "classification_weighted_f1")
     assert actual_weighted_f1 == approx(expected_stats["weighted_f1"])
+    actual_a_f1 = get_stat_value(actual_stats, "classification_a_f1")
+    assert actual_a_f1 == approx(expected_stats["a_f1"])
+    actual_b_f1 = get_stat_value(actual_stats, "classification_b_f1")
+    assert actual_b_f1 == approx(expected_stats["b_f1"])
+    actual_c_f1 = get_stat_value(actual_stats, "classification_c_f1")
+    assert actual_c_f1 == approx(expected_stats["c_f1"])
 
 
 def test_evaluate_instances_multilabel():
@@ -174,7 +185,7 @@ def test_evaluate_instances_multilabel():
     )
 
     actual_stats = ClassificationMetric(
-        scores=["f1"], averages=["macro", "micro", "weighted"], labels=labels, delimiter=","
+        scores=["f1"], averages=["macro", "micro", "weighted", None], labels=labels, delimiter=","
     ).evaluate_instances(request_states, "")
     actual_macro_f1 = get_stat_value(actual_stats, "classification_macro_f1")
     assert actual_macro_f1 == approx(expected_stats["macro_f1"])
@@ -182,3 +193,9 @@ def test_evaluate_instances_multilabel():
     assert actual_micro_f1 == approx(expected_stats["micro_f1"])
     actual_weighted_f1 = get_stat_value(actual_stats, "classification_weighted_f1")
     assert actual_weighted_f1 == approx(expected_stats["weighted_f1"])
+    actual_a_f1 = get_stat_value(actual_stats, "classification_a_f1")
+    assert actual_a_f1 == approx(expected_stats["a_f1"])
+    actual_b_f1 = get_stat_value(actual_stats, "classification_b_f1")
+    assert actual_b_f1 == approx(expected_stats["b_f1"])
+    actual_c_f1 = get_stat_value(actual_stats, "classification_c_f1")
+    assert actual_c_f1 == approx(expected_stats["c_f1"])

--- a/src/helm/benchmark/metrics/test_classification_metrics.py
+++ b/src/helm/benchmark/metrics/test_classification_metrics.py
@@ -47,7 +47,7 @@ def get_stat_value(stats: List[Stat], stat_name: str):
 
 def compute_stats(all_classes_counts: Dict[str, Dict[str, int]]):
     micro_counts: Dict[str, int] = defaultdict(int)
-    for class_name, class_counts in all_classes_counts.items():
+    for class_counts in all_classes_counts.values():
         for key, class_count in class_counts.items():
             micro_counts[key] += class_count
     micro_precision = micro_counts["tp"] / (micro_counts["tp"] + micro_counts["fp"])

--- a/src/helm/benchmark/metrics/test_classification_metrics.py
+++ b/src/helm/benchmark/metrics/test_classification_metrics.py
@@ -96,20 +96,14 @@ def test_evaluate_instances_yes_and_no():
         }
     )
 
-    actual_macro_f1 = get_stat_value(
-        ClassificationMetric(average="macro", labels=labels).evaluate_instances(request_states, ""),
-        "classification_macro_f1",
-    )
+    actual_stats = ClassificationMetric(
+        scores=["f1"], averages=["macro", "micro", "weighted"], labels=labels
+    ).evaluate_instances(request_states, "")
+    actual_macro_f1 = get_stat_value(actual_stats, "classification_macro_f1")
     assert actual_macro_f1 == approx(expected_stats["macro_f1"])
-    actual_micro_f1 = get_stat_value(
-        ClassificationMetric(average="micro", labels=labels).evaluate_instances(request_states, ""),
-        "classification_micro_f1",
-    )
+    actual_micro_f1 = get_stat_value(actual_stats, "classification_micro_f1")
     assert actual_micro_f1 == approx(expected_stats["micro_f1"])
-    actual_weighted_f1 = get_stat_value(
-        ClassificationMetric(average="weighted", labels=labels).evaluate_instances(request_states, ""),
-        "classification_weighted_f1",
-    )
+    actual_weighted_f1 = get_stat_value(actual_stats, "classification_weighted_f1")
     assert actual_weighted_f1 == approx(expected_stats["weighted_f1"])
 
 
@@ -140,21 +134,15 @@ def test_evaluate_instances_multi_class():
         }
     )
 
-    actual_macro_f1 = get_stat_value(
-        ClassificationMetric(average="macro", labels=labels).evaluate_instances(request_states, ""),
-        "classification_macro_f1",
-    )
+    actual_stats = ClassificationMetric(
+        scores=["f1"], averages=["macro", "micro", "weighted"], labels=labels
+    ).evaluate_instances(request_states, "")
+    actual_macro_f1 = get_stat_value(actual_stats, "classification_macro_f1")
     assert actual_macro_f1 == approx(expected_stats["macro_f1"])
-    actual_micro_f1 = get_stat_value(
-        ClassificationMetric(average="micro", labels=labels).evaluate_instances(request_states, ""),
-        "classification_micro_f1",
-    )
+    actual_micro_f1 = get_stat_value(actual_stats, "classification_micro_f1")
     assert actual_micro_f1 == approx(expected_stats["micro_f1"])
-    weighted_micro_f1 = get_stat_value(
-        ClassificationMetric(average="weighted", labels=labels).evaluate_instances(request_states, ""),
-        "classification_weighted_f1",
-    )
-    assert weighted_micro_f1 == approx(expected_stats["weighted_f1"])
+    actual_weighted_f1 = get_stat_value(actual_stats, "classification_weighted_f1")
+    assert actual_weighted_f1 == approx(expected_stats["weighted_f1"])
 
 
 def test_evaluate_instances_multilabel():
@@ -185,18 +173,12 @@ def test_evaluate_instances_multilabel():
         }
     )
 
-    actual_macro_f1 = get_stat_value(
-        ClassificationMetric(average="macro", labels=labels, delimiter=",").evaluate_instances(request_states, ""),
-        "classification_macro_f1",
-    )
+    actual_stats = ClassificationMetric(
+        scores=["f1"], averages=["macro", "micro", "weighted"], labels=labels, delimiter=","
+    ).evaluate_instances(request_states, "")
+    actual_macro_f1 = get_stat_value(actual_stats, "classification_macro_f1")
     assert actual_macro_f1 == approx(expected_stats["macro_f1"])
-    actual_micro_f1 = get_stat_value(
-        ClassificationMetric(average="micro", labels=labels, delimiter=",").evaluate_instances(request_states, ""),
-        "classification_micro_f1",
-    )
+    actual_micro_f1 = get_stat_value(actual_stats, "classification_micro_f1")
     assert actual_micro_f1 == approx(expected_stats["micro_f1"])
-    actual_micro_f1 = get_stat_value(
-        ClassificationMetric(average="weighted", labels=labels, delimiter=",").evaluate_instances(request_states, ""),
-        "classification_weighted_f1",
-    )
-    assert actual_micro_f1 == approx(expected_stats["weighted_f1"])
+    actual_weighted_f1 = get_stat_value(actual_stats, "classification_weighted_f1")
+    assert actual_weighted_f1 == approx(expected_stats["weighted_f1"])

--- a/src/helm/benchmark/metrics/test_classification_metrics.py
+++ b/src/helm/benchmark/metrics/test_classification_metrics.py
@@ -77,12 +77,37 @@ def compute_stats(all_classes_counts: Dict[str, Dict[str, int]]):
     return stats
 
 
+def test_evaluate_instances_default_parameters():
+    request_states = [
+        _request_state("yes", [_Option("yes", True)]),
+        _request_state("yes ", [_Option("yes", True)]),
+        _request_state("yeS", [_Option("yes", True)]),
+        _request_state("yes", [_Option("no", True)]),
+        _request_state("no", [_Option("yes", True)]),
+        _request_state("no", [_Option("no", True)]),
+        _request_state("invalid", [_Option("no", True)]),
+    ]
+
+    expected_stats = compute_stats(
+        {
+            "yes": {"tp": 3, "fp": 1, "tn": 2, "fn": 1},
+            "no": {"tp": 1, "fp": 1, "tn": 3, "fn": 2},
+        }
+    )
+
+    actual_stats = ClassificationMetric().evaluate_instances(request_states, "")
+    actual_macro_f1 = get_stat_value(actual_stats, "classification_macro_f1")
+    assert actual_macro_f1 == approx(expected_stats["macro_f1"])
+    actual_micro_f1 = get_stat_value(actual_stats, "classification_micro_f1")
+    assert actual_micro_f1 == approx(expected_stats["micro_f1"])
+
+
 def test_evaluate_instances_yes_and_no():
     labels = ["yes", "no"]
     request_states = [
         _request_state("yes", [_Option("yes", True)]),
-        _request_state("yes", [_Option("yes", True)]),
-        _request_state("yes", [_Option("yes", True)]),
+        _request_state("yes ", [_Option("yes", True)]),
+        _request_state("yeS", [_Option("yes", True)]),
         _request_state("yes", [_Option("no", True)]),
         _request_state("no", [_Option("yes", True)]),
         _request_state("no", [_Option("no", True)]),
@@ -99,7 +124,6 @@ def test_evaluate_instances_yes_and_no():
     actual_stats = ClassificationMetric(
         scores=["f1"], averages=["macro", "micro", "weighted", None], labels=labels
     ).evaluate_instances(request_states, "")
-    print(actual_stats)
     actual_macro_f1 = get_stat_value(actual_stats, "classification_macro_f1")
     assert actual_macro_f1 == approx(expected_stats["macro_f1"])
     actual_micro_f1 = get_stat_value(actual_stats, "classification_micro_f1")


### PR DESCRIPTION
- Breaking change: Do not strip articles when normalizing text (previously, this would be bad for a class named "a")
- Allow using different averaging methods for computing classification metrics
- Allow computing precision and recall
- Allow computing per-class classification metrics by using `None` as an averaging method
- Encourage users to explicitly set the labels