### PR TITLE
Fix Azure content filter error

### DIFF
--- a/src/helm/clients/openai_client.py
+++ b/src/helm/clients/openai_client.py
@@ -29,7 +29,9 @@ class OpenAIClient(CachingClient):
     # Error OpenAI throws when the image in the prompt violates their content policy
     INAPPROPRIATE_IMAGE_ERROR: str = "Your input image may contain content that is not allowed by our safety system"
     INAPPROPRIATE_PROMPT_ERROR: str = "Invalid prompt: your prompt was flagged"
-    INAPPROPRIATE_PROMPT_AZURE_ERROR: str = "The response was filtered due to the prompt triggering Azure OpenAI's content management policy."
+    INAPPROPRIATE_PROMPT_AZURE_ERROR: str = (
+        "The response was filtered due to the prompt triggering Azure OpenAI's content management policy."
+    )
 
     # OpenAI server error
     OPENAI_SERVER_ERROR: str = (
@@ -42,7 +44,6 @@ class OpenAIClient(CachingClient):
         "The prompt violates OpenAI's content policy. "
         "See https://labs.openai.com/policies/content-policy for more information."
     )
-    
 
     def __init__(
         self,

--- a/src/helm/clients/openai_client.py
+++ b/src/helm/clients/openai_client.py
@@ -32,6 +32,9 @@ class OpenAIClient(CachingClient):
     INAPPROPRIATE_PROMPT_AZURE_ERROR: str = (
         "The response was filtered due to the prompt triggering Azure OpenAI's content management policy."
     )
+    INAPPROPRIATE_PROMPT_MICROSOFT_ERROR: str = (
+        "The response was filtered due to the prompt triggering Microsoft's content management policy."
+    )
 
     # OpenAI server error
     OPENAI_SERVER_ERROR: str = (
@@ -262,7 +265,7 @@ class OpenAIClient(CachingClient):
                     completions=[empty_completion] * request.num_completions,
                     embedding=[],
                 )
-            elif self.INAPPROPRIATE_PROMPT_AZURE_ERROR in str(e):
+            elif self.INAPPROPRIATE_PROMPT_AZURE_ERROR in str(e) or self.INAPPROPRIATE_PROMPT_MICROSOFT_ERROR in str(e):
                 return RequestResult(
                     success=False,
                     cached=False,


### PR DESCRIPTION
Azure has additional content filter policies where the filter message doesn't match with supported content filters.

This PR aims to catch the content filter error thrown by Azure and treat the response like an empty response.

Example error:

```
OpenAI error: Error code: 400 - {'error': {'message': "The response was filtered due to the prompt triggering Azure OpenAI's content management policy. Please modify your prompt and retry. To learn more about our content filtering policies please read our documentation: https://go.microsoft.com/fwlink/?linkid=2198766", 'type': None, 'param': 'prompt', 'code': 'content_filter', 'status': 400}}
```