### PR TITLE
add stop sequences for medec

### DIFF
--- a/src/helm/benchmark/run_specs/medhelm_run_specs.py
+++ b/src/helm/benchmark/run_specs/medhelm_run_specs.py
@@ -158,6 +158,7 @@ def get_medec_run_spec() -> RunSpec:
         output_noun="Answer",
         max_tokens=256,
         max_train_instances=0,
+        stop_sequences=[],
     )
 
     # Define the metrics


### PR DESCRIPTION
Add stop sequence to medec scenario to accommodate reasoning models and prevent model responses from being empty.