### PR TITLE
Add a version of DeepSeek R1 that hides thinking tokens from output

### DIFF
--- a/src/helm/clients/together_client.py
+++ b/src/helm/clients/together_client.py
@@ -336,8 +336,6 @@ class TogetherChatClient(CachingClient):
         self.output_processor: Optional[Callable[[str], str]] = (
             get_class_by_name(output_processor) if output_processor else None
         )
-        print("self.output_processor")
-        print(self.output_processor)
 
     def convert_to_raw_chat_request(self, request: Request) -> TogetherRawChatRequest:
         request.validate()

--- a/src/helm/clients/together_client.py
+++ b/src/helm/clients/together_client.py
@@ -1,13 +1,14 @@
 from copy import deepcopy
 from itertools import zip_longest
 import threading
-from typing import List, Dict, Any, Mapping, Optional, TypedDict, Union
+from typing import Callable, List, Dict, Any, Mapping, Optional, TypedDict, Union
 
 import requests
 from retrying import retry
 
 from helm.common.cache import CacheConfig
 from helm.common.media_object import IMAGE_TYPE, TEXT_TYPE
+from helm.common.object_spec import get_class_by_name
 from helm.common.optional_dependencies import handle_module_not_found_error
 from helm.common.request import wrap_request_time, Request, RequestResult, GeneratedOutput, Token
 from helm.clients.client import CachingClient, truncate_sequence, cleanup_str
@@ -324,11 +325,19 @@ class TogetherChatClient(CachingClient):
         api_key: Optional[str],
         together_model: Optional[str] = None,
         disable_logprobs: Optional[bool] = None,
+        output_processor: Optional[str] = None,
     ):
         super().__init__(cache_config=cache_config)
         self._client = Together(api_key=api_key)
         self._together_model = together_model
         self._disable_logprobs = bool(disable_logprobs)
+        # self.output_processor is actually a function, not a class
+
+        self.output_processor: Optional[Callable[[str], str]] = (
+            get_class_by_name(output_processor) if output_processor else None
+        )
+        print("self.output_processor")
+        print(self.output_processor)
 
     def convert_to_raw_chat_request(self, request: Request) -> TogetherRawChatRequest:
         request.validate()
@@ -410,7 +419,10 @@ class TogetherChatClient(CachingClient):
                         break
                     tokens.append(Token(text=token_text, logprob=token_logprob or 0.0))
             assert choice.message.role == "assistant"
-            generated_outputs.append(GeneratedOutput(text=choice.message.content, logprob=0.0, tokens=tokens))
+            output_text = choice.message.content
+            if self.output_processor:
+                output_text = self.output_processor(output_text)
+            generated_outputs.append(GeneratedOutput(text=output_text, logprob=0.0, tokens=tokens))
         return RequestResult(
             success=True,
             cached=cached,

--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -446,6 +446,17 @@ model_deployments:
       args:
         disable_logprobs: True
 
+  - name: together/deepseek-r1-hide-reasoning
+    model_name: deepseek-ai/deepseek-r1-hide-reasoning
+    tokenizer_name: deepseek-ai/deepseek-r1
+    max_sequence_length: 32768
+    client_spec:
+      class_name: "helm.clients.together_client.TogetherChatClient"
+      args:
+        together_model: deepseek-ai/deepseek-r1
+        disable_logprobs: True
+        output_processor: helm.benchmark.metrics.output_processors.remove_deepseek_r1_thinking
+
   # Gooseai
 
   # TODO: Migrate these models to use OpenAIClient

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -808,6 +808,16 @@ models:
     release_date: 2025-01-20
     tags: [TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
 
+  - name: deepseek-ai/deepseek-r1-hide-reasoning
+    display_name: DeepSeek R1 (hide reasoning)
+    description: DeepSeek R1 is DeepSeek's first-generation reasoning model which incoporates which incorporates multi-stage training and cold-start data before RL. ([paper](https://arxiv.org/abs/2501.12948)) The reasoning tokens are hidden from the output of the model.
+    creator_organization_name: DeepSeek
+    access: open
+    # NOTE: The total size of DeepSeek-R3 model1 on HuggingFace is 685B
+    num_parameters: 685000000000
+    release_date: 2025-01-20
+    tags: [TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
+ 
   # EleutherAI
   - name: eleutherai/gpt-j-6b # Served by GooseAi, HuggingFace and Together.
     display_name: GPT-J (6B)


### PR DESCRIPTION
This adds a model `deepseek-ai/deepseek-r1-hide-reasoning` which is identical to `deepseek-ai/deepseek-r1` except that the thinking tokens are removed from the final output text. This emulates the behavior of OpenAI's o1 / o1-mini / o3-mini so that the two can be fairly compared.