### PR TITLE
Fix incorrect thinking parsing in TogetherClient

### DIFF
--- a/src/helm/clients/together_client.py
+++ b/src/helm/clients/together_client.py
@@ -107,7 +107,7 @@ def _parse_thinking(input: str) -> Tuple[str, str]:
     if match:
         return (match.group(1), match.group(2))
 
-    match = re.match(r"<think>\n?(.*)", input)
+    match = re.match(r"<think>\n?(.*)", input, re.DOTALL)
     if match:
         return (match.group(1), "")
 


### PR DESCRIPTION
Previously, if the response from Together was truncated before the thinking closing tag, only the first line of the thinking would be preserved due to an incorrect regex.