### PR TITLE
Adjust `max_tokens` restriction for Anthropic models

### DIFF
--- a/src/helm/clients/anthropic_client.py
+++ b/src/helm/clients/anthropic_client.py
@@ -243,7 +243,7 @@ class AnthropicMessagesResponseError(Exception):
 
 class AnthropicMessagesClient(CachingClient):
     # Source: https://docs.anthropic.com/claude/docs/models-overview
-    MAX_OUTPUT_TOKENS: int = 4096
+    MAX_OUTPUT_TOKENS: int = 64000
 
     MAX_IMAGE_SIZE_BYTES: int = 5242880  # 5MB
 


### PR DESCRIPTION
See #3546 for discussions.

Increase `MAX_OUTPUT_TOKENS` for `AnthropicMessagesClient` to 64k according to https://docs.anthropic.com/claude/docs/models-overview