### PR TITLE
Fix the `reasoning_effort` parameter in Openai Client

### DIFF
--- a/src/helm/clients/openai_client.py
+++ b/src/helm/clients/openai_client.py
@@ -242,7 +242,7 @@ class OpenAIClient(CachingClient):
             raw_request.pop("temperature", None)
 
             if self.reasoning_effort:
-                raw_request["reasoning_effort"] = "self.reasoning_effort"
+                raw_request["reasoning_effort"] = self.reasoning_effort
         elif is_vlm(request.model):
             # Avoid error:
             # "Invalid type for 'stop': expected an unsupported value, but got null instead."


### PR DESCRIPTION
Specifying any level of "reasoning effort" for o1 / o3-mini models resulted in an error:
```
helm.proxy.services.remote_service.RemoteServiceError: Failed to make request to openai/o1-2024-12-17-low-reasoning-effort after retrying 5 times. Error: OpenAI error: Error code: 400 - {'error': {'message': "Invalid value: 'self.reasoning_effort'. Supported values are: 'low', 'medium', and 'high'."...
```

After some investigation, we suspect the cause is [this line in the OpenAI Client](https://github.com/stanford-crfm/helm/blob/main/src/helm/clients/openai_client.py#L245), where a hardcoded string is set as reasoning_effort.

This PR aims to fix the issue.