### PR TITLE
Fixes for BigCodeBench Evaluator

### DIFF
--- a/src/helm/benchmark/annotation/annotator_factory.py
+++ b/src/helm/benchmark/annotation/annotator_factory.py
@@ -46,6 +46,7 @@ class AnnotatorFactory:
             },
             provider_bindings={
                 "api_key": lambda: provide_api_key(self.credentials, annotator_name),
+                "endpoint": lambda: self.credentials.get(annotator_name + "Endpoint", None),
                 "file_storage_path": lambda: self._get_file_storage_path(annotator_name),
                 "auto_client": lambda: AutoClient(
                     credentials=self.credentials,

--- a/src/helm/benchmark/annotation/bigcodebench_annotator.py
+++ b/src/helm/benchmark/annotation/bigcodebench_annotator.py
@@ -1,14 +1,15 @@
+from typing import Any, List, Dict, Optional
 import ast
+import json
 import tempfile
 import traceback
-import json
+
+from gradio_client import Client, handle_file
+from retrying import retry
 
 from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.annotation.annotator import Annotator
 from helm.common.hierarchical_logger import hlog
-
-from typing import Any, List, Dict, Optional
-from gradio_client import Client, handle_file
 
 
 # Based on https://github.com/bigcode-project/bigcodebench/blob/0331489b29cbf2653b4669597ef431e158882aab/bigcodebench/syncheck.py#L14  # noqa: E501
@@ -68,6 +69,7 @@ class BigCodeBenchAnnotator(Annotator):
     def annotate(self, request_state: RequestState) -> Any:
         raise NotImplementedError("annotate() is not supported; use annotate_all() instead")
 
+    @retry(stop_max_attempt_number=3, wait_fixed=4000)
     def send_request_to_gradio_evaluator(self, filename: str, task_ids: List[str]):
         if len(task_ids) == self.DATASET_SIZE:
             selective_evaluate = ""

--- a/src/helm/benchmark/annotation/bigcodebench_annotator.py
+++ b/src/helm/benchmark/annotation/bigcodebench_annotator.py
@@ -7,11 +7,11 @@ from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.annotation.annotator import Annotator
 from helm.common.hierarchical_logger import hlog
 
-from typing import Any, Iterable, List, Dict, Optional
+from typing import Any, List, Dict, Optional
 from gradio_client import Client, handle_file
 
 
-# Based on https://github.com/bigcode-project/bigcodebench/blob/0331489b29cbf2653b4669597ef431e158882aab/bigcodebench/syncheck.py#L14
+# Based on https://github.com/bigcode-project/bigcodebench/blob/0331489b29cbf2653b4669597ef431e158882aab/bigcodebench/syncheck.py#L14  # noqa: E501
 # Licensed under Apache 2.0
 def syntax_check(code, verbose=False):
     try:
@@ -23,7 +23,7 @@ def syntax_check(code, verbose=False):
         return False
 
 
-# Based on https://github.com/bigcode-project/bigcodebench/blob/0331489b29cbf2653b4669597ef431e158882aab/bigcodebench/sanitize.py#L30
+# Based on https://github.com/bigcode-project/bigcodebench/blob/0331489b29cbf2653b4669597ef431e158882aab/bigcodebench/sanitize.py#L30  # noqa: E501
 # Licensed under Apache 2.0
 def code_extract(text: str) -> str:
     lines = text.split("\n")
@@ -59,20 +59,20 @@ class BigCodeBenchAnnotator(Annotator):
             hlog(f"BigCodeBenchAnnotator will use the configured endpoint {endpoint}")
             self.client = Client(endpoint, hf_token=api_key)
         else:
-            hlog(f"WARNING: BigCodeBenchAnnotator will use the default public evaluator endpoint {self.DEFAULT_URL} - "
-                 "set bigcodebenchApiKey and bigcodebenchEndpoint in credentials.conf to use a cloned evaluator instead")
+            hlog(
+                f"WARNING: BigCodeBenchAnnotator will use the default public evaluator endpoint {self.DEFAULT_URL} - "
+                "set bigcodebenchApiKey and bigcodebenchEndpoint in credentials.conf to use a cloned evaluator instead"
+            )
             self.client = Client(self.DEFAULT_URL)
-        
 
     def annotate(self, request_state: RequestState) -> Any:
         raise NotImplementedError("annotate() is not supported; use annotate_all() instead")
 
-    def send_request_to_gradio_evaluator(self, filename: str, task_ids: Iterable[str]):
+    def send_request_to_gradio_evaluator(self, filename: str, task_ids: List[str]):
         if len(task_ids) == self.DATASET_SIZE:
             selective_evaluate = ""
         else:
             selective_evaluate = ",".join([task_id.removeprefix("BigCodeBench/") for task_id in task_ids])
-        print(selective_evaluate)
         return self.client.predict(
             split=self.SPLIT,
             subset=self.SUBSET,
@@ -99,9 +99,8 @@ class BigCodeBenchAnnotator(Annotator):
                 for task_id, solution in task_id_to_solution.items():
                     json.dump({"task_id": task_id, "solution": solution}, f)
                     f.write("\n")
-            evaluator_result = self.send_request_to_gradio_evaluator(temp_file.name, task_id_to_solution.keys())[0]
-        print(json.dumps(evaluator_result, indent=2))
+            eval_result = self.send_request_to_gradio_evaluator(temp_file.name, list(task_id_to_solution.keys()))[0]
         return [
-            {"bigcodebench": {"pass_at_one": evaluator_result["eval"][request_state.instance.id][0]["status"] == "pass"}}
+            {"bigcodebench": {"pass_at_one": eval_result["eval"][request_state.instance.id][0]["status"] == "pass"}}
             for request_state in request_states
         ]

--- a/src/helm/benchmark/annotation/bigcodebench_annotator.py
+++ b/src/helm/benchmark/annotation/bigcodebench_annotator.py
@@ -1,4 +1,5 @@
 import ast
+import tempfile
 import traceback
 import json
 
@@ -6,15 +7,12 @@ from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.annotation.annotator import Annotator
 from helm.common.hierarchical_logger import hlog
 
-from typing import Any, List, Dict
+from typing import Any, Iterable, List, Dict, Optional
 from gradio_client import Client, handle_file
-from tempfile import TemporaryDirectory
-from retrying import retry
 
 
-OUTPUT_FILENAME = "tmp_result.jsonl"
-
-
+# Based on https://github.com/bigcode-project/bigcodebench/blob/0331489b29cbf2653b4669597ef431e158882aab/bigcodebench/syncheck.py#L14
+# Licensed under Apache 2.0
 def syntax_check(code, verbose=False):
     try:
         ast.parse(code)
@@ -25,6 +23,8 @@ def syntax_check(code, verbose=False):
         return False
 
 
+# Based on https://github.com/bigcode-project/bigcodebench/blob/0331489b29cbf2653b4669597ef431e158882aab/bigcodebench/sanitize.py#L30
+# Licensed under Apache 2.0
 def code_extract(text: str) -> str:
     lines = text.split("\n")
     longest_line_pair = (0, 0)
@@ -47,63 +47,61 @@ class BigCodeBenchAnnotator(Annotator):
 
     name = "bigcodebench"
 
-    def __init__(self):
-        self.remote_execute_api = "https://bigcode-bigcodebench-evaluator.hf.space/"
-        self.split = "instruct"
-        self.subset = "full"
-        self.pass_k = "1"  # Original: "1,5,10"
+    DEFAULT_URL = "https://bigcode-bigcodebench-evaluator.hf.space/"
+    SPLIT = "instruct"
+    SUBSET = "full"
+    PASS_K = "1"
+    DATASET_SIZE = 1140
+
+    def __init__(self, api_key: Optional[str], endpoint: Optional[str]):
         self.use_global_metric = True
-        self.num_instances = 1140  # Instruct full seting of the dataset
+        if api_key and endpoint:
+            hlog(f"BigCodeBenchAnnotator will use the configured endpoint {endpoint}")
+            self.client = Client(endpoint, hf_token=api_key)
+        else:
+            hlog(f"WARNING: BigCodeBenchAnnotator will use the default public evaluator endpoint {self.DEFAULT_URL} - "
+                 "set bigcodebenchApiKey and bigcodebenchEndpoint in credentials.conf to use a cloned evaluator instead")
+            self.client = Client(self.DEFAULT_URL)
+        
 
     def annotate(self, request_state: RequestState) -> Any:
-        pass
+        raise NotImplementedError("annotate() is not supported; use annotate_all() instead")
 
-    @retry(stop_max_attempt_number=3, wait_fixed=4000)
-    def predict_with_retry(self, filename: str):
-        client = Client(self.remote_execute_api)
-        results, evals = client.predict(
-            split=self.split,
-            subset=self.subset,
+    def send_request_to_gradio_evaluator(self, filename: str, task_ids: Iterable[str]):
+        if len(task_ids) == self.DATASET_SIZE:
+            selective_evaluate = ""
+        else:
+            selective_evaluate = ",".join([task_id.removeprefix("BigCodeBench/") for task_id in task_ids])
+        print(selective_evaluate)
+        return self.client.predict(
+            split=self.SPLIT,
+            subset=self.SUBSET,
             samples=handle_file(filename),
-            pass_k=self.pass_k,
+            pass_k=self.PASS_K,
             api_name="/predict",
+            selective_evaluate=selective_evaluate,
         )
-        pass_at_one = evals["pass@1"]
-        return results, pass_at_one
 
     def annotate_all(self, request_states: List[RequestState]) -> List[Dict[str, Any]]:
-        assert all(request_state.result is not None for request_state in request_states)
-        assert all(
-            request_state.result is not None and len(request_state.result.completions) == 1
+        task_id_to_solution: Dict[str, str] = {}
+        for request_state in request_states:
+            assert request_state.instance.id is not None
+            task_id = request_state.instance.id
+            assert request_state.result is not None
+            assert len(request_state.result.completions) == 1
+            model_output_text = request_state.result.completions[0].text
+            solution = code_extract(model_output_text)
+            task_id_to_solution[task_id] = solution
+
+        with tempfile.NamedTemporaryFile(suffix=".jsonl") as temp_file:
+            hlog(f"Temporary file for BigCodeBenchAnnotator: {temp_file.name}")
+            with open(temp_file.name, "w") as f:
+                for task_id, solution in task_id_to_solution.items():
+                    json.dump({"task_id": task_id, "solution": solution}, f)
+                    f.write("\n")
+            evaluator_result = self.send_request_to_gradio_evaluator(temp_file.name, task_id_to_solution.keys())[0]
+        print(json.dumps(evaluator_result, indent=2))
+        return [
+            {"bigcodebench": {"pass_at_one": evaluator_result["eval"][request_state.instance.id][0]["status"] == "pass"}}
             for request_state in request_states
-        )
-        assert all(request_state.instance.extra_data for request_state in request_states)
-
-        with TemporaryDirectory() as tmpdir:
-            with open(OUTPUT_FILENAME, "w") as file:
-                hlog(f"Temp Dir: {tmpdir}")
-                res = []
-                for i in range(self.num_instances):
-                    init_line = f'{{"task_id": "BigCodeBench/{i}", "solution": ""}}\n'
-                    res.append(init_line)
-                for request_state in request_states:
-                    line: str
-                    assert request_state.result is not None
-                    model_output_text = request_state.result.completions[0].text
-                    solution = code_extract(model_output_text)
-                    assert request_state.instance.id is not None
-                    idx = int(request_state.instance.id.split("/")[-1])
-                    res[idx] = json.dumps({"task_id": request_state.instance.id, "solution": solution}) + "\n"
-                for line in res:
-                    file.write(line)
-
-        try:
-            results, _ = self.predict_with_retry(OUTPUT_FILENAME)
-            ret = [
-                {"bigcodebench": {"pass_at_one": results["eval"][state.instance.id][0]["status"] == "pass"}}
-                for state in request_states
-            ]
-            return ret
-        except Exception as e:
-            hlog(f"Failed to complete the operation after 3 attempts. Exception: {e}")
-            raise e
+        ]

--- a/src/helm/benchmark/scenarios/bigcodebench_scenario.py
+++ b/src/helm/benchmark/scenarios/bigcodebench_scenario.py
@@ -44,15 +44,14 @@ class BigCodeBenchScenario(Scenario):
 
         # Read all instances
         instances: List[Instance] = []
-        for idx, row in enumerate(dataset):
-
+        for row in dataset:
+            id = row["task_id"]
             input = Input(text=row["instruct_prompt"])
             instance = Instance(
+                id=id,
                 input=input,
                 references=[],
                 split=TEST_SPLIT,
-                id=row["task_id"],
-                extra_data={"task_id": row["task_id"]},
             )
             instances.append(instance)
 


### PR DESCRIPTION
- Allow using a cloned evaluator instance
- Allow using the `selective_evaluate` parameter for downsampling instances
- Remove `extra_data` from instances
- Misc style fixes