### PR TITLE
fixes pagination of metrics displayed on the front-end.

### DIFF
--- a/helm-frontend/src/components/RunMetrics.tsx
+++ b/helm-frontend/src/components/RunMetrics.tsx
@@ -48,7 +48,7 @@ export default function Run({ runName, suite, metricFieldMap }: Props) {
     return <Loading />;
   }
 
-  const totalMetricsPages = Math.floor(stats.length / METRICS_PAGE_SIZE);
+  const totalMetricsPages = Math.ceil(stats.length / METRICS_PAGE_SIZE);
 
   const pagedMetrics = stats.slice(
     (currentMetricsPage - 1) * METRICS_PAGE_SIZE,


### PR DESCRIPTION
This PR aims to fix an issue in the frontend related to the pagination calculation for metrics displayed in the interface.

Previously, in the file [RunMetrics.tsx](https://github.com/stanford-crfm/helm/blob/main/helm-frontend/src/components/RunMetrics.tsx), the line responsible for computing the total number of metric pages was:

`const totalMetricsPages = Math.floor(stats.length / METRICS_PAGE_SIZE);
`

Using Math.floor caused the value to always round down, which resulted in only a subset of the metrics being rendered. For example, when the total number of metrics was not an exact multiple of METRICS_PAGE_SIZE, the last page was not displayed, and some metrics were omitted from the view.

This PR fixes the issue by replacing Math.floor with Math.ceil, ensuring that all metrics are correctly paginated and displayed:

`const totalMetricsPages = Math.ceil(stats.length / METRICS_PAGE_SIZE);`

With this change, the total number of pages is accurately calculated, and no metrics are hidden when there's enough data to fill additional pages, even partially.