### PR TITLE
Add support to redact model outputs

### DIFF
--- a/scripts/redact_scenario_states.py
+++ b/scripts/redact_scenario_states.py
@@ -51,16 +51,20 @@ def redact_instance(instance: Instance) -> Instance:
     redacted_references = [redact_reference(reference) for reference in instance.references]
     return dataclasses.replace(instance, input=redacted_input, references=redacted_references)
 
+
 def redact_request(request: Request) -> Request:
     return dataclasses.replace(request, prompt=REDACTED_STRING, messages=None, multimodal_prompt=None)
+
 
 def redact_output_mapping(output_mapping: Optional[Dict[str, str]]) -> Optional[Dict[str, str]]:
     if output_mapping is None:
         return None
     return {key: REDACTED_STRING for key in output_mapping}
 
+
 def redact_token(token: Token) -> Token:
     return dataclasses.replace(token, text=REDACTED_STRING)
+
 
 def redact_completion(completion: GeneratedOutput) -> GeneratedOutput:
     # Replacing tokens for empty list in case length of completion reveals information about the prompt
@@ -70,6 +74,7 @@ def redact_completion(completion: GeneratedOutput) -> GeneratedOutput:
 def redact_result(result: RequestResult) -> RequestResult:
     redacted_completions = [redact_completion(completion) for completion in result.completions]
     return dataclasses.replace(result, completions=redacted_completions)
+
 
 def redact_request_state(request_state: RequestState, redact_output: bool) -> RequestState:
     result = redact_result(request_state.result) if redact_output else request_state.result

--- a/scripts/redact_scenario_states.py
+++ b/scripts/redact_scenario_states.py
@@ -77,6 +77,7 @@ def redact_result(result: RequestResult) -> RequestResult:
 
 
 def redact_request_state(request_state: RequestState, redact_output: bool) -> RequestState:
+    assert request_state.result is not None
     result = redact_result(request_state.result) if redact_output else request_state.result
     return dataclasses.replace(
         request_state,

--- a/scripts/redact_scenario_states.py
+++ b/scripts/redact_scenario_states.py
@@ -22,7 +22,7 @@ from helm.benchmark.adaptation.scenario_state import ScenarioState
 from helm.benchmark.scenarios.scenario import Instance, Reference
 from helm.common.codec import from_json, to_json
 from helm.common.hierarchical_logger import hlog
-from helm.common.request import Request
+from helm.common.request import Request, RequestResult, GeneratedOutput, Token
 
 
 SCENARIO_STATE_FILE_NAME = "scenario_state.json"
@@ -62,28 +62,42 @@ def redact_output_mapping(output_mapping: Optional[Dict[str, str]]) -> Optional[
     return {key: REDACTED_STRING for key in output_mapping}
 
 
-def redact_request_state(request_state: RequestState) -> RequestState:
+def redact_completion(completion: GeneratedOutput) -> GeneratedOutput:
+    # Replacing tokens for empty list in case length of completion reveals information about the prompt
+    return dataclasses.replace(completion, text=REDACTED_STRING, tokens=[])
+
+
+def redact_result(result: RequestResult) -> RequestResult:
+    redacted_completions = [redact_completion(completion) for completion in result.completions]
+    return dataclasses.replace(result, completions=redacted_completions)
+
+
+def redact_request_state(request_state: RequestState, redact_output: bool) -> RequestState:
+    result = redact_result(request_state.result) if redact_output else request_state.result
     return dataclasses.replace(
         request_state,
         instance=redact_instance(request_state.instance),
         request=redact_request(request_state.request),
         output_mapping=redact_output_mapping(request_state.output_mapping),
+        result=result,
     )
 
 
-def redact_scenario_state(scenario_state: ScenarioState) -> ScenarioState:
-    redacted_request_states = [redact_request_state(request_state) for request_state in scenario_state.request_states]
+def redact_scenario_state(scenario_state: ScenarioState, redact_output: bool) -> ScenarioState:
+    redacted_request_states = [
+        redact_request_state(request_state, redact_output) for request_state in scenario_state.request_states
+    ]
     return dataclasses.replace(scenario_state, request_states=redacted_request_states)
 
 
-def modify_scenario_state_for_run(run_path: str) -> None:
+def modify_scenario_state_for_run(run_path: str, redact_output: bool) -> None:
     scenario_state_path = os.path.join(run_path, SCENARIO_STATE_FILE_NAME)
     scenario_state = read_scenario_state(scenario_state_path)
-    redacted_scenario_state = redact_scenario_state(scenario_state)
+    redacted_scenario_state = redact_scenario_state(scenario_state, redact_output)
     write_scenario_state(scenario_state_path, redacted_scenario_state)
 
 
-def modify_scenario_states_for_suite(run_suite_path: str) -> None:
+def modify_scenario_states_for_suite(run_suite_path: str, redact_output: bool) -> None:
     """Load the runs in the run suite path."""
     # run_suite_path can contain subdirectories that are not runs (e.g. eval_cache, groups)
     # so filter them out.
@@ -100,7 +114,7 @@ def modify_scenario_states_for_suite(run_suite_path: str) -> None:
             hlog(f"WARNING: {run_dir_name} doesn't have {SCENARIO_STATE_FILE_NAME}, skipping")
             continue
         run_path: str = os.path.join(run_suite_path, run_dir_name)
-        modify_scenario_state_for_run(run_path)
+        modify_scenario_state_for_run(run_path, redact_output)
 
 
 def main():
@@ -113,11 +127,13 @@ def main():
         type=str,
         help="Name of the suite this summarization should go under.",
     )
+    parser.add_argument("--redact-output", action="store_true", help="Whether to redact the generated outputs.")
     args = parser.parse_args()
     output_path = args.output_path
     suite = args.suite
+    redact_output = args.redact_output
     run_suite_path = os.path.join(output_path, "runs", suite)
-    modify_scenario_states_for_suite(run_suite_path)
+    modify_scenario_states_for_suite(run_suite_path, redact_output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As part of MedHELM, we need the ability to redact not only the requests, but also the generated responses. This is to prevent PIH data from real patients.