### PR TITLE
Remove logo from SEA-HELM landing

### DIFF
--- a/helm-frontend/src/components/Landing/SEAHELMLanding.tsx
+++ b/helm-frontend/src/components/Landing/SEAHELMLanding.tsx
@@ -1,6 +1,5 @@
 import MiniLeaderboard from "@/components/MiniLeaderboard";
 import { Link } from "react-router-dom";
-import aisingapore from "@/assets/seahelm/aisingapore.png";
 export default function SEAHELMLanding() {
   return (
     <div className="container mx-auto px-16">
@@ -9,31 +8,35 @@ export default function SEAHELMLanding() {
       </h1>
       <div className="flex flex-col lg:flex-row gap-8">
         <div className="flex-1 text-l">
-          <div className="text-center">
-            <a href="https://aisingapore.org/">
-              <img
-                src={aisingapore}
-                alt="Logo"
-                className="inline h-32 mx-4 my-4"
-              />
+          <p className="mb-4 italic">
+            This leaderboard is a collaboration with{" "}
+            <a
+              href="https://aisingapore.org/"
+              className="font-bold underline text-blue-600 hover:text-blue-800 visited:text-purple-600"
+            >
+              AI Singapore
             </a>
-          </div>
-          With the rapid emergence of novel capabilities in Large Language
-          Models (LLMs), the need for rigorous multilingual and multicultural
-          benchmarks that are integrated has become more pronounced. Though
-          existing LLM benchmarks are capable of evaluating specific
-          capabilities of LLMs in English as well as in various mid- to
-          low-resource languages, including those in the Southeast Asian (SEA)
-          region, a comprehensive and authentic evaluation suite for the SEA
-          languages has not been developed thus far. Here, we present{" "}
-          <strong className="font-bold">SEA-HELM</strong>, a holistic linguistic
-          and cultural LLM evaluation suite that emphasizes SEA languages,
-          comprising five core pillars: (1) NLP Classics, (2) LLM-specifics, (3)
-          SEA Linguistics, (4) SEA Culture, (5) Safety. SEA-HELM currently
-          supports Filipino, Indonesian, Tamil, Thai, and Vietnamese. We also
-          introduce the SEA-HELM leaderboard, which allows users to understand
-          models' multilingual and multicultural performance in a systematic and
-          user-friendly manner.
+            .
+          </p>
+          <p className="my-4">
+            With the rapid emergence of novel capabilities in Large Language
+            Models (LLMs), the need for rigorous multilingual and multicultural
+            benchmarks that are integrated has become more pronounced. Though
+            existing LLM benchmarks are capable of evaluating specific
+            capabilities of LLMs in English as well as in various mid- to
+            low-resource languages, including those in the Southeast Asian (SEA)
+            region, a comprehensive and authentic evaluation suite for the SEA
+            languages has not been developed thus far. Here, we present{" "}
+            <strong className="font-bold">SEA-HELM</strong>, a holistic
+            linguistic and cultural LLM evaluation suite that emphasizes SEA
+            languages, comprising five core pillars: (1) NLP Classics, (2)
+            LLM-specifics, (3) SEA Linguistics, (4) SEA Culture, (5) Safety.
+            SEA-HELM currently supports Filipino, Indonesian, Tamil, Thai, and
+            Vietnamese. We also introduce the SEA-HELM leaderboard, which allows
+            users to understand models' multilingual and multicultural
+            performance in a systematic and user-friendly manner.
+          </p>
+
           <div className="flex flex-row justify-center mt-4">
             <a
               className="px-10 btn rounded-md mx-4"


### PR DESCRIPTION
Unfortunately logos are no longer permitted on the HELM website due to the [Stanford name use guidelines](https://trademarks.stanford.edu/name-use-guidelines).