### PR TITLE
fix: set MIME type for config.js in server

### DIFF
--- a/src/helm/benchmark/server.py
+++ b/src/helm/benchmark/server.py
@@ -9,7 +9,7 @@ import json
 from os import path
 import urllib
 
-from bottle import Bottle, static_file, HTTPResponse
+from bottle import Bottle, static_file, HTTPResponse, response
 import yaml
 
 from helm.benchmark.presentation.schema import SCHEMA_CLASSIC_YAML_FILENAME
@@ -21,6 +21,7 @@ app = Bottle()
 
 @app.get("/config.js")
 def serve_config():
+    response.content_type = "application/javascript; charset=UTF-8"
     if app.config["helm.release"]:
         return (
             f'window.BENCHMARK_OUTPUT_BASE_URL = "{app.config["helm.outputurl"]}";\n'


### PR DESCRIPTION
We discovered a small issue in the HELM server where /config.js does not set a proper MIME type, meaning browsers will refuse to execute it if the `X-Content-Type-Options: nosniff` is ever injected (e.g. if HELM is behind a proxy).

This PR fixes that issue.