### PR TITLE
Refactor: Use Python `logging` library in `hlog`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,7 @@ cohere==5.13.6
 colorama==0.4.6
 colorcet==3.0.1
 coloredlogs==15.0.1
+colorlog==6.9.0
 confection==0.1.5
 contourpy==1.3.0
 cycler==0.12.1

--- a/scripts/decrypt_scenario_states.py
+++ b/scripts/decrypt_scenario_states.py
@@ -12,7 +12,7 @@ from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.adaptation.scenario_state import ScenarioState
 from helm.benchmark.scenarios.scenario import Instance, Reference
 from helm.common.codec import from_json, to_json
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hwarn
 from helm.common.request import Request, RequestResult
 
 _SCENARIO_STATE_FILE_NAME = "scenario_state.json"
@@ -155,10 +155,10 @@ def modify_scenario_states_for_suite(run_suite_path: str, scenario: str) -> None
         scenario_state_path: str = os.path.join(run_suite_path, run_dir_name, _SCENARIO_STATE_FILE_NAME)
         encryption_data_path = os.path.join(run_suite_path, run_dir_name, _DISPLAY_ENCRYPTION_DATA_JSON_FILE_NAME)
         if not os.path.exists(scenario_state_path):
-            hlog(f"WARNING: {run_dir_name} doesn't have {_SCENARIO_STATE_FILE_NAME}, skipping")
+            hwarn(f"{run_dir_name} doesn't have {_SCENARIO_STATE_FILE_NAME}, skipping")
             continue
         if not os.path.exists(encryption_data_path):
-            hlog(f"WARNING: {run_dir_name} doesn't have {_DISPLAY_ENCRYPTION_DATA_JSON_FILE_NAME}, skipping")
+            hwarn(f"{run_dir_name} doesn't have {_DISPLAY_ENCRYPTION_DATA_JSON_FILE_NAME}, skipping")
             continue
         run_path: str = os.path.join(run_suite_path, run_dir_name)
         modify_scenario_state_for_run(run_path)

--- a/scripts/encrypt_scenario_states.py
+++ b/scripts/encrypt_scenario_states.py
@@ -24,7 +24,7 @@ from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.adaptation.scenario_state import ScenarioState
 from helm.benchmark.scenarios.scenario import Instance, Reference
 from helm.common.codec import from_json, to_json
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hlog, hwarn
 from helm.common.request import Request, RequestResult
 from helm.common.general import write
 
@@ -148,7 +148,7 @@ def modify_scenario_states_for_suite(run_suite_path: str, scenario: str) -> None
         run_path: str = os.path.join(run_suite_path, run_dir_name)
         scenario_state_path: str = os.path.join(run_path, _SCENARIO_STATE_FILE_NAME)
         if not os.path.exists(scenario_state_path):
-            hlog(f"WARNING: {run_dir_name} doesn't have {_SCENARIO_STATE_FILE_NAME}, skipping")
+            hwarn(f"{run_dir_name} doesn't have {_SCENARIO_STATE_FILE_NAME}, skipping")
             continue
         encryption_data_path: str = os.path.join(run_path, _ENCRYTED_DATA_JSON_FILE_NAME)
         if os.path.exists(encryption_data_path):

--- a/scripts/medhelm/redact_annotations.py
+++ b/scripts/medhelm/redact_annotations.py
@@ -18,7 +18,7 @@ from tqdm import tqdm
 from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.adaptation.scenario_state import ScenarioState
 from helm.common.codec import from_json, to_json
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hwarn
 
 
 SCENARIO_STATE_FILE_NAME = "scenario_state.json"
@@ -89,7 +89,7 @@ def modify_scenario_states_for_suite(run_suite_path: str) -> None:
     for run_dir_name in tqdm(run_dir_names, disable=None):
         scenario_state_path: str = os.path.join(run_suite_path, run_dir_name, SCENARIO_STATE_FILE_NAME)
         if not os.path.exists(scenario_state_path):
-            hlog(f"WARNING: {run_dir_name} doesn't have {SCENARIO_STATE_FILE_NAME}, skipping")
+            hwarn(f"{run_dir_name} doesn't have {SCENARIO_STATE_FILE_NAME}, skipping")
             continue
         run_path: str = os.path.join(run_suite_path, run_dir_name)
         modify_scenario_state_for_run(run_path)

--- a/scripts/offline_eval/deepfloyd/deepfloyd.py
+++ b/scripts/offline_eval/deepfloyd/deepfloyd.py
@@ -19,7 +19,7 @@ from helm.common.cache import (
 )
 from helm.common.request import Request
 from helm.common.file_caches.local_file_cache import LocalFileCache
-from helm.common.hierarchical_logger import hlog, htrack_block
+from helm.common.hierarchical_logger import hlog, htrack_block, hwarn
 from helm.clients.image_generation.deep_floyd_client import DeepFloydClient
 
 
@@ -206,7 +206,7 @@ if __name__ == "__main__":
         hlog(f"Initialized MongoDB cache with URI: {args.mongo_uri}")
         cache_config = MongoCacheConfig(args.mongo_uri, ORGANIZATION)
     elif args.cache_dir:
-        hlog(f"WARNING: Initialized SQLite cache at path: {args.cache_dir}. Are you debugging??")
+        hwarn(f"Initialized SQLite cache at path: {args.cache_dir}. Are you debugging??")
         cache_config = SqliteCacheConfig(os.path.join(args.cache_dir, f"{ORGANIZATION}.sqlite"))
     else:
         raise ValueError("Either --cache-dir or --mongo-uri should be specified")

--- a/scripts/redact_scenario_states.py
+++ b/scripts/redact_scenario_states.py
@@ -21,7 +21,7 @@ from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.adaptation.scenario_state import ScenarioState
 from helm.benchmark.scenarios.scenario import Instance, Reference
 from helm.common.codec import from_json, to_json
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hwarn
 from helm.common.request import Request, RequestResult, GeneratedOutput, Token
 
 
@@ -116,7 +116,7 @@ def modify_scenario_states_for_suite(run_suite_path: str, redact_output: bool) -
     for run_dir_name in tqdm(run_dir_names, disable=None):
         scenario_state_path: str = os.path.join(run_suite_path, run_dir_name, SCENARIO_STATE_FILE_NAME)
         if not os.path.exists(scenario_state_path):
-            hlog(f"WARNING: {run_dir_name} doesn't have {SCENARIO_STATE_FILE_NAME}, skipping")
+            hwarn(f"{run_dir_name} doesn't have {SCENARIO_STATE_FILE_NAME}, skipping")
             continue
         run_path: str = os.path.join(run_suite_path, run_dir_name)
         modify_scenario_state_for_run(run_path, redact_output)

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ include_package_data = True
 install_requires=
     # Common
     cattrs~=22.2
+    colorlog~=6.9
     dacite~=1.6
     importlib-resources~=5.10
     Mako~=1.2

--- a/src/helm/benchmark/adaptation/adapters/in_context_learning_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/in_context_learning_adapter.py
@@ -10,7 +10,7 @@ from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.scenarios.scenario import Instance, TRAIN_SPLIT, EVAL_SPLITS, Reference
 from helm.common.general import parallel_map
 from helm.common.request import Request
-from helm.common.hierarchical_logger import hlog, htrack, htrack_block
+from helm.common.hierarchical_logger import hlog, htrack, htrack_block, hwarn
 from helm.benchmark.adaptation.adapters.adapter import Adapter
 
 
