### PR TITLE
Run expander for Palmyra X5

### DIFF
--- a/src/helm/benchmark/presentation/run_entries_safety_palmyra_x5.conf
+++ b/src/helm/benchmark/presentation/run_entries_safety_palmyra_x5.conf
@@ -1,0 +1,9 @@
+# run entries for initial HELM Safety release
+
+entries: [
+{description: "xstest:model=text", priority: 1},
+{description: "anthropic_red_team:model=text", priority: 1},
+{description: "simple_safety_tests:model=text", priority: 1},
+{description: "harm_bench:model=text", priority: 2},
+{description: "bbq:subject=all,method=multiple_choice_joint,output_format_instructions=mcqa_no_period,max_train_instances=0,model=text", priority: 3},
+]

--- a/src/helm/benchmark/run_expander.py
+++ b/src/helm/benchmark/run_expander.py
@@ -1479,6 +1479,8 @@ class OutputFormatInstructions(RunExpander):
                 instructions = "Answer with only a single letter."
             elif self.scenario == "mcqa":
                 instructions = "Answer with only a single letter."
+            elif self.scenario == "mcqa_no_period":
+                instructions = "Answer with only a single letter. Do not include a period in your answer."
             elif self.scenario == "mcqa_only_last_question":
                 instructions = "Answer only the last question with only a single letter."
             else:


### PR DESCRIPTION
Palmyra X5 responds to MCQA questions with a trailing period e.g. "A." so it needs to be specifically told not to do that.