### PR TITLE
Avoid accessing SQLite accounts file in helm-run

### DIFF
--- a/src/helm/benchmark/adaptation/adapters/test_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/test_adapter.py
@@ -1,9 +1,9 @@
 import shutil
 import tempfile
 
-from helm.common.authentication import Authentication
+
 from helm.common.cache_backend_config import BlackHoleCacheBackendConfig
-from helm.proxy.services.server_service import ServerService
+from helm.common.local_context import LocalContext
 from helm.benchmark.window_services.tokenizer_service import TokenizerService
 
 
@@ -14,8 +14,8 @@ class TestAdapter:
 
     def setup_method(self):
         self.path: str = tempfile.mkdtemp()
-        service = ServerService(base_path=self.path, root_mode=True, cache_backend_config=BlackHoleCacheBackendConfig())
-        self.tokenizer_service = TokenizerService(service, Authentication("test"))
+        context = LocalContext(base_path=self.path, cache_backend_config=BlackHoleCacheBackendConfig())
+        self.tokenizer_service = TokenizerService(context)
 
     def teardown_method(self, _):
         shutil.rmtree(self.path)

--- a/src/helm/benchmark/metrics/metric_service.py
+++ b/src/helm/benchmark/metrics/metric_service.py
@@ -1,38 +1,38 @@
 from typing import Optional
 
-from helm.common.authentication import Authentication
+from helm.common.context import Context
 from helm.common.critique_request import CritiqueRequest, CritiqueRequestResult
 from helm.common.file_upload_request import FileUploadResult, FileUploadRequest
 from helm.common.nudity_check_request import NudityCheckRequest, NudityCheckResult
 from helm.common.clip_score_request import CLIPScoreRequest, CLIPScoreResult
 from helm.common.perspective_api_request import PerspectiveAPIRequest, PerspectiveAPIRequestResult
 from helm.benchmark.window_services.tokenizer_service import TokenizerService
-from helm.proxy.services.service import Service
 from helm.common.cache import Cache
 
 
+# TODO: Rename this to TokenizerContext
 class MetricService(TokenizerService):
     """
-    A wrapper around `Service` that makes only necessary server requests when calculating metrics.
+    A wrapper around `Context` that makes only necessary server requests when calculating metrics.
     """
 
-    def __init__(self, service: Service, auth: Authentication):
-        super().__init__(service, auth)
+    def __init__(self, context: Context):
+        super().__init__(context)
 
     def check_nudity(self, request: NudityCheckRequest) -> NudityCheckResult:
-        return self._service.check_nudity(self._auth, request)
+        return self._context.check_nudity(request)
 
     def compute_clip_score(self, request: CLIPScoreRequest) -> CLIPScoreResult:
-        return self._service.compute_clip_score(self._auth, request)
+        return self._context.compute_clip_score(request)
 
     def upload(self, request: FileUploadRequest) -> FileUploadResult:
-        return self._service.upload(self._auth, request)
+        return self._context.upload(request)
 
     def get_toxicity_scores(self, request: PerspectiveAPIRequest) -> PerspectiveAPIRequestResult:
-        return self._service.get_toxicity_scores(self._auth, request)
+        return self._context.get_toxicity_scores(request)
 
     def make_critique_request(self, request: CritiqueRequest) -> Optional[CritiqueRequestResult]:
-        return self._service.make_critique_request(self._auth, request)
+        return self._context.make_critique_request(request)
 
     def get_cache(self, shard_name: str) -> Cache:
-        return Cache(self._service.get_cache_config(shard_name))
+        return Cache(self._context.get_cache_config(shard_name))

--- a/src/helm/benchmark/metrics/tokens/test_openai_token_cost_estimator.py
+++ b/src/helm/benchmark/metrics/tokens/test_openai_token_cost_estimator.py
@@ -7,7 +7,7 @@ from helm.benchmark.metrics.metric_service import MetricService
 from helm.common.authentication import Authentication
 from helm.common.request import Request
 from helm.common.tokenization_request import TokenizationRequestResult, TokenizationToken
-from helm.proxy.services.remote_service import RemoteService
+from helm.common.remote_context import RemoteContext
 from helm.benchmark.metrics.tokens.openai_token_cost_estimator import OpenAITokenCostEstimator
 
 
