### PR TITLE
Allow processing output before metrics

### DIFF
--- a/src/helm/benchmark/metrics/output_processing_metric.py
+++ b/src/helm/benchmark/metrics/output_processing_metric.py
@@ -16,10 +16,6 @@ from helm.common.object_spec import get_class_by_name
 from helm.common.request import GeneratedOutput
 
 
-def remove_thinking(input: str) -> str:
-    return input.split("</think>")[-1]
-
-
 class MetricSpecDict(TypedDict):
     class_name: str
     args: Dict[str, Any]

--- a/src/helm/benchmark/metrics/output_processing_metric.py
+++ b/src/helm/benchmark/metrics/output_processing_metric.py
@@ -1,0 +1,67 @@
+import dataclasses
+from typing import Any, Dict, List, TypedDict
+from helm.benchmark.adaptation.request_state import RequestState
+from helm.benchmark.adaptation.scenario_state import ScenarioState
+from helm.benchmark.metrics.metric import (
+    Metric,
+    MetricInterface,
+    MetricResult,
+    MetricSpec,
+    PerInstanceStats,
+    create_metric,
+)
+from helm.benchmark.metrics.metric_service import MetricService
+from helm.benchmark.metrics.statistic import Stat
+from helm.common.object_spec import get_class_by_name
+from helm.common.request import GeneratedOutput
+
+
+def remove_thinking(input: str) -> str:
+    return input.split("</think>")[-1]
+
+
+class MetricSpecDict(TypedDict):
+    class_name: str
+    args: Dict[str, Any]
+
+
+def dict_to_metric_spec(metric_spec_dict: MetricSpecDict) -> MetricSpec:
+    return MetricSpec(metric_spec_dict["class_name"], metric_spec_dict["args"])
+
+
+def metric_spec_to_dict(metric_spec: MetricSpec) -> MetricSpecDict:
+    return {"class_name": metric_spec.class_name, "args": metric_spec.args}
+
+
+class OutputProcessingMetric(MetricInterface):
+    def __init__(self, processor: str, metric_specs: List[MetricSpecDict]):
+        self.processor = get_class_by_name(processor)  # actually a function, not a class
+        self.metrics: List[Metric] = [create_metric(dict_to_metric_spec(metric_spec)) for metric_spec in metric_specs]
+
+    def _process_request_state(self, request_state: RequestState) -> RequestState:
+        if not request_state.result:
+            return request_state
+        processed_completions: List[GeneratedOutput] = []
+        for completion in request_state.result.completions:
+            processed_completions.append(dataclasses.replace(completion, text=self.processor(completion.text)))
+        return dataclasses.replace(
+            request_state, result=dataclasses.replace(request_state.result, completions=processed_completions)
+        )
+
+    def evaluate(
+        self, scenario_state: ScenarioState, metric_service: MetricService, eval_cache_path: str, parallelism: int
+    ) -> MetricResult:
+        aggregated_stats: List[Stat] = []
+        per_instance_stats: List[PerInstanceStats] = []
+
+        processed_scenario_state = dataclasses.replace(
+            scenario_state,
+            request_states=[
+                self._process_request_state(request_state) for request_state in scenario_state.request_states
+            ],
+        )
+        for metric in self.metrics:
+            metric_result = metric.evaluate(processed_scenario_state, metric_service, eval_cache_path, parallelism)
+            aggregated_stats.extend(metric_result.aggregated_stats)
+            per_instance_stats.extend(metric_result.per_instance_stats)
+        return MetricResult(aggregated_stats=aggregated_stats, per_instance_stats=per_instance_stats)

--- a/src/helm/benchmark/metrics/output_processing_metric.py
+++ b/src/helm/benchmark/metrics/output_processing_metric.py
@@ -16,23 +16,19 @@ from helm.common.object_spec import get_class_by_name
 from helm.common.request import GeneratedOutput
 
 
-class MetricSpecDict(TypedDict):
+class _MetricSpecDict(TypedDict):
     class_name: str
     args: Dict[str, Any]
 
 
-def dict_to_metric_spec(metric_spec_dict: MetricSpecDict) -> MetricSpec:
+def _dict_to_metric_spec(metric_spec_dict: _MetricSpecDict) -> MetricSpec:
     return MetricSpec(metric_spec_dict["class_name"], metric_spec_dict["args"])
 
 
-def metric_spec_to_dict(metric_spec: MetricSpec) -> MetricSpecDict:
-    return {"class_name": metric_spec.class_name, "args": metric_spec.args}
-
-
 class OutputProcessingMetric(MetricInterface):
