### PR TITLE
Add back in OpenAI Responses Client

### DIFF
--- a/src/helm/clients/openai_client.py
+++ b/src/helm/clients/openai_client.py
@@ -27,7 +27,7 @@ except ModuleNotFoundError as e:
     handle_module_not_found_error(e, ["openai"])
 
 
-class OpenAIClientUtils():
+class OpenAIClientUtils:
     """Methods used by both the chat completions client and the responses API client"""
 
     @classmethod
@@ -36,12 +36,14 @@ class OpenAIClientUtils():
         return bool(re.match(r"^o\d+", model_engine))
 
     # Error OpenAI throws when the image in the prompt violates their content policy
-    INAPPROPRIATE_IMAGE_ERROR: str = (
-        "Your input image may contain content that is not allowed by our safety system"
-    )
+    INAPPROPRIATE_IMAGE_ERROR: str = "Your input image may contain content that is not allowed by our safety system"
     INAPPROPRIATE_PROMPT_ERROR: str = "Invalid prompt: your prompt was flagged"
-    INAPPROPRIATE_PROMPT_AZURE_ERROR: str = "The response was filtered due to the prompt triggering Azure OpenAI's content management policy."
-    INAPPROPRIATE_PROMPT_MICROSOFT_ERROR: str = "The response was filtered due to the prompt triggering Microsoft's content management policy."
+    INAPPROPRIATE_PROMPT_AZURE_ERROR: str = (
+        "The response was filtered due to the prompt triggering Azure OpenAI's content management policy."
+    )
+    INAPPROPRIATE_PROMPT_MICROSOFT_ERROR: str = (
+        "The response was filtered due to the prompt triggering Microsoft's content management policy."
+    )
 
     # OpenAI server error
     OPENAI_SERVER_ERROR: str = (
@@ -100,6 +102,7 @@ class OpenAIClientUtils():
 
         error: str = f"OpenAI error: {e}"
         return RequestResult(success=False, cached=False, error=error, completions=[], embedding=[])
+
 
 class OpenAIClient(CachingClient):
     END_OF_TEXT: str = "<|endoftext|>"

--- a/src/helm/clients/openai_client.py
+++ b/src/helm/clients/openai_client.py
@@ -1,6 +1,9 @@
 # mypy: check_untyped_defs = False
 from dataclasses import replace
+import re
 from typing import Any, Dict, List, Optional, cast, Union, Callable
+
+from openai import OpenAIError
 
 from helm.benchmark.model_metadata_registry import is_vlm
 from helm.common import multimodal_request_utils
@@ -24,18 +27,21 @@ except ModuleNotFoundError as e:
     handle_module_not_found_error(e, ["openai"])
 
 
-class OpenAIClient(CachingClient):
-    END_OF_TEXT: str = "<|endoftext|>"
+class OpenAIClientUtils():
+    """Methods used by both the chat completions client and the responses API client"""
+
+    @classmethod
+    def is_reasoning_model(cls, model_engine: str) -> bool:
+        # All OpenAI  reasoning models start "o[somenumber]", so we regexp for that to future proof things
+        return bool(re.match(r"^o\d+", model_engine))
 
     # Error OpenAI throws when the image in the prompt violates their content policy
-    INAPPROPRIATE_IMAGE_ERROR: str = "Your input image may contain content that is not allowed by our safety system"
+    INAPPROPRIATE_IMAGE_ERROR: str = (
+        "Your input image may contain content that is not allowed by our safety system"
+    )
     INAPPROPRIATE_PROMPT_ERROR: str = "Invalid prompt: your prompt was flagged"
-    INAPPROPRIATE_PROMPT_AZURE_ERROR: str = (
-        "The response was filtered due to the prompt triggering Azure OpenAI's content management policy."
-    )
-    INAPPROPRIATE_PROMPT_MICROSOFT_ERROR: str = (
-        "The response was filtered due to the prompt triggering Microsoft's content management policy."
-    )
+    INAPPROPRIATE_PROMPT_AZURE_ERROR: str = "The response was filtered due to the prompt triggering Azure OpenAI's content management policy."
+    INAPPROPRIATE_PROMPT_MICROSOFT_ERROR: str = "The response was filtered due to the prompt triggering Microsoft's content management policy."
 
     # OpenAI server error
     OPENAI_SERVER_ERROR: str = (
@@ -48,6 +54,55 @@ class OpenAIClient(CachingClient):
         "The prompt violates OpenAI's content policy. "
         "See https://labs.openai.com/policies/content-policy for more information."
     )
+
+    @classmethod
+    def handle_openai_error(cls, e: OpenAIError, request: Request):
+        if cls.INAPPROPRIATE_IMAGE_ERROR in str(e) or cls.INAPPROPRIATE_PROMPT_ERROR in str(e):
+            hwarn(f"Failed safety check: {str(request)}")
+            empty_completion = GeneratedOutput(
+                text="",
+                logprob=0,
+                tokens=[],
+                finish_reason={"reason": cls.CONTENT_POLICY_VIOLATED_FINISH_REASON},
+            )
+            return RequestResult(
+                success=True,
+                cached=False,
+                request_time=0,
+                completions=[empty_completion] * request.num_completions,
+                embedding=[],
+            )
+        elif cls.OPENAI_SERVER_ERROR in str(e):
+            # Handle these errors by returning an empty completion to unblock
+            hwarn(f"OpenAI server error for request: {str(request)}")
+            empty_completion = GeneratedOutput(
+                text="",
+                logprob=0,
+                tokens=[],
+                finish_reason={"reason": cls.OPENAI_SERVER_ERROR},
+            )
+            return RequestResult(
+                success=True,
+                cached=False,
+                request_time=0,
+                completions=[empty_completion] * request.num_completions,
+                embedding=[],
+            )
+        elif cls.INAPPROPRIATE_PROMPT_AZURE_ERROR in str(e) or cls.INAPPROPRIATE_PROMPT_MICROSOFT_ERROR in str(e):
+            return RequestResult(
+                success=False,
+                cached=False,
+                error="Content blocked by Azure's content management filter",
+                completions=[],
+                embedding=[],
+                error_flags=ErrorFlags(is_retriable=False, is_fatal=False),
+            )
+
+        error: str = f"OpenAI error: {e}"
+        return RequestResult(success=False, cached=False, error=error, completions=[], embedding=[])
+
+class OpenAIClient(CachingClient):
+    END_OF_TEXT: str = "<|endoftext|>"
 
     def __init__(
         self,
@@ -223,7 +278,7 @@ class OpenAIClient(CachingClient):
         # Refer to the "Reasoning models" documentation further discussion of o1 model limitations:
         # https://platform.openai.com/docs/guides/reasoning
         model_engine: str = request.model_engine
-        if model_engine.startswith("o1") or model_engine.startswith("o3") or model_engine.startswith("o4"):
+        if OpenAIClientUtils.is_reasoning_model(model_engine):
             # Avoid error:
             # "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."  # noqa: E501
             # Note that openai>=1.45 is needed for this
@@ -275,49 +330,7 @@ class OpenAIClient(CachingClient):
             cache_key = self._get_cache_key(raw_request, request)
             response, cached = self.cache.get(cache_key, wrap_request_time(do_it))
         except openai.OpenAIError as e:
-            if self.INAPPROPRIATE_IMAGE_ERROR in str(e) or self.INAPPROPRIATE_PROMPT_ERROR in str(e):
-                hlog(f"Failed safety check: {str(request)}")
-                empty_completion = GeneratedOutput(
-                    text="",
-                    logprob=0,
-                    tokens=[],
-                    finish_reason={"reason": self.CONTENT_POLICY_VIOLATED_FINISH_REASON},
-                )
-                return RequestResult(
-                    success=True,
-                    cached=False,
-                    request_time=0,
-                    completions=[empty_completion] * request.num_completions,
-                    embedding=[],
-                )
-            elif self.OPENAI_SERVER_ERROR in str(e):
-                # Handle these errors by returning an empty completion to unblock
-                hlog(f"OpenAI server error for request: {str(request)}")
-                empty_completion = GeneratedOutput(
-                    text="",
-                    logprob=0,
-                    tokens=[],
-                    finish_reason={"reason": self.OPENAI_SERVER_ERROR},
-                )
-                return RequestResult(
-                    success=True,
-                    cached=False,
-                    request_time=0,
-                    completions=[empty_completion] * request.num_completions,
-                    embedding=[],
-                )
-            elif self.INAPPROPRIATE_PROMPT_AZURE_ERROR in str(e) or self.INAPPROPRIATE_PROMPT_MICROSOFT_ERROR in str(e):
-                return RequestResult(
-                    success=False,
-                    cached=False,
-                    error="Content blocked by Azure's content management filter",
-                    completions=[],
-                    embedding=[],
-                    error_flags=ErrorFlags(is_retriable=False, is_fatal=False),
-                )
-
-            error: str = f"OpenAI error: {e}"
-            return RequestResult(success=False, cached=False, error=error, completions=[], embedding=[])
+            return OpenAIClientUtils.handle_openai_error(e, request)
 
         completions: List[GeneratedOutput] = []
         for raw_completion in response["choices"]:

--- a/src/helm/clients/openai_responses_client.py
+++ b/src/helm/clients/openai_responses_client.py
@@ -1,0 +1,204 @@
+# mypy: check_untyped_defs = False
+from typing import Any, Dict, List, Optional, cast, Union
+
+from helm.clients.openai_client import OpenAIClientUtils
+from helm.common.cache import CacheConfig
+from helm.common.media_object import TEXT_TYPE
+from helm.common.request import (
+    Thinking,
+    wrap_request_time,
+    Request,
+    RequestResult,
+    GeneratedOutput,
+    Token,
+)
+from helm.common.optional_dependencies import handle_module_not_found_error
+from helm.common.tokenization_request import (
+    TokenizationRequest,
+    TokenizationRequestResult,
+)
+from helm.clients.client import (
+    CachingClient,
+    truncate_sequence,
+    generate_uid_for_multimodal_prompt,
+)
+from helm.tokenizers.tokenizer import Tokenizer
+
+try:
+    import openai
+    from openai import OpenAI
+except ModuleNotFoundError as e:
+    handle_module_not_found_error(e, ["openai"])
+
+class OpenAIResponseClient(CachingClient):
+    def __init__(
+        self,
+        tokenizer: Tokenizer,
+        tokenizer_name: str,
+        cache_config: CacheConfig,
+        api_key: Optional[str] = None,
+        org_id: Optional[str] = None,
+        base_url: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
+        openai_model_name: Optional[str] = None,
+    ):
+        super().__init__(cache_config=cache_config)
+        self.tokenizer = tokenizer
+        self.tokenizer_name = tokenizer_name
+        self.client = OpenAI(api_key=api_key, organization=org_id, base_url=base_url)
+        self.reasoning_effort = reasoning_effort
+        self.openai_model_name = openai_model_name
+
+    def _get_cache_key(self, raw_request: Dict, request: Request):
+        cache_key = CachingClient.make_cache_key(raw_request, request)
+        if request.multimodal_prompt:
+            prompt_key: str = generate_uid_for_multimodal_prompt(
+                request.multimodal_prompt
+            )
+            cache_key = {**cache_key, "multimodal_prompt": prompt_key}
+        return cache_key
+    
+    def _make_raw_request(self, request: Request) -> dict[str, Any]:
+        input: Union[str, List[Dict[str, Any]]]
+        if request.multimodal_prompt is not None:
+            content = []
+            request.validate()
+            for media_object in request.multimodal_prompt.media_objects:
+                if media_object.is_type("image") and media_object.location:
+                    from helm.common.images_utils import encode_base64
+
+                    base64_image: str = encode_base64(media_object.location)
+                    content.append(
+                        {
+                            "type": "input_image",
+                            "image_url": f"data:image/jpeg;base64,{base64_image}",
+                        }
+                    )
+                elif media_object.is_type(TEXT_TYPE):
+                    assert media_object.text is not None
+                    content.append({"type": "input_text", "text": media_object.text})
+                else:
+                    raise ValueError(
+                        f"Unrecognized MediaObject type {media_object.type}"
+                    )
+            input = [{"role": "user", "content": content}]
+        else:
+            input = request.prompt
+
+        raw_request: Dict[str, Any] = {
+            "model": self.openai_model_name or request.model_engine,
+            "input": input,
+            "top_p": request.top_p,
+            "max_output_tokens": request.max_tokens,
+            "temperature": request.temperature,
+            # Don't store responses for later retrieval
+            "store": False,
+        }
+        if self.reasoning_effort:
+            raw_request["reasoning"] = {
+                "effort": self.reasoning_effort
+            }
+        # If o-series model, get reasoning summaries
+        # Plus other changes
+        # TODO: Refactor with line 226 in openai_client.py to common util
+        model_engine: str = request.model_engine
+        if OpenAIClientUtils.is_reasoning_model(model_engine):
+            raw_request["reasoning"]["summary"] = "detailed"
+            # Avoid error:
+            # "Error code: 400 - {'error': {'message': "Unsupported parameter: 'temperature' is
+            # not supported with this model.", 'type': 'invalid_request_error', 'param': 'temperature',
+            # 'code': 'unsupported_parameter'}}"
+            raw_request.pop("temperature", None)
+
+            # The following parameters also happen to be unsupported by the o-series (code unsupported_parameter)
+            raw_request.pop("top_p", None)
+        
+        return raw_request
+
+    def make_request(self, request: Request) -> RequestResult:
+        # Content can either be text or a list of multimodal content made up of text and images:
+        # https://platform.openai.com/docs/api-reference/responses/create
+        raw_request = self._make_request(request)
+
+        def do_it() -> Dict[str, Any]:
+            raw_response = self.client.responses.create(**raw_request).model_dump(
+                mode="json"
+            )
+            assert not raw_response["error"], f"Error in response: {raw_response}"
+            return raw_response
+
+        try:
+            cache_key = self._get_cache_key(raw_request, request)
+            response, cached = self.cache.get(cache_key, wrap_request_time(do_it))
+        except openai.OpenAIError as e:
+            return OpenAIClientUtils.handle_openai_error(e, request)
+
+        completions: List[GeneratedOutput] = []
+
+        # Look for the completiom with type: "message" for the output
+        # (based on observing the API on 11.06.2025)
+        message_output = list(filter(response["output"], lambda x: x["type"] == "message"))
+        # Expect length of 1, else, OpenAI API has changed, and we don't know what to do!
+        assert len(message_output) == 1, "Unexpected response format from OpenAI API - > 1 message response provided!"
+        message_output = message_output[0]
+
+        # Similarly, look for the reasoning output based on API observations
+        reasoning_output = list(filter(response["output"], lambda x: x["type"] == "reasoning"))
+        # Either we have no reasoning, or some reasoning
+        assert len(reasoning_output) <= 1, "Unexpected response format from OpenAI API - > 1 reasoning response provided!"
+        for output in response["output"]:
+            output_type = output["type"] # one of "message" or "reasoning" from API observation
+            is_reasoning_output = None
+            output_key = None
+            match output_type:
+                case "message":
+                    output_key = "content"
+                    is_reasoning_output = False
+                case "reasoning":
+                    output_key = "summary"
+                    is_reasoning_output = True
+
+            for raw_completion in output[output_key]:
+                raw_completion_content = raw_completion["text"]
+                text: str = (
+                    request.prompt + raw_completion_content
+                    if request.echo_prompt and not is_reasoning_output
+                    else raw_completion_content
+                )
+                tokenization_result: TokenizationRequestResult = self.tokenizer.tokenize(
+                    TokenizationRequest(text, tokenizer=self.tokenizer_name)
+                )
+                tokens: List[Token] = [
+                    Token(text=cast(str, raw_token), logprob=0)
+                    for raw_token in tokenization_result.raw_tokens
+                ]
+                completion = None
+                if is_reasoning_output:
+                    # Openai provides thinking outputs separately to main completion output
+                    # So we have to add it separately
+                    completion = GeneratedOutput(
+                        text="",
+                        logprob=0,  # OpenAI does not provide logprobs
+                        tokens=tokens,
+                        thinking=Thinking(text=raw_completion_content),
+                    )
+                else:
+                    completion = GeneratedOutput(
+                        text=text,
+                        logprob=0,  # OpenAI does not provide logprobs
+                        tokens=tokens,
+                    )
+                completions.append(
+                    truncate_sequence(completion, request)
+                )  # Truncate the text by stop sequences
+        
+        # Construct reasoning if it exists
+
+        return RequestResult(
+            success=True,
+            cached=cached,
+            request_time=response["request_time"],
+            request_datetime=response.get("request_datetime"),
+            completions=completions,
+            embedding=[],
+        )

--- a/src/helm/clients/openai_responses_client.py
+++ b/src/helm/clients/openai_responses_client.py
@@ -1,5 +1,7 @@
 # mypy: check_untyped_defs = False
-from typing import Any, Dict, List, Optional, cast, Union
+import dataclasses
+from typing import Any, Dict, List, Optional, Union
+
 
 from helm.clients.openai_client import OpenAIClientUtils
 from helm.common.cache import CacheConfig
@@ -10,16 +12,11 @@ from helm.common.request import (
     Request,
     RequestResult,
     GeneratedOutput,
-    Token,
 )
 from helm.common.optional_dependencies import handle_module_not_found_error
-from helm.common.tokenization_request import (
-    TokenizationRequest,
-    TokenizationRequestResult,
-)
 from helm.clients.client import (
     CachingClient,
-    truncate_sequence,
+    truncate_and_tokenize_response_text,
     generate_uid_for_multimodal_prompt,
 )
 from helm.tokenizers.tokenizer import Tokenizer
@@ -29,6 +26,7 @@ try:
     from openai import OpenAI
 except ModuleNotFoundError as e:
     handle_module_not_found_error(e, ["openai"])
+
 
 class OpenAIResponseClient(CachingClient):
     def __init__(
@@ -45,19 +43,21 @@ class OpenAIResponseClient(CachingClient):
         super().__init__(cache_config=cache_config)
         self.tokenizer = tokenizer
         self.tokenizer_name = tokenizer_name
-        self.client = OpenAI(api_key=api_key, organization=org_id, base_url=base_url)
+        self.client = OpenAI(
+            api_key=api_key,
+            organization=org_id,
+            base_url=base_url,
+        )
         self.reasoning_effort = reasoning_effort
         self.openai_model_name = openai_model_name
 
     def _get_cache_key(self, raw_request: Dict, request: Request):
         cache_key = CachingClient.make_cache_key(raw_request, request)
         if request.multimodal_prompt:
-            prompt_key: str = generate_uid_for_multimodal_prompt(
-                request.multimodal_prompt
-            )
+            prompt_key: str = generate_uid_for_multimodal_prompt(request.multimodal_prompt)
             cache_key = {**cache_key, "multimodal_prompt": prompt_key}
         return cache_key
-    
+
     def _make_raw_request(self, request: Request) -> dict[str, Any]:
         input: Union[str, List[Dict[str, Any]]]
         if request.multimodal_prompt is not None:
@@ -78,9 +78,7 @@ class OpenAIResponseClient(CachingClient):
                     assert media_object.text is not None
                     content.append({"type": "input_text", "text": media_object.text})
                 else:
-                    raise ValueError(
-                        f"Unrecognized MediaObject type {media_object.type}"
-                    )
+                    raise ValueError(f"Unrecognized MediaObject type {media_object.type}")
             input = [{"role": "user", "content": content}]
         else:
             input = request.prompt
@@ -89,18 +87,17 @@ class OpenAIResponseClient(CachingClient):
             "model": self.openai_model_name or request.model_engine,
             "input": input,
             "top_p": request.top_p,
-            "max_output_tokens": request.max_tokens,
+            # API errors if max_output_tokens is less than 16
+            # (Error you get: "Invalid 'max_output_tokens': integer below minimum value. Expected a value >= 16, but got 5 instead.")
+            "max_output_tokens": max(16, request.max_tokens),
             "temperature": request.temperature,
             # Don't store responses for later retrieval
             "store": False,
         }
         if self.reasoning_effort:
-            raw_request["reasoning"] = {
-                "effort": self.reasoning_effort
-            }
+            raw_request["reasoning"] = {"effort": self.reasoning_effort}
         # If o-series model, get reasoning summaries
         # Plus other changes
-        # TODO: Refactor with line 226 in openai_client.py to common util
         model_engine: str = request.model_engine
         if OpenAIClientUtils.is_reasoning_model(model_engine):
             raw_request["reasoning"]["summary"] = "detailed"
@@ -112,87 +109,68 @@ class OpenAIResponseClient(CachingClient):
 
             # The following parameters also happen to be unsupported by the o-series (code unsupported_parameter)
             raw_request.pop("top_p", None)
-        
+
         return raw_request
 
     def make_request(self, request: Request) -> RequestResult:
         # Content can either be text or a list of multimodal content made up of text and images:
         # https://platform.openai.com/docs/api-reference/responses/create
-        raw_request = self._make_request(request)
+        raw_request = self._make_raw_request(request)
 
-        def do_it() -> Dict[str, Any]:
-            raw_response = self.client.responses.create(**raw_request).model_dump(
-                mode="json"
+        # The responses API does not support a "num_completions" parameter, so we need to handle it ourselves with a simple loop
+        completions: list[GeneratedOutput] = []
+        for i in range(request.num_completions):
+
+            def do_it() -> Dict[str, Any]:
+                raw_response = self.client.responses.create(**raw_request).model_dump(mode="json")
+                assert not raw_response.get("error", None), f"Error in response: {raw_response}"
+                return raw_response
+
+            try:
+                cache_key = self._get_cache_key(raw_request, request)
+                response, cached = self.cache.get(cache_key, wrap_request_time(do_it))
+            except openai.OpenAIError as e:
+                return OpenAIClientUtils.handle_openai_error(e, request)
+
+            # We can only return one completition really, but we get an array of messages back, so we need to contact them
+            reasoning_output = ""
+            text_output = ""
+
+            for output in response["output"]:
+                output_type = output["type"]  # one of "message" or "reasoning" from API observation
+                is_reasoning_output = None
+                output_key = None
+                match output_type:
+                    case "message":
+                        output_key = "content"
+                        is_reasoning_output = False
+                    case "reasoning":
+                        output_key = "summary"
+                        is_reasoning_output = True
+
+                for raw_completion in output[output_key]:
+                    raw_completion_content = raw_completion["text"]
+                    text: str = (
+                        request.prompt + raw_completion_content
+                        if request.echo_prompt and not is_reasoning_output
+                        else raw_completion_content
+                    )
+
+                    if is_reasoning_output:
+                        reasoning_output += raw_completion_content
+                    else:
+                        text_output += text
+
+            completion = truncate_and_tokenize_response_text(
+                text_output,
+                request,
+                self.tokenizer,
+                self.tokenizer_name,
+                original_finish_reason="",
             )
-            assert not raw_response["error"], f"Error in response: {raw_response}"
-            return raw_response
-
-        try:
-            cache_key = self._get_cache_key(raw_request, request)
-            response, cached = self.cache.get(cache_key, wrap_request_time(do_it))
-        except openai.OpenAIError as e:
-            return OpenAIClientUtils.handle_openai_error(e, request)
-
-        completions: List[GeneratedOutput] = []
-
-        # Look for the completiom with type: "message" for the output
-        # (based on observing the API on 11.06.2025)
-        message_output = list(filter(response["output"], lambda x: x["type"] == "message"))
-        # Expect length of 1, else, OpenAI API has changed, and we don't know what to do!
-        assert len(message_output) == 1, "Unexpected response format from OpenAI API - > 1 message response provided!"
-        message_output = message_output[0]
-
-        # Similarly, look for the reasoning output based on API observations
-        reasoning_output = list(filter(response["output"], lambda x: x["type"] == "reasoning"))
-        # Either we have no reasoning, or some reasoning
-        assert len(reasoning_output) <= 1, "Unexpected response format from OpenAI API - > 1 reasoning response provided!"
-        for output in response["output"]:
-            output_type = output["type"] # one of "message" or "reasoning" from API observation
-            is_reasoning_output = None
-            output_key = None
-            match output_type:
-                case "message":
-                    output_key = "content"
-                    is_reasoning_output = False
-                case "reasoning":
-                    output_key = "summary"
-                    is_reasoning_output = True
-
-            for raw_completion in output[output_key]:
-                raw_completion_content = raw_completion["text"]
-                text: str = (
-                    request.prompt + raw_completion_content
-                    if request.echo_prompt and not is_reasoning_output
-                    else raw_completion_content
-                )
-                tokenization_result: TokenizationRequestResult = self.tokenizer.tokenize(
-                    TokenizationRequest(text, tokenizer=self.tokenizer_name)
-                )
-                tokens: List[Token] = [
-                    Token(text=cast(str, raw_token), logprob=0)
-                    for raw_token in tokenization_result.raw_tokens
-                ]
-                completion = None
-                if is_reasoning_output:
-                    # Openai provides thinking outputs separately to main completion output
-                    # So we have to add it separately
-                    completion = GeneratedOutput(
-                        text="",
-                        logprob=0,  # OpenAI does not provide logprobs
-                        tokens=tokens,
-                        thinking=Thinking(text=raw_completion_content),
-                    )
-                else:
-                    completion = GeneratedOutput(
-                        text=text,
-                        logprob=0,  # OpenAI does not provide logprobs
-                        tokens=tokens,
-                    )
-                completions.append(
-                    truncate_sequence(completion, request)
-                )  # Truncate the text by stop sequences
-        
-        # Construct reasoning if it exists
+            if reasoning_output:
+                completion = dataclasses.replace(completion, thinking=Thinking(text=reasoning_output))
+            completions.append(completion)
 
         return RequestResult(
             success=True,

--- a/src/helm/clients/openai_responses_client.py
+++ b/src/helm/clients/openai_responses_client.py
@@ -88,7 +88,8 @@ class OpenAIResponseClient(CachingClient):
             "input": input,
             "top_p": request.top_p,
             # API errors if max_output_tokens is less than 16
-            # (Error you get: "Invalid 'max_output_tokens': integer below minimum value. Expected a value >= 16, but got 5 instead.")
+            # (Error you get: "Invalid 'max_output_tokens': integer below minimum value.
+            #    Expected a value >= 16, but got 5 instead.")
             "max_output_tokens": max(16, request.max_tokens),
             "temperature": request.temperature,
             # Don't store responses for later retrieval
@@ -117,9 +118,10 @@ class OpenAIResponseClient(CachingClient):
         # https://platform.openai.com/docs/api-reference/responses/create
         raw_request = self._make_raw_request(request)
 
-        # The responses API does not support a "num_completions" parameter, so we need to handle it ourselves with a simple loop
+        # The responses API does not support a "num_completions" parameter,
+        # so we need to handle it ourselves with a simple loop
         completions: list[GeneratedOutput] = []
-        for i in range(request.num_completions):
+        for _ in range(request.num_completions):
 
             def do_it() -> Dict[str, Any]:
                 raw_response = self.client.responses.create(**raw_request).model_dump(mode="json")
@@ -132,7 +134,8 @@ class OpenAIResponseClient(CachingClient):
             except openai.OpenAIError as e:
                 return OpenAIClientUtils.handle_openai_error(e, request)
 
-            # We can only return one completition really, but we get an array of messages back, so we need to contact them
+            # We can only return one completition really,
+            # but we get an array of messages back, so we need to contact them
             reasoning_output = ""
             text_output = ""
 

--- a/src/helm/clients/openai_responses_client.py
+++ b/src/helm/clients/openai_responses_client.py
@@ -84,7 +84,7 @@ class OpenAIResponseClient(CachingClient):
             input = request.prompt
 
         raw_request: Dict[str, Any] = {
-            "model": self.openai_model_name or request.model_engine,
+            "model": self._get_model_for_request(request),
             "input": input,
             "top_p": request.top_p,
             # API errors if max_output_tokens is less than 16
@@ -112,6 +112,9 @@ class OpenAIResponseClient(CachingClient):
             raw_request.pop("top_p", None)
 
         return raw_request
+
+    def _get_model_for_request(self, request: Request) -> str:
+        return self.openai_model_name or request.model_engine
 
     def make_request(self, request: Request) -> RequestResult:
         # Content can either be text or a list of multimodal content made up of text and images:

--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -2433,14 +2433,14 @@ model_deployments:
     tokenizer_name: openai/cl100k_base
     max_sequence_length: 128000
     client_spec:
-      class_name: "helm.clients.openai_client.OpenAIResponseClient"
+      class_name: "helm.clients.openai_responses_client.OpenAIResponseClient"
 
   - name: openai/o1-pro-2025-03-19-low-reasoning-effort
     model_name: openai/o1-pro-2025-03-19-low-reasoning-effort
     tokenizer_name: openai/cl100k_base
     max_sequence_length: 128000
     client_spec:
-      class_name: "helm.clients.openai_client.OpenAIResponseClient"
+      class_name: "helm.clients.openai_responses_client.OpenAIResponseClient"
       args:
         openai_model_name: o1-pro-2025-03-19
         reasoning_effort: low
@@ -2450,7 +2450,7 @@ model_deployments:
     tokenizer_name: openai/cl100k_base
     max_sequence_length: 128000
     client_spec:
-      class_name: "helm.clients.openai_client.OpenAIResponseClient"
+      class_name: "helm.clients.openai_responses_client.OpenAIResponseClient"
       args:
         openai_model_name: o1-pro-2025-03-19
         reasoning_effort: high


### PR DESCRIPTION
Noticed that a HELM Client that supports the OpenAI Responses API was added in 6ef825ed894b91822c65f99611155d239018d928 in #3523, but then was missing when the PR was merged.

Newer models like `o3-pro` only support the responses API, so this PR adds the client back in, updates it a little to e.g. insert reasoning into the HELM response & bring in some logic from the main client as well.

NOTE: My ability to test this against all the benchmarks is limited, I have validated it at least works with some text only benchmarks, where "works" here means "I can see results on the web ui".