### PR TITLE
Added missing dependencies for medhelm

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -292,13 +292,20 @@ heim =
     crfm-helm[images]
 
 medhelm = 
-    # Summarization metrics
+    crfm-helm[accelerate]
+    crfm-helm[openai]
     crfm-helm[summarization]
+    crfm-helm[yandex]
 
     #MedHELM scenarios
-    python-docx~=1.1.2
+    bert_score~=0.3.13
     langchain~=0.3.9
+    langchain-community~=0.3.8
     lxml~=5.3.0
+    openpyxl~=3.1
+    python-docx~=1.1.2
+    torch~=2.2.2
+    torchvision~=0.17.2
 
 audiolm =
     crfm-helm[openai]


### PR DESCRIPTION
Medhelm had missing dependencies not listed on the setup.cfg file. This PR adds fix this issue.