### PR TITLE
Move pytrec_eval to its own optional dependencies section

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -340,6 +340,7 @@ all =
     # crfm-helm[seahelm] is excluded because pyonmttok does not support Python 3.12
     # crfm-helm[dev] is excluded because end-users don't need it.
     # crfm-helm[summarize] is excluded because it requires torch<2.0
+    # crfm-helm[ranking] is excluded because pytrec_eval causes build errors (see #3470)
     # TODO(#2280): Add crfm-helm[summarize] back.
 
 # Development only

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,11 +77,13 @@ scenarios =
 metrics =
     google-api-python-client~=2.64  # For perspective_api_client via toxicity_metrics
     numba~=0.56  # For copyright_metrics
-    pytrec_eval==0.5  # For ranking_metrics
     sacrebleu~=2.2.1  # For disinformation_metrics, machine_translation_metrics
     langdetect~=1.0.9  # For ifeval_metrics
     immutabledict~=4.2.0  # For ifeval_metrics
     gradio_client~=1.3  # For bigcodebench_metrics
+
+ranking = 
+    pytrec_eval==0.5  # For ranking_metrics
 
 summarization =
     summ-eval~=0.892  # For summarization_metrics


### PR DESCRIPTION
GitHub Actions can't install pytrec_eval for some reason, so we remove it.

```
Run uv pip compile setup.cfg --extra all --extra dev --universal --no-annotate --constraints constraints.txt -o requirements.txt
  × Failed to build `pytrec-eval==0.5`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit
      status: 1)

      [stdout]
      Fetching trec_eval from
      https://github.com/usnistgov/trec_eval/archive/v9.0.8.tar.gz.

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 14, in <module>
        File
      "/home/runner/.cache/uv/builds-v0/.tmpnEgVyF/lib/python3.9/site-packages/setuptools/build_meta.py",
      line 334, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
        File
      "/home/runner/.cache/uv/builds-v0/.tmpnEgVyF/lib/python3.9/site-packages/setuptools/build_meta.py",
      line 304, in _get_build_requires
          self.run_setup()
        File
      "/home/runner/.cache/uv/builds-v0/.tmpnEgVyF/lib/python3.9/site-packages/setuptools/build_meta.py",
      line 522, in run_setup
          super().run_setup(setup_script=setup_script)
        File
      "/home/runner/.cache/uv/builds-v0/.tmpnEgVyF/lib/python3.9/site-packages/setuptools/build_meta.py",
      line 320, in run_setup
          exec(code, locals())
        File "<string>", line 64, in <module>
        File
      "/home/runner/.cache/uv/builds-v0/.tmpnEgVyF/lib/python3.9/site-packages/setuptools/__init__.py",
      line [11](https://github.com/stanford-crfm/helm/actions/runs/14039388122/job/39308699291#step:5:12)6, in setup
          _install_setup_requires(attrs)
        File
      "/home/runner/.cache/uv/builds-v0/.tmpnEgVyF/lib/python3.9/site-packages/setuptools/__init__.py",
      line 87, in _install_setup_requires
          dist.parse_config_files(ignore_option_errors=True)
        File
      "/home/runner/.cache/uv/builds-v0/.tmpnEgVyF/lib/python3.9/site-packages/_virtualenv.py",
      line [20](https://github.com/stanford-crfm/helm/actions/runs/14039388122/job/39308699291#step:5:21), in parse_config_files
          result = old_parse_config_files(self, *args, **kwargs)
        File
      "/home/runner/.cache/uv/builds-v0/.tmpnEgVyF/lib/python3.9/site-packages/setuptools/dist.py",
      line 730, in parse_config_files
          self._parse_config_files(filenames=inifiles)
        File
      "/home/runner/.cache/uv/builds-v0/.tmpnEgVyF/lib/python3.9/site-packages/setuptools/dist.py",
      line 599, in _parse_config_files
          opt = self._enforce_underscore(opt, section)
        File
      "/home/runner/.cache/uv/builds-v0/.tmpnEgVyF/lib/python3.9/site-packages/setuptools/dist.py",
      line 6[29](https://github.com/stanford-crfm/helm/actions/runs/14039388122/job/39308699291#step:5:30), in _enforce_underscore
          raise InvalidConfigError(
      setuptools.errors.InvalidConfigError: Invalid dash-separated key
      'description-file' in 'metadata' (setup.cfg), please use the underscore
      name 'description_file' instead.

      hint: This usually indicates a problem with the package or the build
      environment.
```