### PR TITLE
Allow running the MMLU-Pro computer science subject

### DIFF
--- a/src/helm/benchmark/scenarios/mmlu_pro_scenario.py
+++ b/src/helm/benchmark/scenarios/mmlu_pro_scenario.py
@@ -40,7 +40,7 @@ class MMLUProScenario(Scenario):
 
     def __init__(self, subject: str):
         super().__init__()
-        self.subject: str = subject
+        self.subject: str = subject.replace("_", " ")
 
     def process_dataset(self, data: Dataset, split: str) -> List[Instance]:
         """


### PR DESCRIPTION
The subject "computer science" has a space in it, so we have to replace underscores with space so that a run entry like `mmlu_pro:subset=computer_science` will work correctly.