### PR TITLE
Disable test_math_scenario due to DMCA takedown

### DIFF
--- a/src/helm/benchmark/scenarios/test_bigcodebench_scenario.py
+++ b/src/helm/benchmark/scenarios/test_bigcodebench_scenario.py
@@ -24,4 +24,3 @@ def test_bigcodebench_scenario_get_instances():
         )
     )
     assert instances[0].split == TEST_SPLIT
-    assert instances[0].extra_data

--- a/src/helm/benchmark/scenarios/test_bigcodebench_scenario.py
+++ b/src/helm/benchmark/scenarios/test_bigcodebench_scenario.py
@@ -11,6 +11,7 @@ def test_bigcodebench_scenario_get_instances():
     with TemporaryDirectory() as tmpdir:
         instances = bigcodebench_scenario.get_instances(tmpdir)
     assert len(instances) == 1140
+    assert instances[0].id == "BigCodeBench/0"
     assert instances[0].input == Input(
         text=(
             "Calculates the average of the sums of absolute differences between each pair "
@@ -24,4 +25,3 @@ def test_bigcodebench_scenario_get_instances():
     )
     assert instances[0].split == TEST_SPLIT
     assert instances[0].extra_data
-    assert instances[0].extra_data["task_id"] == "BigCodeBench/0"

--- a/src/helm/benchmark/scenarios/test_math_scenario.py
+++ b/src/helm/benchmark/scenarios/test_math_scenario.py
@@ -5,6 +5,7 @@ from helm.benchmark.scenarios.math_scenario import MATHScenario
 from helm.benchmark.scenarios.scenario import Input, Output, Reference
 
 
+@pytest.mark.skip(reason="competition_math has been disabled on Hugging Face Hub due to a DMCA takedown")
 @pytest.mark.scenarios
 def test_math_scenario_get_instances():
     math_scenario = MATHScenario(subject="number_theory", level="1")

--- a/src/helm/benchmark/scenarios/test_wildbench_scenario.py
+++ b/src/helm/benchmark/scenarios/test_wildbench_scenario.py
@@ -13,6 +13,3 @@ def test_wildbench_scenario_get_instances():
     assert len(instances) == 1024
     assert instances[0].split == TEST_SPLIT
     assert instances[0].extra_data
-
-    assert instances[0].extra_data["user_query"].startswith("add 10 more balanced governments[aoc2]\n{\n\tGovernment")
-    assert len(instances[0].extra_data["user_query"]) == 17619


### PR DESCRIPTION
[competition_math](https://huggingface.co/datasets/hendrycks/competition_math) has been disabled on Hugging Face Hub due to a DMCA takedown

Also fix the BigCodeBench test.