### PR TITLE
Rename Vite config environment variable to VITE_HELM_FRONTEND_BASE

### DIFF
--- a/helm-frontend/vite.config.ts
+++ b/helm-frontend/vite.config.ts
@@ -23,7 +23,7 @@ const ServeBenchmarkOutputPlugin = {
 // https://vitejs.dev/config/
 export default () => {
   return defineConfig({
-    base: process.env.VITE_BASE || "",
+    base: process.env.VITE_HELM_FRONTEND_BASE || "",
     plugins: [react(), ServeBenchmarkOutputPlugin],
     resolve: {
       alias: {


### PR DESCRIPTION
Change the name to namespace it to the HELM frontend.