@@ -23,7 +23,7 @@ class TestOpenAITokenCostEstimator:
 
     def setup_method(self, method):
         self._token_cost_estimator = OpenAITokenCostEstimator()
-        self._mock_metric_service = MetricService(RemoteService("DUMMY_URL"), Authentication(api_key="test"))
+        self._mock_metric_service = MetricService(RemoteContext("DUMMY_URL", Authentication(api_key="test")))
         gpt2_tokenizer = GPT2TokenizerFast.from_pretrained("gpt2")
         tokenization_request_result = TokenizationRequestResult(
             success=True,

--- a/src/helm/benchmark/runner.py
+++ b/src/helm/benchmark/runner.py
@@ -164,8 +164,8 @@ class Runner:
             )
         )
         self.dry_run: bool = execution_spec.dry_run
-        self.tokenizer_service = TokenizerService(self.executor.service, execution_spec.auth)
-        self.metric_service = MetricService(self.executor.service, execution_spec.auth)
+        self.tokenizer_service = TokenizerService(self.executor.context)
+        self.metric_service = MetricService(self.executor.context)
         self.skip_instances: bool = skip_instances
         self.cache_instances: bool = cache_instances
         self.cache_instances_only: bool = cache_instances_only

--- a/src/helm/benchmark/scenarios/numeracy_scenario.py
+++ b/src/helm/benchmark/scenarios/numeracy_scenario.py
@@ -11,6 +11,7 @@ from typing import List, Optional, Tuple, Dict
 
 from helm.benchmark.adaptation.adapters.adapter_factory import ADAPT_GENERATION
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
+from helm.common.local_context import LocalContext
 from helm.benchmark.window_services.tokenizer_service import TokenizerService
 from helm.common.authentication import Authentication
 from helm.common.optional_dependencies import handle_module_not_found_error
@@ -39,7 +40,7 @@ except ModuleNotFoundError as e:
 #       https://github.com/stanford-crfm/benchmarking/issues/569
 def get_test_tokenizer_service() -> TokenizerService:
     # Pointed to the default local path set in run.py (--local-path)
-    return TokenizerService(ServerService(base_path="prod_env", root_mode=True), Authentication("test"))
+    return TokenizerService(LocalContext(base_path="prod_env"))
 
 
 SOLUTION_TAG: str = "solution"

--- a/src/helm/benchmark/window_services/test_utils.py
+++ b/src/helm/benchmark/window_services/test_utils.py
@@ -1,8 +1,7 @@
 from typing import List
 
-from helm.common.authentication import Authentication
+from helm.common.local_context import LocalContext
 from helm.common.cache_backend_config import CacheBackendConfig
-from helm.proxy.services.server_service import ServerService
 from helm.benchmark.metrics.metric_service import MetricService
 from helm.benchmark.window_services.tokenizer_service import TokenizerService
 
