### PR TITLE
Minor tweaks to log format

### DIFF
--- a/src/helm/common/hierarchical_logger.py
+++ b/src/helm/common/hierarchical_logger.py
@@ -127,8 +127,8 @@ def setup_default_logging():
     Setup a default logger to STDOUT for HELM via Python logging
     """
     formatter = ColoredFormatter(
-        "%(black)s%(asctime)s %(log_color)s%(levelname)-8s%(reset)s %(message)s",
-        datefmt=None,
+        "%(asctime)s %(log_color)s%(levelname)-8s%(reset)s %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S",
         reset=True,
         log_colors={
             "DEBUG": "cyan",

--- a/src/helm/common/hierarchical_logger.py
+++ b/src/helm/common/hierarchical_logger.py
@@ -127,7 +127,7 @@ def setup_default_logging():
     Setup a default logger to STDOUT for HELM via Python logging
     """
     formatter = ColoredFormatter(
-        "%(asctime)s %(log_color)s%(levelname)-8s%(reset)s %(message)s",
+        "%(bold_black)s%(asctime)s%(reset)s %(log_color)s%(levelname)-8s%(reset)s %(message)s",
         datefmt="%Y-%m-%dT%H:%M:%S",
         reset=True,
         log_colors={


### PR DESCRIPTION
- Use default color instead of black for the timestamp so that it is visible on terminals with black backgrounds
- Use ISO 8601 datetime format without timezone or microseconds (e.g. `2025-05-22T10:45:32`) to save four space and to improve machine readability

Addresses #3595

cc @Gum-Joe