### PR TITLE
Add AMI, LibriSpeech audio scenarios and fix Speech Robust Bench audio scenario

### DIFF
--- a/src/helm/benchmark/presentation/run_entries_audio.conf
+++ b/src/helm/benchmark/presentation/run_entries_audio.conf
@@ -6,8 +6,6 @@ entries: [
     {description: "audiocaps:model=audiolm", priority: 1}
     {description: "voxceleb2:model=audiolm", priority: 1}
     {description: "librispeech:model=audiolm", priority: 1}
-    {description: "ami:subject=ihm,model=audiolm", priority: 1}
-    {description: "ami:subject=sdm,model=audiolm", priority: 1}
 
     ####################################################################################################################
     # Fairness
@@ -34,10 +32,12 @@ entries: [
     # Robustness
     ####################################################################################################################
 
-    {description: "speech_robust_bench:subject=librispeech_gnoise,model=audiolm", priority: 1}
-    {description: "speech_robust_bench:subject=librispeech_env_noise,model=audiolm", priority: 1}
-    {description: "speech_robust_bench:subject=ami_far,model=audiolm", priority: 1}
-    {description: "speech_robust_bench:subject=ami_near,model=audiolm", priority: 1}
+    {description: "speech_robust_bench:subject=librispeech_gnoise,level=1,model=audiolm", priority: 1}
+    {description: "speech_robust_bench:subject=librispeech_env_noise,level=1,model=audiolm", priority: 1}
+    {description: "speech_robust_bench:subject=librispeech_gnoise,level=2,model=audiolm", priority: 1}
+    {description: "speech_robust_bench:subject=librispeech_env_noise,level=2,model=audiolm", priority: 1}
+    {description: "speech_robust_bench:subject=librispeech_gnoise,level=3,model=audiolm", priority: 1}
+    {description: "speech_robust_bench:subject=librispeech_env_noise,level=3,model=audiolm", priority: 1}
 
     ####################################################################################################################
     # Bias

--- a/src/helm/benchmark/presentation/run_entries_audio.conf
+++ b/src/helm/benchmark/presentation/run_entries_audio.conf
@@ -5,7 +5,9 @@ entries: [
 
     {description: "audiocaps:model=audiolm", priority: 1}
     {description: "voxceleb2:model=audiolm", priority: 1}
-    {description: "vocal_sound:model=audiolm", priority: 1}
+    {description: "librispeech:model=audiolm", priority: 1}
+    {description: "ami:subject=ihm,model=audiolm", priority: 1}
+    {description: "ami:subject=sdm,model=audiolm", priority: 1}
 
     ####################################################################################################################
     # Fairness
@@ -32,10 +34,8 @@ entries: [
     # Robustness
     ####################################################################################################################
 
-    {description: "speech_robust_bench:subject=accented_cv,model=audiolm", priority: 1}
-    {description: "speech_robust_bench:subject=accented_cv_es,model=audiolm", priority: 1}
-    {description: "speech_robust_bench:subject=chime_far,model=audiolm", priority: 1}
-    {description: "speech_robust_bench:subject=chime_near,model=audiolm", priority: 1}
+    {description: "speech_robust_bench:subject=librispeech_gnoise,model=audiolm", priority: 1}
+    {description: "speech_robust_bench:subject=librispeech_env_noise,model=audiolm", priority: 1}
     {description: "speech_robust_bench:subject=ami_far,model=audiolm", priority: 1}
     {description: "speech_robust_bench:subject=ami_near,model=audiolm", priority: 1}
 

--- a/src/helm/benchmark/run_specs/audio_run_specs.py
+++ b/src/helm/benchmark/run_specs/audio_run_specs.py
@@ -438,3 +438,44 @@ def get_air_bench_chat_run_spec(subject: str) -> RunSpec:
         metric_specs=metric_specs,
         groups=[run_spec_name],
     )
+
+
+@run_spec_function("ami")
+def get_ami_run_spec(subject: str) -> RunSpec:
+    scenario_spec = ScenarioSpec(
+        class_name="helm.benchmark.scenarios.audio_language.ami_scenario.AMIScenario",
+        args={"subject": subject},
+    )
+    adapter_spec = _get_generation_adapter_spec(
+        instructions=ASR_INSTRUCTIONS,
+        max_tokens=100,
+    )
+    metric_specs = _get_audio_recognition_metric_specs()
+    run_spec_name: str = "ami"
+    return RunSpec(
+        name=f"{run_spec_name}:subject={subject}",
+        scenario_spec=scenario_spec,
+        adapter_spec=adapter_spec,
+        metric_specs=metric_specs,
+        groups=[run_spec_name],
+    )
+
+
+@run_spec_function("librispeech")
+def get_librispeech_run_spec() -> RunSpec:
+    scenario_spec = ScenarioSpec(
+        class_name="helm.benchmark.scenarios.audio_language.librispeech_scenario.LibriSpeechScenario",
+    )
+    adapter_spec = _get_generation_adapter_spec(
+        instructions=ASR_INSTRUCTIONS,
+        max_tokens=100,
+    )
+    metric_specs = _get_audio_recognition_metric_specs()
+    run_spec_name: str = "librispeech"
+    return RunSpec(
+        name=f"{run_spec_name}",
+        scenario_spec=scenario_spec,
+        adapter_spec=adapter_spec,
+        metric_specs=metric_specs,
+        groups=[run_spec_name],
+    )

--- a/src/helm/benchmark/run_specs/audio_run_specs.py
+++ b/src/helm/benchmark/run_specs/audio_run_specs.py
@@ -357,10 +357,10 @@ def get_common_voice_15_run_spec(language: str) -> RunSpec:
 
 
 @run_spec_function("speech_robust_bench")
-def get_speech_robust_bench_run_spec(subject: str) -> RunSpec:
+def get_speech_robust_bench_run_spec(subject: str, level: int) -> RunSpec:
     scenario_spec = ScenarioSpec(
         class_name="helm.benchmark.scenarios.audio_language.speech_robust_bench_scenario.SpeechRobustBenchScenario",
-        args={"subject": subject},
+        args={"subject": subject, "level": level},
     )
     adapter_spec = _get_generation_adapter_spec(
         instructions=ASR_INSTRUCTIONS,
@@ -369,7 +369,7 @@ def get_speech_robust_bench_run_spec(subject: str) -> RunSpec:
     metric_specs = _get_audio_recognition_metric_specs()
     run_spec_name: str = "speech_robust_bench"
     return RunSpec(
-        name=f"{run_spec_name}:subject={subject}",
+        name=f"{run_spec_name}:subject={subject},level={level}",
         scenario_spec=scenario_spec,
         adapter_spec=adapter_spec,
         metric_specs=metric_specs,

--- a/src/helm/benchmark/scenarios/audio_language/ami_scenario.py
+++ b/src/helm/benchmark/scenarios/audio_language/ami_scenario.py
@@ -1,0 +1,96 @@
+from typing import List
+import os
+import json
+
+from helm.benchmark.scenarios.scenario import (
+    Scenario,
+    Instance,
+    Reference,
+    TEST_SPLIT,
+    CORRECT_TAG,
+    Input,
+    Output,
+)
+from tqdm import tqdm
+from datasets import load_dataset
+from helm.common.media_object import MediaObject, MultimediaObject
+from helm.common.audio_utils import ensure_audio_file_exists_from_array
+from helm.common.general import ensure_file_downloaded
+
+
+class AMIScenario(Scenario):
+    """AMI Meeting Corpus
+    The AMI Meeting Corpus (Carletta et al. 2005) is a multi-modal data set consisting of
+    100 hours of meeting recordings. It is being created in the context of a project that
+    is developing meeting browsing technology. The corpus is being recorded using a wide
+    range of devices including close-talking and far-field microphones, individual and
+    room-view video cameras, projection, a whiteboard, and individual pens, all of which
+    produce output signals that are synchronized with each other.
+
+    Paper: https://link.springer.com/chapter/10.1007/11677482_3
+    Code: https://groups.inf.ed.ac.uk/ami/corpus/
+
+    Citation:
+    @inproceedings{Carletta2005TheAM,
+        title={The AMI Meeting Corpus: A Pre-announcement},
+        author={Jean Carletta and Simone Ashby and Sebastien Bourban and Mike Flynn and Ma{\"e}l Guillemot
+        and Thomas Hain and Jaroslav Kadlec and Vasilis Karaiskos and Wessel Kraaij and Melissa Kronenthal
+        and Guillaume Lathoud and Mike Lincoln and Agnes Lisowska Masson and Iain McCowan and Wilfried Post
+        and Dennis Reidsma and Pierre D. Wellner},
+        booktitle={Machine Learning for Multimodal Interaction},
+        year={2005},
+        url={https://api.semanticscholar.org/CorpusID:6118869}
+        }
+    """
+
+    HF_DATASET_NAME = "edinburghcstr/ami"
+    HF_MAPPING_URL = (
+        "https://huggingface.co/datasets/PahaII/SRB_instance_key_mapping/resolve/main/srb_instance_keys.json"
+    )
+    name = "ami"
+    description = (
+        "Speech recognition of speech recorded with different devices "
+        "([Carletta et al, 2005](https://link.springer.com/chapter/10.1007/11677482_3))."
+    )
+    SUBJECT_DICT = {
+        "ihm": {"mapping_key": "ami_ihm_id2line", "srb_mapping": "nearfield"},
+        "sdm": {"mapping_key": "ami_sdm_id2line", "srb_mapping": "farfield"},
+    }
+    tags: List[str] = ["audio", "recognition"]
+
+    def __init__(self, subject: str) -> None:
+        super().__init__()
+        subject = subject.lower()
+        if subject not in AMIScenario.SUBJECT_DICT.keys():
+            raise ValueError(f"Invalid subject. Valid subjects are: {AMIScenario.SUBJECT_DICT.keys()}")
+
+        self._subject: str = subject
+
+    def get_instances(self, output_path: str) -> List[Instance]:
+        instances: List[Instance] = []
+        audio_save_dir = os.path.join(output_path, "audio_files")
+        mapping_local_path = os.path.join(output_path, "srb_instance_keys.json")
+        ensure_file_downloaded(source_url=AMIScenario.HF_MAPPING_URL, target_path=mapping_local_path)
+        meta_data = load_dataset(
+            AMIScenario.HF_DATASET_NAME,
+            name=self._subject,
+            cache_dir=output_path,
+            split=TEST_SPLIT,
+        )
+        index_mappings = AMIScenario.SUBJECT_DICT[self._subject]["mapping_key"]
+        srb_mappings = AMIScenario.SUBJECT_DICT[self._subject]["srb_mapping"]
+        mapping_dict = json.load(open(mapping_local_path))
+        srb_mapping_keys = mapping_dict["srb_aim_field_key2audio"][srb_mappings]
+        index2line_num = mapping_dict[index_mappings]
+        for line_num in tqdm(list(srb_mapping_keys)):
+            row = meta_data[int(index2line_num[line_num])]
+            local_audio_name = f"{self._subject}_{line_num}.wav"
+            local_audio_path = os.path.join(audio_save_dir, local_audio_name)
+            ensure_audio_file_exists_from_array(local_audio_path, row["audio"]["array"], row["audio"]["sampling_rate"])
+            answer = row["text"].lower()
+            input = Input(
+                multimedia_content=MultimediaObject([MediaObject(content_type="audio/wav", location=local_audio_path)])
+            )
+            references = [Reference(Output(text=answer), tags=[CORRECT_TAG])]
+            instances.append(Instance(input=input, references=references, split=TEST_SPLIT))
+        return instances

--- a/src/helm/benchmark/scenarios/audio_language/librispeech_scenario.py
+++ b/src/helm/benchmark/scenarios/audio_language/librispeech_scenario.py
@@ -1,0 +1,80 @@
+from typing import List
+import os
+import json
+
+from helm.benchmark.scenarios.scenario import (
+    Scenario,
+    Instance,
+    Reference,
+    TEST_SPLIT,
+    CORRECT_TAG,
+    Input,
+    Output,
+)
+from tqdm import tqdm
+from datasets import load_dataset
+from helm.common.media_object import MediaObject, MultimediaObject
+from helm.common.audio_utils import ensure_audio_file_exists_from_array
+from helm.common.general import ensure_file_downloaded
+
+
+class LibriSpeechScenario(Scenario):
+    """LibriSpeech Corpus
+    The LibriSpeech corpus (Vassil et al. 2015) is derived from audiobooks that are part of the LibriVox
+    project, and contains 1000 hours of speech sampled at 16 kHz. The data has separately prepared language-model
+    training data and pre-built language models. This corpus is one of the most widely-used ASR corpus, which
+    has been extended to many applicaitons such as robust ASR and multilingual ASR tasks.
+
+    Paper: https://ieeexplore.ieee.org/document/7178964
+    Code: https://www.openslr.org/12
+
+    Citation:
+    @INPROCEEDINGS{7178964,
+        author={Panayotov, Vassil and Chen, Guoguo and Povey, Daniel and Khudanpur, Sanjeev},
+        booktitle={2015 IEEE International Conference on Acoustics, Speech and Signal Processing (ICASSP)},
+        title={Librispeech: An ASR corpus based on public domain audio books},
+        year={2015},
+        doi={10.1109/ICASSP.2015.7178964}}
+    """
+
+    HF_DATASET_NAME = "openslr/librispeech_asr"
+    HF_MAPPING_URL = (
+        "https://huggingface.co/datasets/PahaII/SRB_instance_key_mapping/resolve/main/srb_instance_keys.json"
+    )
+    SRB_KEY = "srb_librispeech_noises_key2audio"
+    SRB_SUBSET = "gnoise.1"
+    MAPPING_KEY = "librispeech_id2line"
+
+    name = "librispeech"
+    description = (
+        "Widely-used speech corpus for the speech recognition task "
+        "([Vassil et al. 2015](https://ieeexplore.ieee.org/document/7178964))."
+    )
+    tags: List[str] = ["audio", "recognition"]
+
+    def get_instances(self, output_path: str) -> List[Instance]:
+        instances: List[Instance] = []
+        audio_save_dir = os.path.join(output_path, "audio_files")
+        mapping_local_path = os.path.join(output_path, "srb_instance_keys.json")
+        ensure_file_downloaded(source_url=LibriSpeechScenario.HF_MAPPING_URL, target_path=mapping_local_path)
+        meta_data = load_dataset(
+            LibriSpeechScenario.HF_DATASET_NAME,
+            name="clean",
+            cache_dir=output_path,
+            split=TEST_SPLIT,
+        )
+        mapping_dict = json.load(open(mapping_local_path))
+        srb_mapping_keys = mapping_dict[self.SRB_KEY][self.SRB_SUBSET]
+        index2line_num = mapping_dict[self.MAPPING_KEY]
+        for line_num in tqdm(list(srb_mapping_keys)):
+            row = meta_data[int(index2line_num[line_num])]
+            local_audio_name = f"{self.name}_{line_num}.mp3"
+            local_audio_path = os.path.join(audio_save_dir, local_audio_name)
+            ensure_audio_file_exists_from_array(local_audio_path, row["audio"]["array"], row["audio"]["sampling_rate"])
+            answer = row["text"].lower()
+            input = Input(
+                multimedia_content=MultimediaObject([MediaObject(content_type="audio/mp3", location=local_audio_path)])
+            )
+            references = [Reference(Output(text=answer), tags=[CORRECT_TAG])]
+            instances.append(Instance(input=input, references=references, split=TEST_SPLIT))
+        return instances

--- a/src/helm/benchmark/scenarios/audio_language/speech_robust_bench_scenario.py
+++ b/src/helm/benchmark/scenarios/audio_language/speech_robust_bench_scenario.py
@@ -74,7 +74,8 @@ class SpeechRobustBenchScenario(Scenario):
             "mapping_key": "srb_librispeech_noises_key2audio",
         },
     }
-
+    # There are 30 different perturbation samples for each LibriSpeech ID
+    PERTURBATION_LEVELS = list(range(1, 31))
     name = "speech_robust_bench"
     description = (
         "Speech recognition for 4 datasets with a wide range of corruptions"
@@ -82,12 +83,15 @@ class SpeechRobustBenchScenario(Scenario):
     )
     tags: List[str] = ["audio", "recognition", "robustness", "multilinguality"]
 
-    def __init__(self, subject: str) -> None:
+    def __init__(self, subject: str, level: int) -> None:
         super().__init__()
 
         self._subject = subject
         if self._subject not in SpeechRobustBenchScenario.SUBJECTS_DICT.keys():
             raise ValueError(f"Invalid subject. Valid subjects are: {SpeechRobustBenchScenario.SUBJECTS_DICT.keys()}")
+        self._level = level
+        if self._level not in SpeechRobustBenchScenario.PERTURBATION_LEVELS:
+            raise ValueError(f"Invalid level. Valid levels are: {SpeechRobustBenchScenario.PERTURBATION_LEVELS}")
 
     def get_instances(self, output_path: str) -> List[Instance]:
         instances: List[Instance] = []
@@ -107,7 +111,7 @@ class SpeechRobustBenchScenario(Scenario):
             split=subject_split,
         )
         for line_num in tqdm(list(mapping_keys.keys())):
-            row = meta_data[int(mapping_keys[line_num][0])]
+            row = meta_data[int(mapping_keys[line_num][self._level-1])]
             local_audio_name = f"{self._subject}_{subject_split}_{line_num}.{subject_audio_type}"
             local_audio_path = os.path.join(audio_save_dir, local_audio_name)
             ensure_audio_file_exists_from_array(local_audio_path, row["audio"]["array"], row["audio"]["sampling_rate"])

--- a/src/helm/benchmark/scenarios/audio_language/speech_robust_bench_scenario.py
+++ b/src/helm/benchmark/scenarios/audio_language/speech_robust_bench_scenario.py
@@ -2,6 +2,7 @@
 
 from typing import List
 import os
+import json
 
 from helm.benchmark.scenarios.scenario import (
     Scenario,
@@ -16,6 +17,7 @@ from tqdm import tqdm
 from datasets import load_dataset
 from helm.common.media_object import MediaObject, MultimediaObject
 from helm.common.audio_utils import ensure_audio_file_exists_from_array
+from helm.common.general import ensure_file_downloaded
 
 
 class SpeechRobustBenchScenario(Scenario):
@@ -25,7 +27,7 @@ class SpeechRobustBenchScenario(Scenario):
     the robustness of ASR models to diverse corruptions. SRB is composed of 114 input
     perturbations which simulate an heterogeneous range of corruptions that ASR models
     may encounter when deployed in the wild. In this scenario, we select four subsets
-    in the benchmark for evaluation.
+    in the benchmark for evaluation, each corresponds to a clean version of audio task.
 
     Paper: https://arxiv.org/abs/2403.07937
     Code: https://github.com/ahmedshah1494/speech_robust_bench
@@ -41,15 +43,16 @@ class SpeechRobustBenchScenario(Scenario):
     """
 
     HF_DATASET_NAME = "mshah1/speech_robust_bench"
+    HF_MAPPING_URL = "https://huggingface.co/datasets/PahaII/SRB_instance_key_mapping/resolve/main/srb_instance_keys.json"
 
     # Select four subsets of the dataset for the benchmark
     SUBJECTS_DICT = {
-        "accented_cv": {"name": "accented_cv", "split": TEST_SPLIT, "type": "audio/mpeg"},
-        "accented_cv_es": {"name": "accented_cv_es", "split": TEST_SPLIT, "type": "audio/mpeg"},
-        "chime_far": {"name": "chime", "split": "farfield", "type": "audio/wav"},
-        "chime_near": {"name": "chime", "split": "nearfield", "type": "audio/wav"},
-        "ami_far": {"name": "in-the-wild-AMI", "split": "farfield", "type": "audio/wav"},
-        "ami_near": {"name": "in-the-wild-AMI", "split": "nearfield", "type": "audio/wav"},
+        "ami_far": {"name": "in-the-wild-AMI", "split": "farfield", "type": "audio/wav", "mapping_key": "srb_aim_field_key2audio"},
+        "ami_near": {"name": "in-the-wild-AMI", "split": "nearfield", "type": "audio/wav", "mapping_key": "srb_aim_field_key2audio"},
+        "librispeech_gnoise": {"name": "librispeech_asr-test.clean_pertEval_500_30", "split": "gnoise.1", "type": "audio/mp3", 
+                               "mapping_key": "srb_librispeech_noises_key2audio"},
+        "librispeech_env_noise": {"name": "librispeech_asr-test.clean_pertEval_500_30", "split": "env_noise_esc50.1", 
+                                  "type": "audio/mp3", "mapping_key": "srb_librispeech_noises_key2audio"},
     }
 
     name = "speech_robust_bench"
@@ -71,18 +74,24 @@ class SpeechRobustBenchScenario(Scenario):
         subject_name = SpeechRobustBenchScenario.SUBJECTS_DICT[self._subject]["name"]
         subject_split = SpeechRobustBenchScenario.SUBJECTS_DICT[self._subject]["split"]
         subject_type = SpeechRobustBenchScenario.SUBJECTS_DICT[self._subject]["type"]
+        subject_audio_type = subject_type.split("/")[-1]
+        subject_mapping = SpeechRobustBenchScenario.SUBJECTS_DICT[self._subject]["mapping_key"]
         audio_save_dir = os.path.join(output_path, "audio_files")
-        for row in tqdm(
-            load_dataset(
+        mapping_local_path = os.path.join(output_path, "srb_instance_keys.json")
+        ensure_file_downloaded(source_url=SpeechRobustBenchScenario.HF_MAPPING_URL, target_path=mapping_local_path)
+        mapping_keys = json.load(open(mapping_local_path))[subject_mapping][subject_split]
+        meta_data = load_dataset(
                 SpeechRobustBenchScenario.HF_DATASET_NAME,
                 name=subject_name,
                 cache_dir=output_path,
                 split=subject_split,
             )
-        ):
-            local_audio_path = os.path.join(audio_save_dir, row["audio"]["path"])
+        for line_num in tqdm(list(mapping_keys.keys())):
+            row = meta_data[int(mapping_keys[line_num][0])]
+            local_audio_name = f"{self._subject}_{subject_split}_{line_num}.{subject_audio_type}"
+            local_audio_path = os.path.join(audio_save_dir, local_audio_name)
             ensure_audio_file_exists_from_array(local_audio_path, row["audio"]["array"], row["audio"]["sampling_rate"])
-            answer = row["text"]
+            answer = row["text"].lower()
             input = Input(
                 multimedia_content=MultimediaObject([MediaObject(content_type=subject_type, location=local_audio_path)])
             )

--- a/src/helm/benchmark/scenarios/audio_language/speech_robust_bench_scenario.py
+++ b/src/helm/benchmark/scenarios/audio_language/speech_robust_bench_scenario.py
@@ -43,16 +43,36 @@ class SpeechRobustBenchScenario(Scenario):
     """
 
     HF_DATASET_NAME = "mshah1/speech_robust_bench"
-    HF_MAPPING_URL = "https://huggingface.co/datasets/PahaII/SRB_instance_key_mapping/resolve/main/srb_instance_keys.json"
+    HF_MAPPING_URL = (
+        "https://huggingface.co/datasets/PahaII/SRB_instance_key_mapping/resolve/main/srb_instance_keys.json"
+    )
 
     # Select four subsets of the dataset for the benchmark
     SUBJECTS_DICT = {
-        "ami_far": {"name": "in-the-wild-AMI", "split": "farfield", "type": "audio/wav", "mapping_key": "srb_aim_field_key2audio"},
-        "ami_near": {"name": "in-the-wild-AMI", "split": "nearfield", "type": "audio/wav", "mapping_key": "srb_aim_field_key2audio"},
-        "librispeech_gnoise": {"name": "librispeech_asr-test.clean_pertEval_500_30", "split": "gnoise.1", "type": "audio/mp3", 
-                               "mapping_key": "srb_librispeech_noises_key2audio"},
-        "librispeech_env_noise": {"name": "librispeech_asr-test.clean_pertEval_500_30", "split": "env_noise_esc50.1", 
-                                  "type": "audio/mp3", "mapping_key": "srb_librispeech_noises_key2audio"},
+        "ami_far": {
+            "name": "in-the-wild-AMI",
+            "split": "farfield",
+            "type": "audio/wav",
+            "mapping_key": "srb_aim_field_key2audio",
+        },
+        "ami_near": {
+            "name": "in-the-wild-AMI",
+            "split": "nearfield",
+            "type": "audio/wav",
+            "mapping_key": "srb_aim_field_key2audio",
+        },
+        "librispeech_gnoise": {
+            "name": "librispeech_asr-test.clean_pertEval_500_30",
+            "split": "gnoise.1",
+            "type": "audio/mp3",
+            "mapping_key": "srb_librispeech_noises_key2audio",
+        },
+        "librispeech_env_noise": {
+            "name": "librispeech_asr-test.clean_pertEval_500_30",
+            "split": "env_noise_esc50.1",
+            "type": "audio/mp3",
+            "mapping_key": "srb_librispeech_noises_key2audio",
+        },
     }
 
     name = "speech_robust_bench"
@@ -81,11 +101,11 @@ class SpeechRobustBenchScenario(Scenario):
         ensure_file_downloaded(source_url=SpeechRobustBenchScenario.HF_MAPPING_URL, target_path=mapping_local_path)
         mapping_keys = json.load(open(mapping_local_path))[subject_mapping][subject_split]
         meta_data = load_dataset(
-                SpeechRobustBenchScenario.HF_DATASET_NAME,
-                name=subject_name,
-                cache_dir=output_path,
-                split=subject_split,
-            )
+            SpeechRobustBenchScenario.HF_DATASET_NAME,
+            name=subject_name,
+            cache_dir=output_path,
+            split=subject_split,
+        )
         for line_num in tqdm(list(mapping_keys.keys())):
             row = meta_data[int(mapping_keys[line_num][0])]
             local_audio_name = f"{self._subject}_{subject_split}_{line_num}.{subject_audio_type}"

--- a/src/helm/benchmark/scenarios/audio_language/speech_robust_bench_scenario.py
+++ b/src/helm/benchmark/scenarios/audio_language/speech_robust_bench_scenario.py
@@ -111,7 +111,7 @@ class SpeechRobustBenchScenario(Scenario):
             split=subject_split,
         )
         for line_num in tqdm(list(mapping_keys.keys())):
-            row = meta_data[int(mapping_keys[line_num][self._level-1])]
+            row = meta_data[int(mapping_keys[line_num][self._level - 1])]
             local_audio_name = f"{self._subject}_{subject_split}_{line_num}.{subject_audio_type}"
             local_audio_path = os.path.join(audio_save_dir, local_audio_name)
             ensure_audio_file_exists_from_array(local_audio_path, row["audio"]["array"], row["audio"]["sampling_rate"])

--- a/src/helm/benchmark/static/schema_audio.yaml
+++ b/src/helm/benchmark/static/schema_audio.yaml
@@ -554,3 +554,52 @@ run_groups:
       who: real speakers
       when: "2019"
       language: English
+
+  - name: ami
+    display_name: AMI Meeting Corpus
+    description: >
+      The AMI Meeting Corpus (Carletta et al. 2005) is a multi-modal data set consisting of 
+      100 hours of meeting recordings. It is being created in the context of a project that 
+      is developing meeting browsing technology. The corpus is being recorded using a wide 
+      range of devices including close-talking and far-field microphones, individual and 
+      room-view video cameras, projection, a whiteboard, and individual pens, all of which 
+      produce output signals that are synchronized with each other.
+
+      The dataset contains the audio, transcriptions for all subsets 
+      ([Carletta et al, 2005](https://link.springer.com/chapter/10.1007/11677482_3)).
+    metric_groups:
+      - accuracy
+      - general_information
+    environment:
+      main_name: wer_score
+      main_split: test
+    taxonomy:
+      task: audio recognition
+      what: audio, transcripts of audio samples from meeting environments 
+      who: real speakers
+      when: "2005"
+      language: English
+
+  - name: librispeech
+    display_name: LibriSpeech
+    description: >
+      The LibriSpeech corpus (Vassil et al. 2015) is derived from audiobooks that are part 
+      of the LibriVox project, and contains 1000 hours of speech sampled at 16 kHz. The 
+      data has separately prepared language-model training data and pre-built language models. 
+      This corpus is one of the most widely-used ASR corpus, which has been extended to many 
+      applicaitons such as robust ASR and multilingual ASR tasks.
+
+      The dataset contains the audio, transcriptions for all subsets 
+      ([Vassil et al. 2015](https://ieeexplore.ieee.org/document/7178964)).
+    metric_groups:
+      - accuracy
+      - general_information
+    environment:
+      main_name: wer_score
+      main_split: test
+    taxonomy:
+      task: audio recognition
+      what: audio, transcripts of audio samples in daily scenarios
+      who: real speakers
+      when: "2015"
+      language: English


### PR DESCRIPTION
1. Add AMI, LibriSpeech audio scenarios and make sure that each example corresponds to their perturbed ones in Speech Robust Bench (SRB) scenario.
2. Add `in-the-wild-ami` subset to SRB and delete two subjects that cannot find correspondence with clean audios.

The mappings between LibriSpeech and SRB are:

`librispeech:model=audiolm`: `speech_robust_bench:subject=librispeech_gnoise,level=1,model=audiolm` (LibriSpeech audio files with different 'gnoise' perturbation)
`librispeech:model=audiolm`: `speech_robust_bench:subject=librispeech_env_noise,level=1,model=audiolm` (LibriSpeech audio files with different environment noise perturbation)

There are 30 different perturbation examples for every LibriSpeech ID in SRB, I added the `level` argument for assigning different samples for different audios with distinct LibriSpeech ID in SRB
