### PR TITLE
Support reasoning_content from vLLM model responses

### DIFF
--- a/src/helm/clients/openai_client.py
+++ b/src/helm/clients/openai_client.py
@@ -351,7 +351,8 @@ class OpenAIClient(CachingClient):
             # that is not in the standard OpenAI API.
             # This field is also used by some model providers such as Grok.
             thinking = (
-                Thinking(text=raw_completion["message"]["reasoning_content"]) if "reasoning_content" in  raw_completion["message"]
+                Thinking(text=raw_completion["message"]["reasoning_content"])
+                if "reasoning_content" in raw_completion["message"]
                 else None
             )
             completion = GeneratedOutput(


### PR DESCRIPTION
vLLM has a optional `reasoning_content` field in the message that is not in the standard OpenAI API. This field is also used by some model providers such as Grok. This PR puts the contents of this field into the `thinking` field of `RequestResponse`.