### PR TITLE
Changed prompts for COREBench

### DIFF
--- a/src/helm/benchmark/scenarios/audio_language/corebench_scenario.py
+++ b/src/helm/benchmark/scenarios/audio_language/corebench_scenario.py
@@ -34,13 +34,13 @@ class COREBenchScenario(Scenario):
     )
 
     COREBENCH_INSTRUCTION = (
-        "\n\n Answer the question by just giving the final answer "
-        "and nothing else. Answer 'unanswerable' if the question is not answerable."
+        "\n\n Answer the question by just giving the final answer and nothing else. "
+        "Answer 'unanswerable' if the question is irrelevant to the audio or cannot be inferred."
     )
 
     name = "corebench"
     description = "Exploring multi-speaker conversational audio reasoning task."
-    tags: List[str] = ["audio", "bias"]
+    tags: List[str] = ["audio", "reasoning"]
 
     def load_jsonl(self, file_path):
         with open(file_path, "r", encoding="utf-8") as f:

--- a/src/helm/benchmark/static/schema_audio.yaml
+++ b/src/helm/benchmark/static/schema_audio.yaml
@@ -273,6 +273,7 @@ run_groups:
     category: Core scenarios
     subgroups:
       - air_bench_chat_reasoning
+      - corebench
 
   - name: knowledge
     display_name: Knowledge


### PR DESCRIPTION
1. We want to be more precise with the prompts so that the ALM will produce `unanswerable` when the question is not relevant to the conversation, but is answerable.
2. Changed the tag from `bias` to `reasoning`