### PR TITLE
Change stop sequence for MedCalc and MedHallu

### DIFF
--- a/src/helm/benchmark/run_specs/medhelm_run_specs.py
+++ b/src/helm/benchmark/run_specs/medhelm_run_specs.py
@@ -37,7 +37,7 @@ def get_medcalc_bench_spec() -> RunSpec:
         output_noun="Answer only the requested quantity without units. No explanation needed",
         max_tokens=10,
         max_train_instances=0,
-        stop_sequences=[]
+        stop_sequences=[],
     )
 
     metric_specs = [
@@ -1003,7 +1003,7 @@ No letter or word, just the integer value.
 Your Judgment"""  # noqa: E501
         ),
         max_train_instances=0,
-        stop_sequences=[]
+        stop_sequences=[],
     )
 
     return RunSpec(

--- a/src/helm/benchmark/run_specs/medhelm_run_specs.py
+++ b/src/helm/benchmark/run_specs/medhelm_run_specs.py
@@ -37,6 +37,7 @@ def get_medcalc_bench_spec() -> RunSpec:
         output_noun="Answer only the requested quantity without units. No explanation needed",
         max_tokens=10,
         max_train_instances=0,
+        stop_sequences=[]
     )
 
     metric_specs = [
@@ -1002,6 +1003,7 @@ No letter or word, just the integer value.
 Your Judgment"""  # noqa: E501
         ),
         max_train_instances=0,
+        stop_sequences=[]
     )
 
     return RunSpec(


### PR DESCRIPTION
Reasoning models were using new line token as first output for MedCalc-Bench and MedHallu. Since these scenarios have new line as the stop sequence, all model responses were empty.

This change removes all stop sequences except for max tokens. Since the exact match metric uses strip(), there is no disadvantage when removing this \n stop sequence.

FYI @raulista1997 @HennyJie 