@@ -39,8 +39,8 @@ class InContextLearningAdapter(Adapter, ABC):
         # Pick out training instances
         all_train_instances: List[Instance] = [instance for instance in instances if instance.split == TRAIN_SPLIT]
         if len(all_train_instances) < self.adapter_spec.max_train_instances:
-            hlog(
-                f"WARNING: only {len(all_train_instances)} training instances, "
+            hwarn(
+                f"only {len(all_train_instances)} training instances, "
                 f"wanted {self.adapter_spec.max_train_instances}"
             )
 

--- a/src/helm/benchmark/annotation/bigcodebench_annotator.py
+++ b/src/helm/benchmark/annotation/bigcodebench_annotator.py
@@ -9,7 +9,7 @@ from retrying import retry
 
 from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.annotation.annotator import Annotator
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hlog, hwarn
 
 
 # Based on https://github.com/bigcode-project/bigcodebench/blob/0331489b29cbf2653b4669597ef431e158882aab/bigcodebench/syncheck.py#L14  # noqa: E501
@@ -60,8 +60,8 @@ class BigCodeBenchAnnotator(Annotator):
             hlog(f"BigCodeBenchAnnotator will use the configured endpoint {endpoint}")
             self.client = Client(endpoint, hf_token=api_key)
         else:
-            hlog(
-                f"WARNING: BigCodeBenchAnnotator will use the default public evaluator endpoint {self.DEFAULT_URL} - "
+            hwarn(
+                f"BigCodeBenchAnnotator will use the default public evaluator endpoint {self.DEFAULT_URL} - "
                 "set bigcodebenchApiKey and bigcodebenchEndpoint in credentials.conf to use a cloned evaluator instead"
             )
             self.client = Client(self.DEFAULT_URL)

--- a/src/helm/benchmark/annotation/bird_sql_annotator.py
+++ b/src/helm/benchmark/annotation/bird_sql_annotator.py
@@ -6,7 +6,7 @@ import sqlite3
 from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.annotation.annotator import Annotator
 from helm.benchmark.runner import get_benchmark_output_path
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hwarn
 
 
 class BirdSQLAnnotator(Annotator):
@@ -34,7 +34,7 @@ class BirdSQLAnnotator(Annotator):
             cursor.execute(ground_truth_sql)
             ground_truth_result = cursor.fetchall()
         except (sqlite3.OperationalError, sqlite3.Warning) as e:
-            hlog(f"WARNING: Ground truth SQL failed with error: {e}")
+            hwarn(f"Ground truth SQL failed with error: {e}")
 
         assert request_state.result is not None
         assert len(request_state.result.completions) == 1

--- a/src/helm/benchmark/annotation/ehr_sql_annotator.py
+++ b/src/helm/benchmark/annotation/ehr_sql_annotator.py
@@ -4,7 +4,7 @@ import re
 import sqlite3
 from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.annotation.annotator import Annotator
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hwarn
 from helm.benchmark.runner import get_benchmark_output_path
 
 
@@ -32,7 +32,7 @@ class EhrSqlAnnotator(Annotator):
                 cursor.execute(ground_truth_sql)
                 ground_truth_result = cursor.fetchall()
         except (sqlite3.OperationalError, sqlite3.Warning) as e:
-            hlog(f"WARNING: Ground truth SQL failed with error: {e}")
+            hwarn(f"Ground truth SQL failed with error: {e}")
 
         # If ground truth SQL execution didn't return results, attempt to use extra_data["value"]
         if not ground_truth_result and request_state.instance.extra_data is not None:

--- a/src/helm/benchmark/annotation/helpdesk_call_summarization_annotator.py
+++ b/src/helm/benchmark/annotation/helpdesk_call_summarization_annotator.py
@@ -5,7 +5,7 @@ from helm.benchmark.annotation.model_as_judge import AnnotatorModelInfo
 from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.annotation.annotator import Annotator
 from helm.clients.auto_client import AutoClient
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hwarn
 from helm.common.request import Request
 from helm.proxy.retry import NonRetriableException
 
@@ -107,8 +107,8 @@ Please respond with your output and reasoning in the following format, your reas
             if reasoning_match:
                 reasoning = reasoning_match.group(1).strip()
             else:
-                hlog(
-                    "WARNING: HelpdeskCallSummarizationAnnotator could not get Reasoning from annotation from "
+                hwarn(
+                    "HelpdeskCallSummarizationAnnotator could not get Reasoning from annotation from "
                     f"{annotator_model_info.model_name}: {annotator_response_text}"
                 )
 
@@ -116,13 +116,13 @@ Please respond with your output and reasoning in the following format, your reas
                 try:
                     score = float(score_match.group(1).strip())
                 except ValueError:
-                    hlog(
-                        "WARNING: HelpdeskCallSummarizationAnnotator could not parse Score from annotation from "
+                    hwarn(
+                        "HelpdeskCallSummarizationAnnotator could not parse Score from annotation from "
                         f"{annotator_model_info.model_name}: {annotator_response_text}"
                     )
             else:
-                hlog(
-                    "WARNING: HelpdeskCallSummarizationAnnotator could not get Score from annotation from "
+                hwarn(
+                    "HelpdeskCallSummarizationAnnotator could not get Score from annotation from "
                     f"{annotator_model_info.model_name}: {annotator_response_text}"
                 )
 

--- a/src/helm/benchmark/annotation/omni_math_annotator.py
+++ b/src/helm/benchmark/annotation/omni_math_annotator.py
@@ -5,7 +5,7 @@ from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.annotation.annotator import Annotator
 from helm.benchmark.annotation.model_as_judge import AnnotatorModelInfo
 from helm.clients.auto_client import AutoClient
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hwarn
 from helm.common.request import Request
 
 
@@ -47,9 +47,8 @@ class OmniMATHAnnotator(Annotator):
             .replace("{{Solution}}", model_output_text)
         )
         if not model_output_text.strip():
-            hlog(
-                "WARNING: OmniMATHAnnotator skipped sending requests to annotator models "
-                "because the model response was empty"
+            hwarn(
+                "OmniMATHAnnotator skipped sending requests to annotator models " "because the model response was empty"
             )
             return {
                 "prompt_text": None,
@@ -85,8 +84,8 @@ class OmniMATHAnnotator(Annotator):
             )
             annotator_response = self._auto_client.make_request(annotator_request)
             if not annotator_response.success:
-                hlog(
-                    "WARNING: OmniMATHAnnotator got an error response from "
+                hwarn(
+                    "OmniMATHAnnotator got an error response from "
                     f"{annotator_model_info.model_name}: {annotator_response.error}"
                 )
             else:
@@ -96,16 +95,16 @@ class OmniMATHAnnotator(Annotator):
                 try:
                     student_final_answer = report_parts["Student Final Answer"]
                 except KeyError:
-                    hlog(
-                        "WARNING: OmniMATHAnnotator could not get Student Final Answer from annotation from "
+                    hwarn(
+                        "OmniMATHAnnotator could not get Student Final Answer from annotation from "
                         f"{annotator_model_info.model_name}: {annotator_response_text}"
                     )
 
                 try:
                     justification = report_parts["Justification"].strip().removesuffix("=== report over ===").strip()
                 except KeyError:
-                    hlog(
-                        "WARNING: OmniMATHAnnotator could not get Justification from annotation from "
+                    hwarn(
+                        "OmniMATHAnnotator could not get Justification from annotation from "
                         f"{annotator_model_info.model_name}: {annotator_response_text}"
                     )
 
@@ -116,13 +115,13 @@ class OmniMATHAnnotator(Annotator):
                     elif equivalence_judgement_str == "FALSE":
                         equivalence_judgement = False
                     else:
-                        hlog(
-                            "WARNING: OmniMATHAnnotator got a non-boolean Equivalence Judgement from annotation from "
+                        hwarn(
+                            "OmniMATHAnnotator got a non-boolean Equivalence Judgement from annotation from "
                             f"{annotator_model_info.model_name}: {equivalence_judgement_str}"
                         )
                 except KeyError:
-                    hlog(
-                        "WARNING: OmniMATHAnnotator could not get Equivalence Judgement from annotation from "
+                    hwarn(
+                        "OmniMATHAnnotator could not get Equivalence Judgement from annotation from "
                         f"{annotator_model_info.model_name}: {annotator_response_text}"
                     )
 

--- a/src/helm/benchmark/annotation/wildbench_annotator.py
+++ b/src/helm/benchmark/annotation/wildbench_annotator.py
@@ -7,7 +7,7 @@ from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.annotation.annotator import Annotator
 from helm.benchmark.annotation.model_as_judge import AnnotatorModelInfo
 from helm.clients.auto_client import AutoClient
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hwarn
 from helm.common.request import Request
 
 
@@ -32,8 +32,8 @@ class WildBenchAnnotator(Annotator):
         model_output_text = request_state.result.completions[0].text
         if not model_output_text.strip():
             # Following https://github.com/allenai/WildBench/blob/d6b8dcaf377d173d031980f97c16e1a82618c03d/src/eval.py
-            hlog(
-                "WARNING: WildBenchAnnotator skipped sending requests to annotator models "
+            hwarn(
+                "WildBenchAnnotator skipped sending requests to annotator models "
                 "because the model response was empty"
             )
             return {
@@ -87,8 +87,8 @@ class WildBenchAnnotator(Annotator):
             score: Optional[float] = None
             annotator_response = self._auto_client.make_request(annotator_request)
             if not annotator_response.success:
-                hlog(
-                    "WARNING: WildBenchAnnotator got an error response from "
+                hwarn(
+                    "WildBenchAnnotator got an error response from "
                     f"{annotator_model_info.model_name}: : {annotator_response.error}"
                 )
             else:
@@ -96,8 +96,8 @@ class WildBenchAnnotator(Annotator):
                 annotator_response_text = annotator_response.completions[0].text
                 annotator_response_parts = self._pattern.search(annotator_response_text)
                 if not annotator_response_parts:
-                    hlog(
-                        "WARNING: WildBenchAnnotator got a malformed annotation from "
+                    hwarn(
+                        "WildBenchAnnotator got a malformed annotation from "
                         f"{annotator_model_info.model_name}: {annotator_response_text}"
                     )
                 else:
@@ -107,8 +107,8 @@ class WildBenchAnnotator(Annotator):
                     try:
                         score = float(score_text)
                     except ValueError:
-                        hlog(
-                            "WARNING: WildBenchAnnotator could not parse the score from the annotation from "
+                        hwarn(
+                            "WildBenchAnnotator could not parse the score from the annotation from "
                             f"{annotator_model_info.model_name}: {annotator_response_text}"
                         )
 

--- a/src/helm/benchmark/executor.py
+++ b/src/helm/benchmark/executor.py
@@ -11,7 +11,7 @@ from helm.common.cache_backend_config import (
     SqliteCacheBackendConfig,
 )
 from helm.common.general import parallel_map
-from helm.common.hierarchical_logger import htrack, hlog
+from helm.common.hierarchical_logger import htrack, hlog, hwarn
 from helm.common.request import RequestResult, GeneratedOutput
 from helm.common.authentication import Authentication
 from helm.benchmark.adaptation.scenario_state import ScenarioState
@@ -115,7 +115,7 @@ class Executor:
             raise ExecutorError(f"{str(e)} Request: {state.request}") from e
         if not result.success:
             if result.error_flags and not result.error_flags.is_fatal:
-                hlog(f"WARNING: Non-fatal error treated as empty completion: {result.error}")
+                hwarn(f"Non-fatal error treated as empty completion: {result.error}")
                 result.completions = [GeneratedOutput(text="", logprob=0, tokens=[])]
             else:
                 raise ExecutorError(f"{str(result.error)} Request: {state.request}")

--- a/src/helm/benchmark/metrics/classification_metrics.py
+++ b/src/helm/benchmark/metrics/classification_metrics.py
@@ -9,7 +9,7 @@ from helm.benchmark.metrics.evaluate_reference_metrics import normalize_text
 from helm.benchmark.metrics.metric import MetricName
 from helm.benchmark.metrics.statistic import Stat
 from helm.benchmark.scenarios.scenario import Reference
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hwarn
 from helm.common.request import GeneratedOutput
 
 
@@ -75,8 +75,8 @@ class ClassificationMetric(EvaluateInstancesMetric):
         self.delimiter = delimiter
         self.labels = labels
         if not self.labels:
-            hlog(
-                "WARNING: `labels` were not set on `ClassificationMetric`, "
+            hwarn(
+                "`labels` were not set on `ClassificationMetric`, "
                 "so they will be inferred from target references. "
                 "It is recommend to explicitly set `labels` on `ClassificationMetric`."
             )

--- a/src/helm/benchmark/metrics/cleva_harms_metrics.py
+++ b/src/helm/benchmark/metrics/cleva_harms_metrics.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from helm.common.perspective_api_request import PerspectiveAPIRequest, PerspectiveAPIRequestResult
 from helm.common.request import RequestResult
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hlog, hwarn
 from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.metrics.cleva_metrics_helper import ChineseTokenizer
@@ -200,7 +200,7 @@ class CLEVAToxicityMetric(ToxicityMetric):
             )
         except PerspectiveAPIClientCredentialsError as e:
             self._perspective_api_unavailable = True
-            hlog(f"WARNING: Skipping ToxicityMetrics because Perspective API Client unavailable due to error: {e}")
+            hwarn(f"Skipping ToxicityMetrics because Perspective API Client unavailable due to error: {e}")
             hlog(
                 "To enable ToxicityMetrics, see: https://crfm-helm.readthedocs.io/en/latest/benchmark/#perspective-api"
             )

--- a/src/helm/benchmark/metrics/conv_fin_qa_calc_metrics.py
+++ b/src/helm/benchmark/metrics/conv_fin_qa_calc_metrics.py
@@ -8,7 +8,7 @@ from helm.benchmark.metrics.metric_name import MetricName
 from helm.benchmark.metrics.metric_service import MetricService
 from helm.benchmark.metrics.statistic import Stat
 from helm.benchmark.scenarios.scenario import CORRECT_TAG
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hwarn
 
 
 def _strip_string(str: str) -> Any:
@@ -41,7 +41,7 @@ def float_equiv(str1: str, str2: str, eps: float = 1e-6) -> float:
         ss2 = _strip_string(str2)
 
         if ss1 is None or ss2 is None:
-            hlog("WARNING: float_equiv returning 1.0 because both values are non-floats")
+            hwarn("float_equiv returning 1.0 because both values are non-floats")
             return 0.0
         return float(abs(ss1 - ss2) < eps)
     except Exception:

--- a/src/helm/benchmark/metrics/efficiency_metrics.py
+++ b/src/helm/benchmark/metrics/efficiency_metrics.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional
 import json
 import importlib_resources as resources
 
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hwarn
 from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.window_services.window_service import WindowService
@@ -112,8 +112,8 @@ class EfficiencyMetric:
             if num_prompt_tokens <= num_output_tokens:
                 num_output_tokens -= num_prompt_tokens
             else:
-                hlog(
-                    f"WARNING: num_prompt_tokens ({num_prompt_tokens}) > num_output_tokens ({num_output_tokens}) "
+                hwarn(
+                    f"num_prompt_tokens ({num_prompt_tokens}) > num_output_tokens ({num_output_tokens}) "
                     f"for prompt: {prompt}"
                 )
                 num_output_tokens = 0

--- a/src/helm/benchmark/metrics/ifeval_metrics.py
+++ b/src/helm/benchmark/metrics/ifeval_metrics.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hwarn
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.metrics.metric import Metric
@@ -46,7 +46,7 @@ class IFEvalMetric(Metric):
                 try:
                     is_following = instruction.check_following(response)
                 except Exception as e:
-                    hlog(f"WARNING: Instruction following checking failed with error message {e}")
+                    hwarn(f"Instruction following checking failed with error message {e}")
             if is_following:
                 is_following_list.append(1)
             else:

--- a/src/helm/benchmark/metrics/toxicity_metrics.py
+++ b/src/helm/benchmark/metrics/toxicity_metrics.py
@@ -2,7 +2,7 @@ from typing import List
 
 from helm.common.perspective_api_request import PerspectiveAPIRequest, PerspectiveAPIRequestResult
 from helm.common.request import RequestResult
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hlog, hwarn
 from helm.benchmark.adaptation.request_state import RequestState
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.clients.perspective_api_client import PerspectiveAPIClientCredentialsError
@@ -62,7 +62,7 @@ class ToxicityMetric(Metric):
             )
         except PerspectiveAPIClientCredentialsError as e:
             self._perspective_api_unavailable = True
-            hlog(f"WARNING: Skipping ToxicityMetrics because Perspective API Client unavailable due to error: {e}")
+            hwarn(f"Skipping ToxicityMetrics because Perspective API Client unavailable due to error: {e}")
             hlog(
                 "To enable ToxicityMetrics, see: https://crfm-helm.readthedocs.io/en/latest/benchmark/#perspective-api"
             )

--- a/src/helm/benchmark/metrics/unitxt_metrics.py
+++ b/src/helm/benchmark/metrics/unitxt_metrics.py
@@ -5,12 +5,12 @@ from typing import Dict, List, Set
 from datasets import load_dataset
 import evaluate
 
-from helm.common.general import hlog
 from helm.benchmark.metrics.metric import MetricInterface, MetricResult, PerInstanceStats
 from helm.benchmark.adaptation.scenario_state import ScenarioState
 from helm.benchmark.metrics.metric_name import MetricName
 from helm.benchmark.metrics.metric_service import MetricService
 from helm.benchmark.metrics.statistic import Stat
+from helm.common.hierarchical_logger import hwarn
 
 
 class UnitxtMetric(MetricInterface):
@@ -86,9 +86,8 @@ class UnitxtMetric(MetricInterface):
                 )
             )
         if non_number_instance_metric_names:
-            hlog(
-                "WARNING: Ignored Unitxt instance metrics because "
-                f"they were not numbers: {non_number_instance_metric_names}"
+            hwarn(
+                "Ignored Unitxt instance metrics because " f"they were not numbers: {non_number_instance_metric_names}"
             )
 
         # Extract global metrics

--- a/src/helm/benchmark/model_deployment_registry.py
+++ b/src/helm/benchmark/model_deployment_registry.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import cattrs
 import yaml
 
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hlog, hwarn
 from helm.common.object_spec import ObjectSpec
 from helm.benchmark.model_metadata_registry import (
     ModelMetadata,
@@ -104,9 +104,7 @@ def register_model_deployment(model_deployment: ModelDeployment) -> None:
     try:
         model_metadata = get_model_metadata(model_name)
     except ValueError:
-        hlog(
-            f"WARNING: Could not find model metadata for model {model_name} of model deployment {model_deployment.name}"
-        )
+        hwarn(f"Could not find model metadata for model {model_name} of model deployment {model_deployment.name}")
         model_metadata = get_unknown_model_metadata(model_name)
         register_model_metadata(model_metadata)
     deployment_names: List[str] = model_metadata.deployment_names or [model_metadata.name]
@@ -130,7 +128,7 @@ def get_model_deployment(name: str, warn_deprecated: bool = False) -> ModelDeplo
         raise ValueError(f"Model deployment {name} not found")
     deployment: ModelDeployment = DEPLOYMENT_NAME_TO_MODEL_DEPLOYMENT[name]
     if deployment.deprecated and warn_deprecated:
-        hlog(f"WARNING: DEPLOYMENT Model deployment {name} is deprecated")
+        hwarn(f"DEPLOYMENT Model deployment {name} is deprecated")
     return deployment
 
 
@@ -182,7 +180,7 @@ def get_default_model_deployment_for_model(
         deployment: ModelDeployment = DEPLOYMENT_NAME_TO_MODEL_DEPLOYMENT[model_name]
         if deployment.deprecated and ignore_deprecated:
             if warn_arg_deprecated:
-                hlog(f"WARNING: Model deployment {model_name} is deprecated")
+                hwarn(f"Model deployment {model_name} is deprecated")
             return None
         return deployment.name
 
@@ -193,7 +191,7 @@ def get_default_model_deployment_for_model(
     if len(available_deployments) > 0:
         available_deployment_names: List[str] = [deployment.name for deployment in available_deployments]
         if warn_arg_deprecated:
-            hlog("WARNING: Model name is deprecated. Please use the model deployment name instead.")
+            hwarn("Model name is deprecated. Please use the model deployment name instead.")
             hlog(f"Available model deployments for model {model_name}: {available_deployment_names}")
 
         # Additionally, if there is a non-deprecated deployment, use it.
@@ -210,7 +208,7 @@ def get_default_model_deployment_for_model(
         else:
             chosen_deployment = available_deployments[0]
             if warn_arg_deprecated:
-                hlog(f"WARNING: All model deployments for model {model_name} are deprecated.")
+                hwarn(f"All model deployments for model {model_name} are deprecated.")
         if warn_arg_deprecated:
             hlog(
                 f"Choosing {chosen_deployment.name} (the first one) as "

--- a/src/helm/benchmark/presentation/contamination.py
+++ b/src/helm/benchmark/presentation/contamination.py
@@ -4,7 +4,7 @@ import dacite
 import importlib_resources as resources
 import yaml
 
-from helm.common.hierarchical_logger import htrack, hlog
+from helm.common.hierarchical_logger import htrack, hlog, hwarn
 from helm.benchmark.model_metadata_registry import MODEL_NAME_TO_MODEL_METADATA
 from helm.benchmark.presentation.schema import Schema
 
@@ -71,10 +71,10 @@ def validate_contamination(contamination: Contamination, schema: Schema):
     for point in contamination.points:
         for model in point.models:
             if model not in MODEL_NAME_TO_MODEL_METADATA:
-                hlog(f"WARNING: model {model} not defined in schema")
+                hwarn(f"model {model} not defined in schema")
         for group in point.groups:
             if group not in schema.name_to_run_group:
-                hlog(f"WARNING: group {group} not defined in schema")
+                hwarn(f"group {group} not defined in schema")
 
 
 def read_contamination():

--- a/src/helm/benchmark/presentation/create_plots.py
+++ b/src/helm/benchmark/presentation/create_plots.py
@@ -11,7 +11,7 @@ import numpy as np
 from scipy.stats import pearsonr
 
 from helm.benchmark.config_registry import register_builtin_configs_from_helm_package
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hlog, setup_default_logging
 from helm.common.optional_dependencies import handle_module_not_found_error
 from helm.benchmark.model_metadata_registry import MODEL_NAME_TO_MODEL_METADATA
 
@@ -600,17 +600,7 @@ class Plotter:
         self.create_constrast_set_plots()
 
 
-def main():
-    """
-    This script creates the plots used in the HELM paper (https://arxiv.org/abs/2211.09110).
-    It should be run _after_ running `summarize.py` with the same `benchmark_output` and `suite` arguments and through
-    the top-level command `helm-create-plots`.
-    """
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-o", "--output-path", type=str, help="Path to benchmarking output", default="benchmark_output")
-    parser.add_argument("--suite", type=str, help="Name of the suite that we are plotting", required=True)
-    parser.add_argument("--plot-format", help="Format for saving plots", default="png", choices=["png", "pdf"])
-    args = parser.parse_args()
+def create_plots(args):
     register_builtin_configs_from_helm_package()
     base_path = os.path.join(args.output_path, "runs", args.suite)
     if not os.path.exists(os.path.join(base_path, "groups")):
@@ -619,6 +609,37 @@ def main():
     save_path = os.path.join(base_path, "plots")
     plotter = Plotter(base_path=base_path, save_path=save_path, plot_format=args.plot_format)
     plotter.create_all_plots()
+
+
+def main():
+    """
+    This script creates the plots used in the HELM paper (https://arxiv.org/abs/2211.09110).
+    It should be run _after_ running `summarize.py` with the same `benchmark_output` and `suite` arguments and through
+    the top-level command `helm-create-plots`.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-o",
+        "--output-path",
+        type=str,
+        help="Path to benchmarking output",
+        default="benchmark_output",
+    )
+    parser.add_argument(
+        "--suite",
+        type=str,
+        help="Name of the suite that we are plotting",
+        required=True,
+    )
+    parser.add_argument(
+        "--plot-format",
+        help="Format for saving plots",
+        default="png",
+        choices=["png", "pdf"],
+    )
+    args = parser.parse_args()
+    setup_default_logging()
+    create_plots(args)
 
 
 if __name__ == "__main__":

--- a/src/helm/benchmark/presentation/schema.py
+++ b/src/helm/benchmark/presentation/schema.py
@@ -11,6 +11,7 @@ import importlib_resources as resources
 from helm.common.general import hlog
 from helm.benchmark.metrics.metric_name import MetricName
 from helm.benchmark.augmentations.perturbation_description import PERTURBATION_WORST
+from helm.common.hierarchical_logger import hwarn
 
 
 # TODO: change to `helm.benchmark.config`
@@ -281,5 +282,5 @@ def read_schema(schema_path: str) -> Schema:
         raw = yaml.safe_load(f)
     schema = dacite.from_dict(Schema, raw)
     if schema.adapter:
-        hlog(f"WARNING: The `adapter` field is deprecated and should be removed from schema file {schema_path}")
+        hwarn(f"The `adapter` field is deprecated and should be removed from schema file {schema_path}")
     return dataclasses.replace(schema, adapter=get_adapter_fields())

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -30,7 +30,7 @@ from helm.common.general import (
     unique_simplification,
 )
 from helm.common.codec import from_json
-from helm.common.hierarchical_logger import hlog, htrack, htrack_block
+from helm.common.hierarchical_logger import hlog, htrack, htrack_block, setup_default_logging
 from helm.benchmark.scenarios.scenario import ScenarioSpec
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.metrics.metric_name import MetricName
@@ -1232,60 +1232,7 @@ class Summarizer:
 
 
 @htrack("summarize")
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "-o", "--output-path", type=str, help="Where the benchmarking output lives", default="benchmark_output"
-    )
-    parser.add_argument(
-        "--schema-path",
-        type=str,
-        help="Path to the schema file (e.g., schema_classic.yaml).",
-    )
-    parser.add_argument(
-        "--suite",
-        type=str,
-        help="Name of the suite this summarization should go under.",
-    )
-    parser.add_argument(
-        "--release",
-        type=str,
-        help="Experimental: Name of the release this summarization should go under.",
-    )
-    parser.add_argument(
-        "--suites", type=str, nargs="+", help="Experimental: List of suites to summarize for this this release."
-    )
-    parser.add_argument("-n", "--num-threads", type=int, help="Max number of threads used to summarize", default=8)
-    parser.add_argument(
-        "--debug",
-        action="store_true",
-        help="Display debugging information.",
-    )
-    parser.add_argument(
-        "--skip-completed-run-display-json",
-        action="store_true",
-        help="Skip write_run_display_json() for runs which already have all output display JSON files",
-    )
-    parser.add_argument(
-        "--local-path",
-        type=str,
-        help="If running locally, the path for `ServerService`.",
-        default="prod_env",
-    )
-    parser.add_argument(
-        "--allow-unknown-models",
-        type=bool,
-        help="Whether to allow unknown models in the metadata file",
-        default=True,
-    )
-    parser.add_argument(
-        "--summarizer-class-name",
-        type=str,
-        default=None,
-        help="EXPERIMENTAL: Full class name of the Summarizer class to use. If unset, uses the default Summarizer.",
-    )
-    args = parser.parse_args()
-
+def summarize(args):
     release: Optional[str] = None
     suites: Optional[str] = None
     suite: Optional[str] = None
@@ -1326,6 +1273,76 @@ def main():
     )
     summarizer.run_pipeline(skip_completed=args.skip_completed_run_display_json)
     hlog("Done.")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-o",
+        "--output-path",
+        type=str,
+        help="Where the benchmarking output lives",
+        default="benchmark_output",
+    )
+    parser.add_argument(
+        "--schema-path",
+        type=str,
+        help="Path to the schema file (e.g., schema_classic.yaml).",
+    )
+    parser.add_argument(
+        "--suite",
+        type=str,
+        help="Name of the suite this summarization should go under.",
+    )
+    parser.add_argument(
+        "--release",
+        type=str,
+        help="Experimental: Name of the release this summarization should go under.",
+    )
+    parser.add_argument(
+        "--suites",
+        type=str,
+        nargs="+",
+        help="Experimental: List of suites to summarize for this this release.",
+    )
+    parser.add_argument(
+        "-n",
+        "--num-threads",
+        type=int,
+        help="Max number of threads used to summarize",
+        default=8,
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Display debugging information.",
+    )
+    parser.add_argument(
+        "--skip-completed-run-display-json",
+        action="store_true",
+        help="Skip write_run_display_json() for runs which already have all output display JSON files",
+    )
+    parser.add_argument(
+        "--local-path",
+        type=str,
+        help="If running locally, the path for `ServerService`.",
+        default="prod_env",
+    )
+    parser.add_argument(
+        "--allow-unknown-models",
+        type=bool,
+        help="Whether to allow unknown models in the metadata file",
+        default=True,
+    )
+    parser.add_argument(
+        "--summarizer-class-name",
+        type=str,
+        default=None,
+        help="EXPERIMENTAL: Full class name of the Summarizer class to use. If unset, uses the default Summarizer.",
+    )
+    args = parser.parse_args()
+    setup_default_logging()
+    summarize(args)
 
 
 if __name__ == "__main__":

--- a/src/helm/benchmark/reeval_run.py
+++ b/src/helm/benchmark/reeval_run.py
@@ -6,7 +6,7 @@ from typing import List
 from helm.benchmark import model_metadata_registry
 from helm.benchmark.presentation.run_entry import RunEntry, read_run_entries
 from helm.common.general import ensure_directory_exists
-from helm.common.hierarchical_logger import hlog, htrack
+from helm.common.hierarchical_logger import hlog, htrack, hwarn
 from helm.common.authentication import Authentication
 from helm.proxy.services.remote_service import create_authentication, add_service_args
 
@@ -191,9 +191,8 @@ def main():
     )
 
     if args.run_specs:
-        hlog(
-            "WARNING: The --run-specs flag is deprecated and will be removed in a future release. "
-            "Use --run-entries instead."
+        hwarn(
+            "The --run-specs flag is deprecated and will be removed in a future release. " "Use --run-entries instead."
         )
 
     hlog("Done.")

--- a/src/helm/benchmark/reeval_runner.py
+++ b/src/helm/benchmark/reeval_runner.py
@@ -12,7 +12,7 @@ from datasets import load_dataset
 
 from helm.benchmark.adaptation.request_state import RequestState
 from helm.common.general import ensure_directory_exists, write, asdict_without_nones
-from helm.common.hierarchical_logger import hlog, htrack_block
+from helm.common.hierarchical_logger import hlog, htrack_block, hwarn
 from helm.common.cache import cache_stats
 from helm.benchmark.scenarios.scenario import (
     Scenario,
@@ -193,7 +193,7 @@ class REEvalRunner(Runner):
             difficulty_dataset = load_dataset("stair-lab/reeval-difficulty", split=split_name)
             prompt_to_difficulty: dict[str, float] = {row["request.prompt"]: row["z"] for row in difficulty_dataset}
         except ValueError:
-            hlog(f"WARNING: no available difficulty for {split_name}, skipping")
+            hwarn(f"no available difficulty for {split_name}, skipping")
             return
 
         unasked_request_states: List[RequestState] = []
@@ -320,7 +320,7 @@ class REEvalRunner(Runner):
         metric_counts: typing.Counter[MetricName] = Counter([stat.name for stat in stats])
         for metric_name, count in metric_counts.items():
             if count > 1:
-                hlog(f"WARNING: duplicate metric name {metric_name}")
+                hwarn(f"duplicate metric name {metric_name}")
 
         # Print out the number of stats
         hlog(f"Generated {len(stats)} stats.")

--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -200,7 +200,7 @@ def validate_args(args):
 
 
 @htrack(None)
-def start_helm(args):
+def helm_run(args):
 
     register_builtin_configs_from_helm_package()
     register_configs_from_directory(args.local_path)
@@ -368,7 +368,7 @@ def main():
     add_run_args(parser)
     args = parser.parse_args()
     setup_default_logging()
-    return start_helm(args)
+    return helm_run(args)
 
 
 if __name__ == "__main__":

--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -9,7 +9,7 @@ from helm.benchmark import model_metadata_registry
 from helm.benchmark.presentation.run_entry import RunEntry, read_run_entries
 from helm.common.cache_backend_config import MongoCacheBackendConfig, SqliteCacheBackendConfig
 from helm.common.general import ensure_directory_exists
-from helm.common.hierarchical_logger import hlog, htrack, htrack_block
+from helm.common.hierarchical_logger import hlog, htrack, htrack_block, setup_default_logging
 from helm.common.authentication import Authentication
 from helm.common.object_spec import parse_object_spec, get_class_by_name
 from helm.proxy.services.remote_service import create_authentication, add_service_args
@@ -200,75 +200,7 @@ def validate_args(args):
 
 
 @htrack(None)
-def main():
-    parser = argparse.ArgumentParser()
-    add_service_args(parser)
-    parser.add_argument(
-        "-c",
-        "--conf-paths",
-        nargs="+",
-        help="Where to read RunSpecs to run from",
-        default=[],
-    )
-    parser.add_argument(
-        "--models-to-run",
-        nargs="+",
-        help="Only RunSpecs with these models specified. If no model is specified, runs with all models.",
-        default=None,
-    )
-    parser.add_argument(
-        "--groups-to-run",
-        nargs="+",
-        help="Only RunSpecs with these (scenario) groups specified. " "If no group is specified, runs with all groups.",
-        default=None,
-    )
-    parser.add_argument(
-        "--exit-on-error",
-        action="store_true",
-        help="Fail and exit immediately if a particular RunSpec fails.",
-    )
-    parser.add_argument(
-        "--skip-completed-runs",
-        action="store_true",
-        help="Skip RunSpecs that have completed i.e. output files exists.",
-    )
-    parser.add_argument(
-        "--priority",
-        type=int,
-        default=None,
-        help="Run RunSpecs with priority less than or equal to this number. "
-        "If a value for --priority is not specified, run on everything",
-    )
-    parser.add_argument(
-        "--run-specs",
-        nargs="*",
-        help="DEPRECATED: Use --run-entries instead. Will be removed in a future release. "
-        "Specifies run entries to run.",
-        default=[],
-    )
-    parser.add_argument("-r", "--run-entries", nargs="*", help="Specifies run entries to run", default=[])
-    parser.add_argument(
-        "--enable-huggingface-models",
-        nargs="+",
-        default=[],
-        help="Experimental: Enable using AutoModelForCausalLM models from Hugging Face Model Hub. "
-        "Format: namespace/model_name[@revision]",
-    )
-    parser.add_argument(
-        "--enable-local-huggingface-models",
-        nargs="+",
-        default=[],
-        help="Experimental: Enable using AutoModelForCausalLM models from a local path.",
-    )
-    parser.add_argument(
-        "--runner-class-name",
-        type=str,
-        default=None,
-        help="Full class name of the Runner class to use. If unset, uses the default Runner.",
-    )
-    add_run_args(parser)
-    args = parser.parse_args()
-    validate_args(args)
+def start_helm(args):
 
     register_builtin_configs_from_helm_package()
     register_configs_from_directory(args.local_path)
@@ -364,6 +296,79 @@ def main():
         )
 
     hlog("Done.")
+
+
+# Separate parsing from starting HELM so we can setup logging
+def main():
+    parser = argparse.ArgumentParser()
+    add_service_args(parser)
+    parser.add_argument(
+        "-c",
+        "--conf-paths",
+        nargs="+",
+        help="Where to read RunSpecs to run from",
+        default=[],
+    )
+    parser.add_argument(
+        "--models-to-run",
+        nargs="+",
+        help="Only RunSpecs with these models specified. If no model is specified, runs with all models.",
+        default=None,
+    )
+    parser.add_argument(
+        "--groups-to-run",
+        nargs="+",
+        help="Only RunSpecs with these (scenario) groups specified. " "If no group is specified, runs with all groups.",
+        default=None,
+    )
+    parser.add_argument(
+        "--exit-on-error",
+        action="store_true",
+        help="Fail and exit immediately if a particular RunSpec fails.",
+    )
+    parser.add_argument(
+        "--skip-completed-runs",
+        action="store_true",
+        help="Skip RunSpecs that have completed i.e. output files exists.",
+    )
+    parser.add_argument(
+        "--priority",
+        type=int,
+        default=None,
+        help="Run RunSpecs with priority less than or equal to this number. "
+        "If a value for --priority is not specified, run on everything",
+    )
+    parser.add_argument(
+        "--run-specs",
+        nargs="*",
+        help="DEPRECATED: Use --run-entries instead. Will be removed in a future release. "
+        "Specifies run entries to run.",
+        default=[],
+    )
+    parser.add_argument("-r", "--run-entries", nargs="*", help="Specifies run entries to run", default=[])
+    parser.add_argument(
+        "--enable-huggingface-models",
+        nargs="+",
+        default=[],
+        help="Experimental: Enable using AutoModelForCausalLM models from Hugging Face Model Hub. "
+        "Format: namespace/model_name[@revision]",
+    )
+    parser.add_argument(
+        "--enable-local-huggingface-models",
+        nargs="+",
+        default=[],
+        help="Experimental: Enable using AutoModelForCausalLM models from a local path.",
+    )
+    parser.add_argument(
+        "--runner-class-name",
+        type=str,
+        default=None,
+        help="Full class name of the Runner class to use. If unset, uses the default Runner.",
+    )
+    add_run_args(parser)
+    args = parser.parse_args()
+    setup_default_logging()
+    return start_helm(args)
 
 
 if __name__ == "__main__":

--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -9,7 +9,7 @@ from helm.benchmark import model_metadata_registry
 from helm.benchmark.presentation.run_entry import RunEntry, read_run_entries
 from helm.common.cache_backend_config import MongoCacheBackendConfig, SqliteCacheBackendConfig
 from helm.common.general import ensure_directory_exists
-from helm.common.hierarchical_logger import hlog, htrack, htrack_block, setup_default_logging
+from helm.common.hierarchical_logger import hlog, htrack, htrack_block, setup_default_logging, hwarn
 from helm.common.authentication import Authentication
 from helm.common.object_spec import parse_object_spec, get_class_by_name
 from helm.proxy.services.remote_service import create_authentication, add_service_args
@@ -290,9 +290,8 @@ def helm_run(args):
     )
 
     if args.run_specs:
-        hlog(
-            "WARNING: The --run-specs flag is deprecated and will be removed in a future release. "
-            "Use --run-entries instead."
+        hwarn(
+            "The --run-specs flag is deprecated and will be removed in a future release. " "Use --run-entries instead."
         )
 
     hlog("Done.")

--- a/src/helm/benchmark/runner.py
+++ b/src/helm/benchmark/runner.py
@@ -13,7 +13,7 @@ from tqdm import tqdm
 
 from helm.benchmark.adaptation.request_state import RequestState
 from helm.common.general import ensure_directory_exists, write, asdict_without_nones
-from helm.common.hierarchical_logger import hlog, htrack_block
+from helm.common.hierarchical_logger import hlog, htrack_block, hwarn
 from helm.common.cache import cache_stats
 from helm.benchmark.scenarios.scenario import (
     EVAL_SPLITS,
@@ -82,7 +82,7 @@ def remove_stats_nans(stats: List[Stat]) -> List[Stat]:
     result: List[Stat] = []
     for stat in stats:
         if math.isnan(stat.sum):
-            hlog(f"WARNING: Removing stat {stat.name.name} because its value is NaN")
+            hwarn(f"Removing stat {stat.name.name} because its value is NaN")
             continue
         result.append(stat)
     return result
@@ -318,7 +318,7 @@ class Runner:
         metric_counts: typing.Counter[MetricName] = Counter([stat.name for stat in stats])
         for metric_name, count in metric_counts.items():
             if count > 1:
-                hlog(f"WARNING: duplicate metric name {metric_name}")
+                hwarn(f"duplicate metric name {metric_name}")
 
         # Print out the number of stats
         hlog(f"Generated {len(stats)} stats.")

--- a/src/helm/benchmark/scenarios/autobencher_capabilities_scenario.py
+++ b/src/helm/benchmark/scenarios/autobencher_capabilities_scenario.py
@@ -12,7 +12,7 @@ from helm.benchmark.scenarios.scenario import (
     Output,
 )
 from helm.common.general import ensure_directory_exists
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hwarn
 
 
 class AutoBencherCapabilitiesScenario(Scenario):
@@ -61,7 +61,7 @@ class AutoBencherCapabilitiesScenario(Scenario):
             # References are category ID, followed by level 2, 3 and 4 category names.
             references = [Reference(output=Output(text=row["gold_answer"]), tags=[CORRECT_TAG])]
             if row["gold_answer"] is None:
-                hlog(f"WARNING: Row had no gold_answer: {row}")
+                hwarn(f"Row had no gold_answer: {row}")
                 continue
             instance = Instance(input=input, references=references, split=TEST_SPLIT)
             instances.append(instance)

--- a/src/helm/benchmark/scenarios/grammar.py
+++ b/src/helm/benchmark/scenarios/grammar.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field, replace
 from functools import cached_property
 from typing import List, Optional
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hwarn
 
 import dacite
 import re
@@ -111,7 +111,7 @@ def validate_grammar(grammar: Grammar):
             # Make sure all categories are defined
             for category in expansion.categories:
                 if category not in grammar.category_to_rules:
-                    hlog(f"WARNING: Category {category} is not defined")
+                    hwarn(f"Category {category} is not defined")
 
 
 def read_grammar(path: str) -> Grammar:

--- a/src/helm/benchmark/window_services/encoder_decoder_window_service.py
+++ b/src/helm/benchmark/window_services/encoder_decoder_window_service.py
@@ -1,6 +1,6 @@
 from abc import ABC
 
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hwarn
 from helm.benchmark.window_services.local_window_service import LocalWindowService
 
 
@@ -21,8 +21,8 @@ class EncoderDecoderWindowService(LocalWindowService, ABC):
         vs. the completions, we check the two values separately.
         """
         if expected_completion_token_length > self.max_output_length:
-            hlog(
-                f"WARNING: The expected completion token length ({expected_completion_token_length}) "
+            hwarn(
+                f"The expected completion token length ({expected_completion_token_length}) "
                 f"exceeds the max output length ({self.max_output_length})."
             )
         return self.get_num_tokens(text) <= self.max_request_length

--- a/src/helm/clients/anthropic_client.py
+++ b/src/helm/clients/anthropic_client.py
@@ -7,7 +7,7 @@ import time
 import urllib.parse
 
 from helm.common.cache import CacheConfig
-from helm.common.hierarchical_logger import htrack_block, hlog
+from helm.common.hierarchical_logger import htrack_block, hlog, hwarn
 from helm.common.media_object import IMAGE_TYPE, TEXT_TYPE
 from helm.common.optional_dependencies import handle_module_not_found_error
 from helm.common.request import (
@@ -293,8 +293,8 @@ class AnthropicMessagesClient(CachingClient):
                         image_width > AnthropicClient.MAX_IMAGE_DIMENSION
                         or image_height > AnthropicClient.MAX_IMAGE_DIMENSION
                     ):
-                        hlog(
-                            f"WARNING: Image {image_location} exceeds max allowed size: "
+                        hwarn(
+                            f"Image {image_location} exceeds max allowed size: "
                             f"{AnthropicClient.MAX_IMAGE_DIMENSION} pixels"
                         )
                         # Save the resized image to a temporary file
@@ -309,8 +309,8 @@ class AnthropicMessagesClient(CachingClient):
                             base64_image = encode_base64(temp_file.name, format="JPEG")
 
                     elif os.path.getsize(image_location) > AnthropicMessagesClient.MAX_IMAGE_SIZE_BYTES:
-                        hlog(
-                            f"WARNING: Image {image_location} exceeds max allowed size: "
+                        hwarn(
+                            f"Image {image_location} exceeds max allowed size: "
                             f"{AnthropicMessagesClient.MAX_IMAGE_SIZE_BYTES} bytes"
                         )
                         # Resize the image so it is smaller than the max allowed size
@@ -389,7 +389,7 @@ class AnthropicMessagesClient(CachingClient):
                 )
                 response, cached = self.cache.get(cache_key, wrap_request_time(do_it))
             except AnthropicMessagesResponseError:
-                hlog("WARNING: Response has empty content")
+                hwarn("Response has empty content")
                 return RequestResult(
                     success=False,
                     cached=False,
@@ -400,10 +400,7 @@ class AnthropicMessagesClient(CachingClient):
                 )
 
             if _is_content_moderation_failure(response):
-                hlog(
-                    f"WARNING: Returning empty request for {request.model_deployment} "
-                    "due to content moderation filter"
-                )
+                hwarn(f"Returning empty request for {request.model_deployment} " "due to content moderation filter")
                 return RequestResult(
                     success=False,
                     cached=cached,
@@ -617,8 +614,8 @@ class AnthropicLegacyClient(CachingClient):
                     if logprobs["tokens"] != tokens:
                         # This is a known limitation with the Anthropic API. For now keep track of the
                         # entries with the mismatch.
-                        hlog(
-                            f"WARNING: naive truncation for logprobs did not work."
+                        hwarn(
+                            f"naive truncation for logprobs did not work."
                             f"\nRequest:{raw_request}\nExpected: {tokens}\nActual: {logprobs['tokens']}"
                         )
                         check_logprobs = True

--- a/src/helm/clients/openai_client.py
+++ b/src/helm/clients/openai_client.py
@@ -7,7 +7,7 @@ from helm.common import multimodal_request_utils
 from helm.common.cache import CacheConfig
 from helm.common.media_object import TEXT_TYPE, MultimediaObject, MediaObject
 from helm.common.request import ErrorFlags, wrap_request_time, Request, RequestResult, GeneratedOutput, Token
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hlog, hwarn
 from helm.common.object_spec import get_class_by_name
 from helm.common.optional_dependencies import handle_module_not_found_error
 from helm.common.tokenization_request import (
@@ -137,7 +137,7 @@ class OpenAIClient(CachingClient):
             if request.messages[-1]["role"] != "user":
                 raise ValueError("Last message must have role 'user'")
             if request.prompt != "":
-                hlog("WARNING: Since message is set, prompt will be ignored")
+                hwarn("Since message is set, prompt will be ignored")
         else:
             # Convert prompt into a single message
             # For now, put the whole prompt in a single user message, and expect the response

--- a/src/helm/clients/palmyra_client.py
+++ b/src/helm/clients/palmyra_client.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List
 
 from helm.clients.openai_client import OpenAIClient
 from helm.common.cache import CacheConfig
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hwarn
 from helm.common.request import wrap_request_time, Request, RequestResult, GeneratedOutput, Token, ErrorFlags
 from helm.common.tokenization_request import (
     TokenizationRequest,
@@ -103,10 +103,7 @@ class PalmyraClient(CachingClient):
                 return RequestResult(success=False, cached=False, error=error, completions=[], embedding=[])
 
             if _is_content_moderation_failure(response):
-                hlog(
-                    f"WARNING: Returning empty request for {request.model_deployment} "
-                    "due to content moderation filter"
-                )
+                hwarn(f"Returning empty request for {request.model_deployment} " "due to content moderation filter")
                 return RequestResult(
                     success=False,
                     cached=False,

--- a/src/helm/clients/reka_client.py
+++ b/src/helm/clients/reka_client.py
@@ -6,7 +6,7 @@ from helm.proxy.retry import NonRetriableException
 from helm.common.cache import CacheConfig
 from helm.common.media_object import TEXT_TYPE
 from helm.common.request import wrap_request_time, Request, RequestResult, GeneratedOutput
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hwarn
 from helm.common.optional_dependencies import handle_module_not_found_error
 from helm.tokenizers.tokenizer import Tokenizer
 from helm.clients.client import CachingClient, truncate_and_tokenize_response_text
@@ -121,7 +121,7 @@ class RekaClient(CachingClient):
             if messages[-1]["role"] != "user":
                 raise ValueError("Last message must have role 'user'")
             if request.prompt != "":
-                hlog("WARNING: Since message is set, prompt will be ignored")
+                hwarn("Since message is set, prompt will be ignored")
             reka_chat_history = self._convert_messages_to_reka_chat_history(messages)
         else:
             current_chat_history: Dict[str, Any] = {

--- a/src/helm/common/credentials_utils.py
+++ b/src/helm/common/credentials_utils.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Mapping, Optional
 
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hlog, hwarn
 
 
 def provide_api_key(
@@ -13,16 +13,16 @@ def provide_api_key(
         hlog(f"Using host_organization api key defined in credentials.conf: {api_key_name}")
         return credentials[api_key_name]
     if "deployments" not in credentials:
-        hlog(
-            "WARNING: Could not find key 'deployments' in credentials.conf, "
+        hwarn(
+            "Could not find key 'deployments' in credentials.conf, "
             f"therefore the API key {api_key_name} should be specified."
         )
         return None
     deployment_api_keys = credentials["deployments"]
     if model is None:
-        hlog(f"WARNING: Could not find key '{host_organization}' in credentials.conf and no model provided")
+        hwarn(f"Could not find key '{host_organization}' in credentials.conf and no model provided")
         return None
     if model not in deployment_api_keys:
-        hlog(f"WARNING: Could not find key '{model}' under key 'deployments' in credentials.conf")
+        hwarn(f"Could not find key '{model}' under key 'deployments' in credentials.conf")
         return None
     return deployment_api_keys[model]

--- a/src/helm/common/hierarchical_logger.py
+++ b/src/helm/common/hierarchical_logger.py
@@ -2,6 +2,7 @@ import logging
 import sys
 import time
 from typing import Any, Callable, List, Optional
+from colorlog import ColoredFormatter
 
 
 class HierarchicalLogger(object):
@@ -119,3 +120,29 @@ class htrack:
                 return fn(*args, **kwargs)
 
         return wrapper
+
+
+def setup_default_logging():
+    """
+    Setup a default logger to STDOUT for HELM via Python logging
+    """
+    formatter = ColoredFormatter(
+        "%(black)s%(asctime)s %(log_color)s%(levelname)-8s%(reset)s %(message)s",
+        datefmt=None,
+        reset=True,
+        log_colors={
+            "DEBUG": "cyan",
+            "INFO": "green",
+            "WARNING": "yellow",
+            "ERROR": "red",
+            "CRITICAL": "red,bg_white",
+        },
+        secondary_log_colors={},
+        style="%",
+    )
+
+    logger = logging.getLogger("helm")
+    logger.setLevel(logging.INFO)
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)

--- a/src/helm/proxy/cli.py
+++ b/src/helm/proxy/cli.py
@@ -21,7 +21,7 @@ from typing import List, Dict
 import re
 import sys
 
-from helm.common.hierarchical_logger import hlog
+from helm.common.hierarchical_logger import hlog, setup_default_logging
 from helm.common.authentication import Authentication
 from helm.proxy.accounts import Usage, Account
 from helm.proxy.services.remote_service import RemoteService, add_service_args, create_authentication
@@ -197,6 +197,8 @@ def main():
     add_account_arguments(delete_parser)
 
     args = parser.parse_args()
+
+    setup_default_logging()
 
     service = create_remote_service(args)
     auth = create_authentication(args)


### PR DESCRIPTION
Follow-up of #3595.

### Changes
1. Create a logger from python `logging` in `HierarchicalLogger`, with the name `helm` (usually you would make a logger per file with `logging.getLogger(__name__)` but this would be a very large refactor)
1. Switch `print` to `logger.info` in `hlog`
2. Add a new ` hwarn` method to print with `logger.warning`, so warnings appear as Python log warnings
3. Refactor the CLI entry points to parse arguments _separately_ to the use of those arguments. This is so we can instantiate the log handler for the CLI separately to any code that might call HELM directly, avoiding overwriting any log handlers created by external callers
4. Refactor all hlog calls for warnings to use the new hwarn method

### Screenshot
![image](https://github.com/user-attachments/assets/07587a2f-cd5c-4bd4-b351-72292cb93094)