-    def __init__(self, processor: str, metric_specs: List[MetricSpecDict]):
+    def __init__(self, processor: str, metric_specs: List[_MetricSpecDict]):
         self.processor = get_class_by_name(processor)  # actually a function, not a class
-        self.metrics: List[Metric] = [create_metric(dict_to_metric_spec(metric_spec)) for metric_spec in metric_specs]
+        self.metrics: List[Metric] = [create_metric(_dict_to_metric_spec(metric_spec)) for metric_spec in metric_specs]
 
     def _process_request_state(self, request_state: RequestState) -> RequestState:
         if not request_state.result:

--- a/src/helm/benchmark/metrics/output_processing_metric.py
+++ b/src/helm/benchmark/metrics/output_processing_metric.py
@@ -1,14 +1,15 @@
 import dataclasses
 from typing import Any, Dict, List, TypedDict
+
 from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.adaptation.scenario_state import ScenarioState
 from helm.benchmark.metrics.metric import (
+    create_metric,
     Metric,
     MetricInterface,
     MetricResult,
     MetricSpec,
     PerInstanceStats,
-    create_metric,
 )
 from helm.benchmark.metrics.metric_service import MetricService
 from helm.benchmark.metrics.statistic import Stat

--- a/src/helm/benchmark/metrics/output_processors.py
+++ b/src/helm/benchmark/metrics/output_processors.py
@@ -1,0 +1,9 @@
+import re
+
+
+def remove_thinking(input: str) -> str:
+    result = input
+    result = re.sub("<think>.*</think>", "", result, flags=re.DOTALL)
+    # If there is a unclosed think block, remove the entire block
+    result = re.sub("<think>.*", "", result, flags=re.DOTALL)
+    return result

--- a/src/helm/benchmark/metrics/output_processors.py
+++ b/src/helm/benchmark/metrics/output_processors.py
@@ -1,9 +1,15 @@
 import re
 
 
-def remove_thinking(input: str) -> str:
-    result = input
-    result = re.sub("<think>.*</think>", "", result, flags=re.DOTALL)
-    # If there is a unclosed think block, remove the entire block
-    result = re.sub("<think>.*", "", result, flags=re.DOTALL)
-    return result
+def remove_deepseek_r1_thinking(input: str) -> str:
+    if "<think>" not in input:
+        return input
+
+    if "</think>\n\n" in input:
+        # The think block is usually followed by two newlines, so we should remove that
+        return re.sub("<think>.*</think>\n\n", "", input, flags=re.DOTALL)
+    elif "</think>" in input:
+        return re.sub("<think>.*</think>", "", input, flags=re.DOTALL)
+    else:
+        # Unclosed think block
+        return ""

--- a/src/helm/benchmark/metrics/test_output_postprocessors.py
+++ b/src/helm/benchmark/metrics/test_output_postprocessors.py
@@ -1,0 +1,7 @@
+from helm.benchmark.metrics.output_processors import remove_thinking
+
+
+def test_remove_thinking():
+    assert remove_thinking("Before think<think>think</think>After think") == "Before thinkAfter think"
+    assert remove_thinking("Before think<think>think") == "Before think"
+    assert remove_thinking("Before think\n<think>\nthink\n</think>\nAfter think") == "Before think\n\nAfter think"

--- a/src/helm/benchmark/metrics/test_output_postprocessors.py
+++ b/src/helm/benchmark/metrics/test_output_postprocessors.py
@@ -1,7 +1,0 @@
-from helm.benchmark.metrics.output_processors import remove_thinking
-
-
-def test_remove_thinking():
-    assert remove_thinking("Before think<think>think</think>After think") == "Before thinkAfter think"
-    assert remove_thinking("Before think<think>think") == "Before think"
-    assert remove_thinking("Before think\n<think>\nthink\n</think>\nAfter think") == "Before think\n\nAfter think"

--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -1473,6 +1473,8 @@ class OutputFormatInstructions(RunExpander):
                 instructions = "Answer with only a single letter."
             elif self.scenario == "mcqa":
                 instructions = "Answer with only a single letter."
+            elif self.scenario == "mcqa_only_last_question":
+                instructions = "Answer only the last question with only a single letter."
             else:
                 instructions = "Answer with only a single letter."
         elif run_spec.adapter_spec.method == ADAPT_GENERATION:


### PR DESCRIPTION
This adds a `process_output` run expander that will run a string function on all output text before it is passed to the metrics.

This allows evaluating DeepSeek R1 on scenarios that expect a specific output format e.g. MMLU can be run using ` mmlu:subject=anatomy,output_format_instructions=mcqa_only_last_question,increase_max_tokens=8192,process_output=helm.benchmark.metrics.output_processors.remove_deepseek_r1_thinking,model=deepseek-ai/deepseek-r1`