### PR TITLE
Fix mobile menu z-index

### DIFF
--- a/helm-frontend/src/components/NavBar/NavBar.tsx
+++ b/helm-frontend/src/components/NavBar/NavBar.tsx
@@ -18,7 +18,7 @@ export default function NavBar() {
           </label>
           <ul
             tabIndex={0}
-            className="menu menu-lg dropdown-content mt-3 z-[1] p-2 bg-base-100 shadow"
+            className="menu menu-lg dropdown-content mt-3 z-50 p-2 bg-base-100 shadow"
           >
             <li>
               <Link to="leaderboard">Leaderboard</Link>


### PR DESCRIPTION
Previously, the leaderboard first column incorrectly covered the dropdown menu for small screens.

Before:

![Screenshot 2025-04-09 133142](https://github.com/user-attachments/assets/a347bafe-966b-4d45-bed4-8474271c9177)

After:

![Screenshot 2025-04-09 133130](https://github.com/user-attachments/assets/7442079e-121a-4696-b83b-f1e6751ea91b)