@@ -229,5 +228,5 @@ GPT4_TEST_TOKENS: List[str] = [
 
 
 def get_tokenizer_service(local_path: str, cache_backend_config: CacheBackendConfig) -> TokenizerService:
-    service = ServerService(base_path=local_path, root_mode=True, cache_backend_config=cache_backend_config)
-    return MetricService(service, Authentication("test"))
+    context = LocalContext(base_path=local_path, cache_backend_config=cache_backend_config)
+    return MetricService(context)

--- a/src/helm/benchmark/window_services/tokenizer_service.py
+++ b/src/helm/benchmark/window_services/tokenizer_service.py
@@ -1,26 +1,25 @@
-from helm.common.authentication import Authentication
+from helm.common.context import Context
 from helm.common.tokenization_request import (
     TokenizationRequest,
     TokenizationRequestResult,
     DecodeRequest,
     DecodeRequestResult,
 )
-from helm.proxy.services.service import Service
 
 
+# TODO: Rename this to TokenizerContext
 class TokenizerService:
     """
-    A wrapper around `Service` that makes only necessary server requests to tokenize.
+    A wrapper around `Context` that makes only necessary server requests to tokenize.
     """
 
-    def __init__(self, service: Service, auth: Authentication):
-        self._service: Service = service
-        self._auth: Authentication = auth
+    def __init__(self, context: Context):
+        self._context: Context = context
 
     def tokenize(self, request: TokenizationRequest) -> TokenizationRequestResult:
         """Tokenize via an API."""
-        return self._service.tokenize(self._auth, request)
+        return self._context.tokenize(request)
 
     def decode(self, request: DecodeRequest) -> DecodeRequestResult:
         """Decode via an API."""
-        return self._service.decode(self._auth, request)
+        return self._context.decode(request)

--- a/src/helm/common/context.py
+++ b/src/helm/common/context.py
@@ -1,0 +1,74 @@
+from abc import ABC, abstractmethod
+
+from helm.common.critique_request import CritiqueRequest, CritiqueRequestResult
+from helm.common.clip_score_request import CLIPScoreRequest, CLIPScoreResult
+from helm.common.file_upload_request import FileUploadResult, FileUploadRequest
+from helm.common.nudity_check_request import NudityCheckRequest, NudityCheckResult
+from helm.common.perspective_api_request import PerspectiveAPIRequestResult, PerspectiveAPIRequest
+from helm.common.moderations_api_request import ModerationAPIRequest, ModerationAPIRequestResult
+from helm.common.tokenization_request import (
+    TokenizationRequest,
+    TokenizationRequestResult,
+    DecodeRequest,
+    DecodeRequestResult,
+)
+from helm.common.request import Request, RequestResult
+from helm.proxy.query import Query, QueryResult
+from helm.common.cache import CacheConfig
+
+
+class Context(ABC):
+    @abstractmethod
+    def expand_query(self, query: Query) -> QueryResult:
+        """Turn the `query` into requests."""
+        pass
+
+    @abstractmethod
+    def make_request(self, request: Request) -> RequestResult:
+        """Actually make a request to an API."""
+        pass
+
+    @abstractmethod
+    def tokenize(self, request: TokenizationRequest) -> TokenizationRequestResult:
+        """Tokenize via an API."""
+        pass
+
+    @abstractmethod
+    def decode(self, request: DecodeRequest) -> DecodeRequestResult:
+        """Decodes to text."""
+        pass
+
+    @abstractmethod
+    def upload(self, request: FileUploadRequest) -> FileUploadResult:
+        """Uploads a file to external storage."""
+        pass
+
+    @abstractmethod
+    def check_nudity(self, request: NudityCheckRequest) -> NudityCheckResult:
+        """Check for nudity for a batch of images."""
+        pass
+
+    @abstractmethod
+    def compute_clip_score(self, request: CLIPScoreRequest) -> CLIPScoreResult:
+        """Computes CLIPScore for a given caption and image."""
+        pass
+
+    @abstractmethod
+    def get_toxicity_scores(self, request: PerspectiveAPIRequest) -> PerspectiveAPIRequestResult:
+        """Get toxicity scores for a batch of text."""
+        pass
+
+    @abstractmethod
+    def get_moderation_results(self, request: ModerationAPIRequest) -> ModerationAPIRequestResult:
+        """Get OpenAI's moderation results for some text."""
+        pass
+
+    @abstractmethod
+    def make_critique_request(self, request: CritiqueRequest) -> CritiqueRequestResult:
+        """Get responses to a critique request."""
+        pass
+
+    @abstractmethod
+    def get_cache_config(self, shard_name: str) -> CacheConfig:
+        """Returns a CacheConfig"""
+        pass

--- a/src/helm/common/context.py
+++ b/src/helm/common/context.py
@@ -15,9 +15,15 @@ from helm.common.tokenization_request import (
 from helm.common.request import Request, RequestResult
 from helm.proxy.query import Query, QueryResult
 from helm.common.cache import CacheConfig
+from helm.proxy.services.service import GeneralInfo
 
 
 class Context(ABC):
+    @abstractmethod
+    def get_general_info(self) -> GeneralInfo:
+        """Get general info."""
+        pass
+
     @abstractmethod
     def expand_query(self, query: Query) -> QueryResult:
         """Turn the `query` into requests."""

--- a/src/helm/common/local_context.py
+++ b/src/helm/common/local_context.py
@@ -1,0 +1,164 @@
+import dataclasses
+import os
+from typing import Optional
+
+from helm.common.context import Context
+from helm.common.cache import CacheConfig
+from helm.common.cache_backend_config import CacheBackendConfig, BlackHoleCacheBackendConfig
+from helm.common.critique_request import CritiqueRequest, CritiqueRequestResult
+from helm.common.moderations_api_request import ModerationAPIRequest, ModerationAPIRequestResult
+from helm.common.clip_score_request import CLIPScoreRequest, CLIPScoreResult
+from helm.common.nudity_check_request import NudityCheckRequest, NudityCheckResult
+from helm.common.file_upload_request import FileUploadRequest, FileUploadResult
+from helm.common.general import ensure_directory_exists, parse_hocon, get_credentials
+from helm.common.perspective_api_request import PerspectiveAPIRequest, PerspectiveAPIRequestResult
+from helm.common.tokenization_request import (
+    TokenizationRequest,
+    TokenizationRequestResult,
+    DecodeRequest,
+    DecodeRequestResult,
+)
+from helm.common.request import Request, RequestResult
+from helm.clients.auto_client import AutoClient
+from helm.clients.moderation_api_client import ModerationAPIClient
+from helm.clients.image_generation.nudity_check_client import NudityCheckClient
+from helm.clients.gcs_client import GCSClient
+from helm.clients.clip_score_client import CLIPScoreClient
+from helm.clients.toxicity_classifier_client import ToxicityClassifierClient
+from helm.proxy.example_queries import example_queries
+from helm.benchmark.model_metadata_registry import ALL_MODELS_METADATA
+from helm.benchmark.model_deployment_registry import get_model_deployment_host_organization
+from helm.proxy.query import Query, QueryResult
+from helm.proxy.retry import retry_request
+from helm.tokenizers.auto_tokenizer import AutoTokenizer
+from helm.proxy.services.service import (
+    CACHE_DIR,
+    GeneralInfo,
+    VERSION,
+    expand_environments,
+    synthesize_request,
+)
+
+
+class LocalContext(Context):
+    """
+    Main class that supports various functionality for the server.
+    """
+
+    def __init__(
+        self,
+        base_path: str = "prod_env",
+        cache_backend_config: CacheBackendConfig = BlackHoleCacheBackendConfig(),
+    ):
+        ensure_directory_exists(base_path)
+        client_file_storage_path = os.path.join(base_path, CACHE_DIR)
+        ensure_directory_exists(client_file_storage_path)
+
+        credentials = get_credentials(base_path)
+
+        self.cache_backend_config = cache_backend_config
+        self.client = AutoClient(credentials, client_file_storage_path, cache_backend_config)
+        self.tokenizer = AutoTokenizer(credentials, cache_backend_config)
+
+        # Lazily instantiate the following clients
+        self.moderation_api_client: Optional[ModerationAPIClient] = None
+        self.toxicity_classifier_client: Optional[ToxicityClassifierClient] = None
+        self.perspective_api_client: Optional[ToxicityClassifierClient] = None
+        self.nudity_check_client: Optional[NudityCheckClient] = None
+        self.clip_score_client: Optional[CLIPScoreClient] = None
+        self.gcs_client: Optional[GCSClient] = None
+
+    def get_general_info(self) -> GeneralInfo:
+        # Can't send release_dates in ModelMetadata bacause dates cannot be round-tripped to and from JSON easily.
+        # TODO(#2158): Either fix this or delete get_general_info.
+        all_models = [dataclasses.replace(model_metadata, release_date=None) for model_metadata in ALL_MODELS_METADATA]
+        return GeneralInfo(version=VERSION, example_queries=example_queries, all_models=all_models)
+
+    def expand_query(self, query: Query) -> QueryResult:
+        """Turn the `query` into requests."""
+        prompt = query.prompt
+        settings = query.settings
+        environments = parse_hocon(query.environments)
+        requests = []
+        for environment in expand_environments(environments):
+            request = synthesize_request(prompt, settings, environment)
+            requests.append(request)
+        return QueryResult(requests=requests)
+
+    def _get_model_group_for_model_deployment(self, model_deployment: str) -> str:
+        if model_deployment.startswith("openai/"):
+            if model_deployment.startswith("openai/code-"):
+                return "codex"
+            elif model_deployment.startswith("openai/dall-e-"):
+                return "dall_e"
+            elif model_deployment.startswith("openai/gpt-4"):
+                return "gpt4"
+            elif model_deployment.startswith("openai/gpt-3"):
+                return "gpt3"
+            elif (
+                model_deployment.startswith("openai/o1")
+                or model_deployment.startswith("openai/o3")
+                or model_deployment.startswith("openai/o4")
+            ):
+                return "o1"
+            else:
+                return "openai"
+        elif model_deployment.startswith("ai21/"):
+            return "jurassic"
+        else:
+            return get_model_deployment_host_organization(model_deployment)
+
+    def make_request(self, request: Request) -> RequestResult:
+        """Actually make a request to an API."""
+        return self.client.make_request(request)
+
+    def tokenize(self, request: TokenizationRequest) -> TokenizationRequestResult:
+        return self.tokenizer.tokenize(request)
+
+    def decode(self, request: DecodeRequest) -> DecodeRequestResult:
+        return self.tokenizer.decode(request)
+
+    def upload(self, request: FileUploadRequest) -> FileUploadResult:
+        if not self.gcs_client:
+            self.gcs_client = self.client.get_gcs_client()
+
+        assert self.gcs_client
+        return self.gcs_client.upload(request)
+
+    def check_nudity(self, request: NudityCheckRequest) -> NudityCheckResult:
+        if not self.nudity_check_client:
+            self.nudity_check_client = self.client.get_nudity_check_client()
+
+        assert self.nudity_check_client
+        return self.nudity_check_client.check_nudity(request)
+
+    def compute_clip_score(self, request: CLIPScoreRequest) -> CLIPScoreResult:
+        if not self.clip_score_client:
+            self.clip_score_client = self.client.get_clip_score_client()
+
+        assert self.clip_score_client
+        return self.clip_score_client.compute_score(request)
+
+    def get_toxicity_scores(self, request: PerspectiveAPIRequest) -> PerspectiveAPIRequestResult:
+        @retry_request
+        def get_toxicity_scores_with_retry(request: PerspectiveAPIRequest) -> PerspectiveAPIRequestResult:
+            if not self.toxicity_classifier_client:
+                self.toxicity_classifier_client = self.client.get_toxicity_classifier_client()
+            return self.toxicity_classifier_client.get_toxicity_scores(request)
+
+        return get_toxicity_scores_with_retry(request)
+
+    def get_moderation_results(self, request: ModerationAPIRequest) -> ModerationAPIRequestResult:
+        @retry_request
+        def get_moderation_results_with_retry(request: ModerationAPIRequest) -> ModerationAPIRequestResult:
+            if not self.moderation_api_client:
+                self.moderation_api_client = self.client.get_moderation_api_client()
+            return self.moderation_api_client.get_moderation_results(request)
+
+        return get_moderation_results_with_retry(request)
+
+    def make_critique_request(self, request: CritiqueRequest) -> CritiqueRequestResult:
+        return self.client.get_critique_client().make_critique_request(request)
+
+    def get_cache_config(self, shard_name: str) -> CacheConfig:
+        return self.cache_backend_config.get_cache_config(shard_name)

--- a/src/helm/common/local_context.py
+++ b/src/helm/common/local_context.py
@@ -27,7 +27,6 @@ from helm.clients.clip_score_client import CLIPScoreClient
 from helm.clients.toxicity_classifier_client import ToxicityClassifierClient
 from helm.proxy.example_queries import example_queries
 from helm.benchmark.model_metadata_registry import ALL_MODELS_METADATA
-from helm.benchmark.model_deployment_registry import get_model_deployment_host_organization
 from helm.proxy.query import Query, QueryResult
 from helm.proxy.retry import retry_request
 from helm.tokenizers.auto_tokenizer import AutoTokenizer
@@ -84,29 +83,6 @@ class LocalContext(Context):
             request = synthesize_request(prompt, settings, environment)
             requests.append(request)
         return QueryResult(requests=requests)
-
-    def _get_model_group_for_model_deployment(self, model_deployment: str) -> str:
-        if model_deployment.startswith("openai/"):
-            if model_deployment.startswith("openai/code-"):
-                return "codex"
-            elif model_deployment.startswith("openai/dall-e-"):
-                return "dall_e"
-            elif model_deployment.startswith("openai/gpt-4"):
-                return "gpt4"
-            elif model_deployment.startswith("openai/gpt-3"):
-                return "gpt3"
-            elif (
-                model_deployment.startswith("openai/o1")
-                or model_deployment.startswith("openai/o3")
-                or model_deployment.startswith("openai/o4")
-            ):
-                return "o1"
-            else:
-                return "openai"
-        elif model_deployment.startswith("ai21/"):
-            return "jurassic"
-        else:
-            return get_model_deployment_host_organization(model_deployment)
 
     def make_request(self, request: Request) -> RequestResult:
         """Actually make a request to an API."""

--- a/src/helm/common/remote_context.py
+++ b/src/helm/common/remote_context.py
@@ -1,0 +1,58 @@
+from helm.common.context import Context
+from helm.common.cache import CacheConfig
+from helm.common.authentication import Authentication
+from helm.common.moderations_api_request import ModerationAPIRequest, ModerationAPIRequestResult
+from helm.common.critique_request import CritiqueRequest, CritiqueRequestResult
+from helm.common.nudity_check_request import NudityCheckRequest, NudityCheckResult
+from helm.common.file_upload_request import FileUploadRequest, FileUploadResult
+from helm.common.perspective_api_request import PerspectiveAPIRequest, PerspectiveAPIRequestResult
+from helm.common.clip_score_request import CLIPScoreRequest, CLIPScoreResult
+from helm.common.tokenization_request import (
+    TokenizationRequest,
+    TokenizationRequestResult,
+    DecodeRequestResult,
+    DecodeRequest,
+)
+from helm.common.request import Request, RequestResult
+from helm.proxy.query import Query, QueryResult
+from helm.proxy.services.remote_service import RemoteService
+from helm.proxy.services.service import Service
+
+
+class RemoteContext(Context):
+    def __init__(self, base_url: str, auth: Authentication):
+        self.service: Service = RemoteService(base_url)
+        self.auth = auth
+
+    def expand_query(self, query: Query) -> QueryResult:
+        return self.service.expand_query(query)
+
+    def make_request(self, request: Request) -> RequestResult:
+        return self.service.make_request(self.auth, request)
+
+    def tokenize(self, request: TokenizationRequest) -> TokenizationRequestResult:
+        return self.service.tokenize(self.auth, request)
+
+    def decode(self, request: DecodeRequest) -> DecodeRequestResult:
+        return self.service.decode(self.auth, request)
+
+    def upload(self, request: FileUploadRequest) -> FileUploadResult:
+        return self.service.upload(self.auth, request)
+
+    def check_nudity(self, request: NudityCheckRequest) -> NudityCheckResult:
+        return self.service.check_nudity(self.auth, request)
+
+    def compute_clip_score(self, request: CLIPScoreRequest) -> CLIPScoreResult:
+        return self.service.compute_clip_score(self.auth, request)
+
+    def get_toxicity_scores(self, request: PerspectiveAPIRequest) -> PerspectiveAPIRequestResult:
+        return self.service.get_toxicity_scores(self.auth, request)
+
+    def get_moderation_results(self, request: ModerationAPIRequest) -> ModerationAPIRequestResult:
+        return self.service.get_moderation_results(self.auth, request)
+
+    def make_critique_request(self, request: CritiqueRequest) -> CritiqueRequestResult:
+        return self.service.make_critique_request(self.auth, request)
+
+    def get_cache_config(self, shard_name: str) -> CacheConfig:
+        return self.service.get_cache_config(shard_name)

--- a/src/helm/common/remote_context.py
+++ b/src/helm/common/remote_context.py
@@ -16,13 +16,16 @@ from helm.common.tokenization_request import (
 from helm.common.request import Request, RequestResult
 from helm.proxy.query import Query, QueryResult
 from helm.proxy.services.remote_service import RemoteService
-from helm.proxy.services.service import Service
+from helm.proxy.services.service import GeneralInfo, Service
 
 
 class RemoteContext(Context):
     def __init__(self, base_url: str, auth: Authentication):
         self.service: Service = RemoteService(base_url)
         self.auth = auth
+
+    def get_general_info(self) -> GeneralInfo:
+        return self.service.get_general_info()
 
     def expand_query(self, query: Query) -> QueryResult:
         return self.service.expand_query(query)

--- a/src/helm/proxy/services/server_service.py
+++ b/src/helm/proxy/services/server_service.py
@@ -1,8 +1,8 @@
-import dataclasses
 import os
 import signal
-from typing import List, Optional
+from typing import List
 
+from helm.common.local_context import LocalContext
 from helm.common.cache import CacheConfig
 from helm.common.cache_backend_config import CacheBackendConfig, BlackHoleCacheBackendConfig
 from helm.common.critique_request import CritiqueRequest, CritiqueRequestResult
@@ -11,7 +11,6 @@ from helm.common.moderations_api_request import ModerationAPIRequest, Moderation
 from helm.common.clip_score_request import CLIPScoreRequest, CLIPScoreResult
 from helm.common.nudity_check_request import NudityCheckRequest, NudityCheckResult
 from helm.common.file_upload_request import FileUploadRequest, FileUploadResult
-from helm.common.general import ensure_directory_exists, parse_hocon, get_credentials
 from helm.common.perspective_api_request import PerspectiveAPIRequest, PerspectiveAPIRequestResult
 from helm.common.tokenization_request import (
     TokenizationRequest,
@@ -22,27 +21,13 @@ from helm.common.tokenization_request import (
 from helm.common.request import Request, RequestResult
 from helm.common.hierarchical_logger import hlog
 from helm.proxy.accounts import Accounts, Account
-from helm.clients.auto_client import AutoClient
-from helm.clients.moderation_api_client import ModerationAPIClient
-from helm.clients.image_generation.nudity_check_client import NudityCheckClient
-from helm.clients.gcs_client import GCSClient
-from helm.clients.clip_score_client import CLIPScoreClient
-from helm.clients.toxicity_classifier_client import ToxicityClassifierClient
-from helm.proxy.example_queries import example_queries
-from helm.benchmark.model_metadata_registry import ALL_MODELS_METADATA
 from helm.benchmark.model_deployment_registry import get_model_deployment_host_organization
 from helm.proxy.query import Query, QueryResult
-from helm.proxy.retry import retry_request
 from helm.proxy.token_counters.auto_token_counter import AutoTokenCounter
-from helm.tokenizers.auto_tokenizer import AutoTokenizer
 from helm.proxy.services.service import (
     Service,
-    CACHE_DIR,
     ACCOUNTS_FILE,
     GeneralInfo,
-    VERSION,
-    expand_environments,
-    synthesize_request,
 )
 
 
@@ -57,43 +42,17 @@ class ServerService(Service):
         root_mode: bool = False,
         cache_backend_config: CacheBackendConfig = BlackHoleCacheBackendConfig(),
     ):
-        ensure_directory_exists(base_path)
-        client_file_storage_path = os.path.join(base_path, CACHE_DIR)
-        ensure_directory_exists(client_file_storage_path)
-
-        credentials = get_credentials(base_path)
         accounts_path = os.path.join(base_path, ACCOUNTS_FILE)
 
-        self.cache_backend_config = cache_backend_config
-        self.client = AutoClient(credentials, client_file_storage_path, cache_backend_config)
-        self.tokenizer = AutoTokenizer(credentials, cache_backend_config)
-        self.token_counter = AutoTokenCounter(self.tokenizer)
+        self.context = LocalContext(base_path, cache_backend_config)
+        self.token_counter = AutoTokenCounter(self.context.tokenizer)
         self.accounts = Accounts(accounts_path, root_mode=root_mode)
 
-        # Lazily instantiate the following clients
-        self.moderation_api_client: Optional[ModerationAPIClient] = None
-        self.toxicity_classifier_client: Optional[ToxicityClassifierClient] = None
-        self.perspective_api_client: Optional[ToxicityClassifierClient] = None
-        self.nudity_check_client: Optional[NudityCheckClient] = None
-        self.clip_score_client: Optional[CLIPScoreClient] = None
-        self.gcs_client: Optional[GCSClient] = None
-
     def get_general_info(self) -> GeneralInfo:
-        # Can't send release_dates in ModelMetadata bacause dates cannot be round-tripped to and from JSON easily.
-        # TODO(#2158): Either fix this or delete get_general_info.
-        all_models = [dataclasses.replace(model_metadata, release_date=None) for model_metadata in ALL_MODELS_METADATA]
-        return GeneralInfo(version=VERSION, example_queries=example_queries, all_models=all_models)
+        return self.context.get_general_info()
 
     def expand_query(self, query: Query) -> QueryResult:
-        """Turn the `query` into requests."""
-        prompt = query.prompt
-        settings = query.settings
-        environments = parse_hocon(query.environments)
-        requests = []
-        for environment in expand_environments(environments):
-            request = synthesize_request(prompt, settings, environment)
-            requests.append(request)
-        return QueryResult(requests=requests)
+        return self.context.expand_query(query)
 
     def _get_model_group_for_model_deployment(self, model_deployment: str) -> str:
         if model_deployment.startswith("openai/"):
@@ -130,7 +89,7 @@ class ServerService(Service):
         self.accounts.check_can_use(auth.api_key, model_group)
 
         # Use!
-        request_result: RequestResult = self.client.make_request(request)
+        request_result: RequestResult = self.context.make_request(request)
 
         # Only deduct if not cached
         if not request_result.cached:
@@ -143,66 +102,39 @@ class ServerService(Service):
     def tokenize(self, auth: Authentication, request: TokenizationRequest) -> TokenizationRequestResult:
         """Tokenize via an API."""
         self.accounts.authenticate(auth)
-        return self.tokenizer.tokenize(request)
+        return self.context.tokenize(request)
 
     def decode(self, auth: Authentication, request: DecodeRequest) -> DecodeRequestResult:
         """Decodes to text."""
         self.accounts.authenticate(auth)
-        return self.tokenizer.decode(request)
+        return self.context.decode(request)
 
     def upload(self, auth: Authentication, request: FileUploadRequest) -> FileUploadResult:
         """Uploads a file to external storage."""
         self.accounts.authenticate(auth)
-
-        if not self.gcs_client:
-            self.gcs_client = self.client.get_gcs_client()
-
-        assert self.gcs_client
-        return self.gcs_client.upload(request)
+        return self.context.upload(request)
 
     def check_nudity(self, auth: Authentication, request: NudityCheckRequest) -> NudityCheckResult:
         """Check for nudity."""
         self.accounts.authenticate(auth)
-
-        if not self.nudity_check_client:
-            self.nudity_check_client = self.client.get_nudity_check_client()
-
-        assert self.nudity_check_client
-        return self.nudity_check_client.check_nudity(request)
+        return self.context.check_nudity(request)
 
     def compute_clip_score(self, auth: Authentication, request: CLIPScoreRequest) -> CLIPScoreResult:
         """Computes CLIPScore for a given caption and image."""
         self.accounts.authenticate(auth)
-
-        if not self.clip_score_client:
-            self.clip_score_client = self.client.get_clip_score_client()
-
-        assert self.clip_score_client
-        return self.clip_score_client.compute_score(request)
+        return self.context.compute_clip_score(request)
 
     def get_toxicity_scores(self, auth: Authentication, request: PerspectiveAPIRequest) -> PerspectiveAPIRequestResult:
-        @retry_request
-        def get_toxicity_scores_with_retry(request: PerspectiveAPIRequest) -> PerspectiveAPIRequestResult:
-            if not self.toxicity_classifier_client:
-                self.toxicity_classifier_client = self.client.get_toxicity_classifier_client()
-            return self.toxicity_classifier_client.get_toxicity_scores(request)
-
         self.accounts.authenticate(auth)
-        return get_toxicity_scores_with_retry(request)
+        return self.context.get_toxicity_scores(request)
 
     def get_moderation_results(self, auth: Authentication, request: ModerationAPIRequest) -> ModerationAPIRequestResult:
-        @retry_request
-        def get_moderation_results_with_retry(request: ModerationAPIRequest) -> ModerationAPIRequestResult:
-            if not self.moderation_api_client:
-                self.moderation_api_client = self.client.get_moderation_api_client()
-            return self.moderation_api_client.get_moderation_results(request)
-
         self.accounts.authenticate(auth)
-        return get_moderation_results_with_retry(request)
+        return self.context.get_moderation_results(request)
 
     def make_critique_request(self, auth: Authentication, request: CritiqueRequest) -> CritiqueRequestResult:
         self.accounts.authenticate(auth)
-        return self.client.get_critique_client().make_critique_request(request)
+        return self.context.make_critique_request(request)
 
     def create_account(self, auth: Authentication) -> Account:
         """Creates a new account."""
@@ -237,4 +169,4 @@ class ServerService(Service):
         hlog("Done.")
 
     def get_cache_config(self, shard_name: str) -> CacheConfig:
-        return self.cache_backend_config.get_cache_config(shard_name)
+        return self.context.get_cache_config(shard_name)


### PR DESCRIPTION
Creates a new `Context` object that doesn't access the SQLite accounts file, and use in the executor in the helm-run code path.

Fixes #1914