### PR TITLE
Improve URL generation for audio media objects in GCS

### DIFF
--- a/helm-frontend/src/components/MediaObjectDisplay.tsx
+++ b/helm-frontend/src/components/MediaObjectDisplay.tsx
@@ -27,7 +27,7 @@ export default function MediaObjectDisplay({ mediaObject }: Props) {
     }
     const url = getBenchmarkEndpoint(
       mediaObject.location
-        .replace("benchmark_output/", "")
+        .replace(/^.*benchmark_output\//, "")
         .replace("prod_env/", "../"),
     );
     return (

--- a/helm-frontend/src/utils/getBenchmarkEndpoint.ts
+++ b/helm-frontend/src/utils/getBenchmarkEndpoint.ts
@@ -2,8 +2,9 @@ export default function getBenchmarkEndpoint(path: string): string {
   if (path.startsWith("http://") || path.startsWith("https://")) {
     return path;
   }
-  return `${window.BENCHMARK_OUTPUT_BASE_URL.replace(/\/$/, "")}/${path.replace(
-    /^\//,
-    "",
-  )}`;
+  return `${window.BENCHMARK_OUTPUT_BASE_URL.replace(/\/$/, "")}/${path
+    .replace(/^\//, "")
+    .split("/")
+    .map((component) => encodeURIComponent(component))
+    .join("/")}`;
 }


### PR DESCRIPTION
- Generate the correct URL for media objects with `"benchmark_output/" in the middle of the location
- URL escape each path fragment for GCS, because GCS does not accept unescaped characters in the public URL