### PR TITLE
Actually make AIR-Bench 2024 annotator configurable

### DIFF
--- a/src/helm/benchmark/run_specs/air_bench_run_specs.py
+++ b/src/helm/benchmark/run_specs/air_bench_run_specs.py
@@ -38,7 +38,11 @@ def get_air_bench_2024_spec(
             f"annotator_model={annotator_args['model']},"
             f"annotator_model_deployment={annotator_args['model_deployment']}"
         )
-    annotator_specs = [AnnotatorSpec(class_name="helm.benchmark.annotation.air_bench_annotator.AIRBench2024Annotator")]
+    annotator_specs = [
+        AnnotatorSpec(
+            class_name="helm.benchmark.annotation.air_bench_annotator.AIRBench2024Annotator", args=annotator_args
+        )
+    ]
     metric_specs = [
         MetricSpec(class_name="helm.benchmark.metrics.air_bench_metrics.AIRBench2024ScoreMetric"),
         MetricSpec(class_name="helm.benchmark.metrics.air_bench_metrics.AIRBench2024BasicGenerationMetric"),


### PR DESCRIPTION
This fixes a bug in #3468 in which the arguments were not actually passed into the annotator. This also requires the change in #3487 to allow annotators to receive arguments.