### PR TITLE
Allow arguments to be passed into annotators

### DIFF
--- a/src/helm/benchmark/annotation/annotator_factory.py
+++ b/src/helm/benchmark/annotation/annotator_factory.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, Mapping, Optional
+from typing import Any, Mapping
 
 from helm.clients.auto_client import AutoClient
 from helm.common.credentials_utils import provide_api_key
@@ -21,23 +21,11 @@ class AnnotatorFactory:
         hlog(f"AnnotatorFactory: file_storage_path = {file_storage_path}")
         hlog(f"AnnotatorFactory: cache_backend_config = {cache_backend_config}")
 
-        # Cache for annotators
-        # This is used to prevent duplicate creation of annotators
-        # It is especially important as annotation is a multi-threaded
-        # process and creating a new annotator for each request can cause
-        # race conditions.
-        self.annotators: Dict[str, Annotator] = {}
-
     def get_annotator(self, annotator_spec: AnnotatorSpec) -> Annotator:
         """Return a annotator based on the name."""
-        # First try to find the annotator in the cache
-        assert annotator_spec.args is None or annotator_spec.args == {}
+        print("[debug] get_annotator called")
         annotator_name: str = annotator_spec.class_name.split(".")[-1].lower().replace("annotator", "")
-        annotator: Optional[Annotator] = self.annotators.get(annotator_name)
-        if annotator is not None:
-            return annotator
 
-        # Otherwise, create the client
         cache_config: CacheConfig = self.cache_backend_config.get_cache_config(annotator_name)
         annotator_spec = inject_object_spec_args(
             annotator_spec,
@@ -55,12 +43,7 @@ class AnnotatorFactory:
                 ),
             },
         )
-        annotator = create_object(annotator_spec)
-
-        # Cache the client
-        self.annotators[annotator_name] = annotator
-
-        return annotator
+        return create_object(annotator_spec)
 
     def _get_file_storage_path(self, annotator_name: str) -> str:
         # Returns the path to use for a local file cache for the given annotator

--- a/src/helm/benchmark/annotation/annotator_factory.py
+++ b/src/helm/benchmark/annotation/annotator_factory.py
@@ -23,7 +23,6 @@ class AnnotatorFactory:
 
     def get_annotator(self, annotator_spec: AnnotatorSpec) -> Annotator:
         """Return a annotator based on the name."""
-        print("[debug] get_annotator called")
         annotator_name: str = annotator_spec.class_name.split(".")[-1].lower().replace("annotator", "")
 
         cache_config: CacheConfig = self.cache_backend_config.get_cache_config(annotator_name)

--- a/src/helm/benchmark/annotation_executor.py
+++ b/src/helm/benchmark/annotation_executor.py
@@ -13,7 +13,7 @@ from helm.common.general import ensure_directory_exists, parallel_map, get_crede
 from helm.common.hierarchical_logger import htrack, hlog
 from helm.benchmark.adaptation.scenario_state import ScenarioState
 from helm.benchmark.adaptation.request_state import RequestState
-from helm.benchmark.annotation.annotator import AnnotatorSpec, Annotator
+from helm.benchmark.annotation.annotator import Annotator
 from helm.benchmark.annotation.annotator_factory import AnnotatorFactory
 from helm.proxy.services.service import CACHE_DIR
 
@@ -88,26 +88,27 @@ class AnnotationExecutor:
             hlog("Skipped annotation.")
             return scenario_state
 
-        if scenario_state.annotator_specs is None or len(scenario_state.annotator_specs) == 0:
+        if not scenario_state.annotator_specs:
             hlog("No annotators to run.")
             return scenario_state
 
-        if all(
-            getattr(self.factory.get_annotator(spec), "use_global_metric", False)
-            for spec in scenario_state.annotator_specs
-        ):
+        try:
+            annotators: List[Annotator] = [
+                self.factory.get_annotator(annotator_spec) for annotator_spec in scenario_state.annotator_specs
+            ]
+        except Exception as e:
+            raise AnnotationExecutorError(f"Could not initialize annotator for spec: {str(e)} ") from e
+
+        if all(getattr(annotator, "use_global_metric", False) for annotator in annotators):
             # Do it!
             request_states = self.process_all(
-                scenario_state.annotator_specs, scenario_state.request_states  # processing all request together
+                annotators, scenario_state.request_states  # processing all request together
             )
 
         else:
             # Do it!
             def do_it(request_state: RequestState) -> RequestState:
