### PR TITLE
Add run entries with additional tokens and instructions for reasoning models

### DIFF
--- a/src/helm/benchmark/presentation/run_entries_capabilities_reasoning_v2.conf
+++ b/src/helm/benchmark/presentation/run_entries_capabilities_reasoning_v2.conf
@@ -1,8 +1,8 @@
 # Scenarios for HELM Capabilities.
 
 entries: [
-  {description: "mmlu_pro:subject=all,output_format_instructions=mmlu_pro,increase_max_tokens=10000,model=text", priority: 1}
-  {description: "gpqa:subset=main,output_format_instructions=gpqa,increase_max_tokens=10000,model=text", priority: 1}
+  {description: "mmlu_pro:subject=all,output_format_instructions=mmlu_pro_suffix,increase_max_tokens=10000,model=text", priority: 1}
+  {description: "gpqa:subset=main,output_format_instructions=gpqa_suffix,increase_max_tokens=10000,model=text", priority: 1}
   {description: "ifeval:increase_max_tokens=10000,model=text", priority: 1}
   {description: "wildbench:subset=v2,increase_max_tokens=10000,model=text", priority: 1}
   {description: "omni_math:increase_max_tokens=10000,model=text", priority: 1}

--- a/src/helm/benchmark/presentation/run_entries_capabilities_reasoning_v2.conf
+++ b/src/helm/benchmark/presentation/run_entries_capabilities_reasoning_v2.conf
@@ -1,0 +1,9 @@
+# Scenarios for HELM Capabilities.
+
+entries: [
+  {description: "mmlu_pro:subject=all,output_format_instructions=mmlu_pro,increase_max_tokens=10000,model=text", priority: 1}
+  {description: "gpqa:subset=main,output_format_instructions=gpqa,increase_max_tokens=10000,model=text", priority: 1}
+  {description: "ifeval:increase_max_tokens=10000,model=text", priority: 1}
+  {description: "wildbench:subset=v2,increase_max_tokens=10000,model=text", priority: 1}
+  {description: "omni_math:increase_max_tokens=10000,model=text", priority: 1}
+]

--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -21,7 +21,10 @@ from helm.benchmark.model_metadata_registry import (
     AUDIO_LANGUAGE_MODEL_TAG,
     INSTRUCTION_FOLLOWING_MODEL_TAG,
 )
-from helm.benchmark.adaptation.adapters.adapter_factory import ADAPT_GENERATION
+from helm.benchmark.adaptation.adapters.adapter_factory import (
+    ADAPT_GENERATION,
+    ADAPT_MULTIPLE_CHOICE_JOINT_CHAIN_OF_THOUGHT,
+)
 from helm.benchmark.model_deployment_registry import get_model_names_with_tokenizer
 from helm.benchmark.run_spec import RunSpec
 from helm.benchmark.adaptation.adapter_spec import ADAPT_MULTIPLE_CHOICE_JOINT, AdapterSpec, Substitution
@@ -1519,6 +1522,11 @@ class OutputFormatInstructions(RunExpander):
                     "Answer only the last question with a short answer. "
                     "Avoid extra, unnecessary information in the answer."
                 )
+            else:
+                raise ValueError(f"Unknown scenario {self.scenario}")
+        elif run_spec.adapter_spec.method == ADAPT_MULTIPLE_CHOICE_JOINT_CHAIN_OF_THOUGHT:
+            if self.scenario == "mmlu_pro" or self.scenario == "gpqa":
+                instructions = 'In your response, replace "insert answer here" with the single uppercase letter corresponding to your answer.'  # noqa: E501
             else:
                 raise ValueError(f"Unknown scenario {self.scenario}")
 


### PR DESCRIPTION
The new instructions are intended to deal with cases where the model responds "The answer is..." followed by the full answer instead of a single letter.