### PR TITLE
fix: issue where validate_args() was missed in helm-run

### DIFF
--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -202,6 +202,7 @@ def validate_args(args):
 @htrack(None)
 def helm_run(args):
 
+    validate_args(args)
     register_builtin_configs_from_helm_package()
     register_configs_from_directory(args.local_path)
 


### PR DESCRIPTION
Annoyingly I missed keeping `validate_args()` in the run function for `helm-run` in #3598; this PR adds it back in as it seems important.