-                assert scenario_state.annotator_specs is not None
-                return self.process(scenario_state.annotator_specs, request_state)
-
-            self.annotator_specs = scenario_state.annotator_specs
+                return self.process(annotators, request_state)
 
             request_states = parallel_map(
                 do_it,
@@ -122,22 +123,20 @@ class AnnotationExecutor:
             annotator_specs=scenario_state.annotator_specs,
         )
 
-    def process(self, annotator_specs: List[AnnotatorSpec], state: RequestState) -> RequestState:
+    def process(self, annotators: List[Annotator], state: RequestState) -> RequestState:
         annotations: Dict[str, Any] = {}
         try:
-            for annotator_spec in annotator_specs:
-                annotator: Annotator = self.factory.get_annotator(annotator_spec)
+            for annotator in annotators:
                 new_annotations = annotator.annotate(state)
                 annotations[annotator.name] = new_annotations
         except Exception as e:
             raise AnnotationExecutorError(f"{str(e)} Request: {state.request}") from e
         return replace(state, annotations=annotations)
 
-    def process_all(self, annotator_specs: List[AnnotatorSpec], states: List[RequestState]) -> List[RequestState]:
+    def process_all(self, annotators: List[Annotator], states: List[RequestState]) -> List[RequestState]:
         annotations: Dict[str, Any] = {}
         try:
-            for annotator_spec in annotator_specs:
-                annotator: Annotator = self.factory.get_annotator(annotator_spec)
+            for annotator in annotators:
                 new_annotations = annotator.annotate_all(states)
                 annotations[annotator.name] = new_annotations
         except Exception as e:

--- a/src/helm/benchmark/run_specs/air_bench_run_specs.py
+++ b/src/helm/benchmark/run_specs/air_bench_run_specs.py
@@ -38,7 +38,11 @@ def get_air_bench_2024_spec(
             f"annotator_model={annotator_args['model']},"
             f"annotator_model_deployment={annotator_args['model_deployment']}"
         )
-    annotator_specs = [AnnotatorSpec(class_name="helm.benchmark.annotation.air_bench_annotator.AIRBench2024Annotator")]
+    annotator_specs = [
+        AnnotatorSpec(
+            class_name="helm.benchmark.annotation.air_bench_annotator.AIRBench2024Annotator", args=annotator_args
+        )
+    ]
     metric_specs = [
         MetricSpec(class_name="helm.benchmark.metrics.air_bench_metrics.AIRBench2024ScoreMetric"),
         MetricSpec(class_name="helm.benchmark.metrics.air_bench_metrics.AIRBench2024BasicGenerationMetric"),

--- a/src/helm/benchmark/run_specs/air_bench_run_specs.py
+++ b/src/helm/benchmark/run_specs/air_bench_run_specs.py
@@ -38,11 +38,7 @@ def get_air_bench_2024_spec(
             f"annotator_model={annotator_args['model']},"
             f"annotator_model_deployment={annotator_args['model_deployment']}"
         )
-    annotator_specs = [
-        AnnotatorSpec(
-            class_name="helm.benchmark.annotation.air_bench_annotator.AIRBench2024Annotator", args=annotator_args
-        )
-    ]
+    annotator_specs = [AnnotatorSpec(class_name="helm.benchmark.annotation.air_bench_annotator.AIRBench2024Annotator")]
     metric_specs = [
         MetricSpec(class_name="helm.benchmark.metrics.air_bench_metrics.AIRBench2024ScoreMetric"),
         MetricSpec(class_name="helm.benchmark.metrics.air_bench_metrics.AIRBench2024BasicGenerationMetric"),


### PR DESCRIPTION
- Remove the `AnnotatorFactory` cache
- Remove unnecessary duplicate instantiations of the annotator
- Make all Image2Struct annotators single-threaded