### PR TITLE
fix: remove top_p, frequency_penalty and presence_penalty from o series models as unsupported

### DIFF
--- a/src/helm/clients/openai_client.py
+++ b/src/helm/clients/openai_client.py
@@ -241,6 +241,11 @@ class OpenAIClient(CachingClient):
             # 'code': 'unsupported_parameter'}}"
             raw_request.pop("temperature", None)
 
+            # The following parameters also happen to be unsupported by the o-series (code unsupported_parameter)
+            raw_request.pop("top_p", None)
+            raw_request.pop("frequency_penalty", None)
+            raw_request.pop("presence_penalty", None)
+
             if self.reasoning_effort:
                 raw_request["reasoning_effort"] = self.reasoning_effort
         elif is_vlm(request.model):


### PR DESCRIPTION
Quick fix to the special casing in the OpenAI client to remove `top_p`, `frequency_penalty` and `presence_penalty` from requests to the o-series models, as these params are unsupported.