### PR TITLE
Long context leaderboard cleanup

### DIFF
--- a/src/helm/benchmark/metrics/openai_mrcr_metrics.py
+++ b/src/helm/benchmark/metrics/openai_mrcr_metrics.py
@@ -11,7 +11,7 @@ from helm.benchmark.scenarios.scenario import CORRECT_TAG
 
 
 class OpenAIMRCRMetric(Metric):
-    """Accuracy metric for OpenAI-MRCR.
+    """Accuracy metric for OpenAI MRCR.
 
     The measured metric is the SequenceMatcher ratio as implemented in https://docs.python.org/3/library/difflib.html.
     The model must prepend an alphanumeric hash to the beginning of its answer. If this hash is not included,

--- a/src/helm/benchmark/presentation/run_entries_long_context.conf
+++ b/src/helm/benchmark/presentation/run_entries_long_context.conf
@@ -1,7 +1,9 @@
 # run entries for long context leaderboard
 
 entries: [
-  {description: "infinite_bench_sum:min_num_words=32768,max_num_words=65536,model=text", priority: 1},
-  {description: "ruler_hotpotqa:max_num_words=65536,model=text", priority: 1},
-  {description: "ruler_squad:max_num_words=65536,model=text", priority: 1},
+  {description: "ruler_hotpotqa:max_num_words=65536", priority: 1},
+  {description: "ruler_squad:max_num_words=65536", priority: 1},
+  {description: "infinite_bench_en_qa:max_num_words=65536", priority: 1},
+  {description: "infinite_bench_sum:max_num_words=65536", priority: 1},
+  {description: "openai_mrcr:needles=8,max_num_words=65536", priority: 1},
 ]

--- a/src/helm/benchmark/presentation/run_entries_long_context.conf
+++ b/src/helm/benchmark/presentation/run_entries_long_context.conf
@@ -1,9 +1,9 @@
 # run entries for long context leaderboard
 
 entries: [
-  {description: "ruler_hotpotqa:max_num_words=65536", priority: 1},
-  {description: "ruler_squad:max_num_words=65536", priority: 1},
-  {description: "infinite_bench_en_qa:max_num_words=65536", priority: 1},
-  {description: "infinite_bench_sum:max_num_words=65536", priority: 1},
-  {description: "openai_mrcr:needles=8,max_num_words=65536", priority: 1},
+  {description: "ruler_hotpotqa:max_num_words=131072", priority: 1},
+  {description: "ruler_squad:max_num_words=131072", priority: 1},
+  {description: "infinite_bench_en_qa:max_num_words=131072", priority: 1},
+  {description: "infinite_bench_sum:max_num_words=131072", priority: 1},
+  {description: "openai_mrcr:needles=8,max_num_words=131072", priority: 1},
 ]

--- a/src/helm/benchmark/run_specs/long_context_run_specs.py
+++ b/src/helm/benchmark/run_specs/long_context_run_specs.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from helm.benchmark.adaptation.adapter_spec import ADAPT_CHAT, ADAPT_GENERATION, AdapterSpec
 from helm.benchmark.metrics.common_metric_specs import get_basic_metric_specs, get_open_ended_generation_metric_specs
 from helm.benchmark.metrics.metric import MetricSpec

--- a/src/helm/benchmark/run_specs/long_context_run_specs.py
+++ b/src/helm/benchmark/run_specs/long_context_run_specs.py
@@ -27,7 +27,7 @@ def _get_long_context_generation_adapter_spec(max_tokens: int) -> AdapterSpec:
 
 
 @run_spec_function("ruler_hotpotqa")
-def get_ruler_hotpotqa_spec(max_num_words: int = 65536) -> RunSpec:
+def get_ruler_hotpotqa_spec(max_num_words: int = 131072) -> RunSpec:
     scenario_spec = ScenarioSpec(
         class_name="helm.benchmark.scenarios.ruler_qa_scenarios.RULERHotpotQAScenario",
         args={
@@ -47,7 +47,7 @@ def get_ruler_hotpotqa_spec(max_num_words: int = 65536) -> RunSpec:
 
 
 @run_spec_function("ruler_squad")
-def get_ruler_squad_spec(max_num_words: int = 65536) -> RunSpec:
+def get_ruler_squad_spec(max_num_words: int = 131072) -> RunSpec:
     scenario_spec = ScenarioSpec(
         class_name="helm.benchmark.scenarios.ruler_qa_scenarios.RULERSQuADScenario",
         args={
@@ -67,7 +67,7 @@ def get_ruler_squad_spec(max_num_words: int = 65536) -> RunSpec:
 
 
 @run_spec_function("infinite_bench_en_qa")
-def get_infinite_bench_en_qa_spec(max_num_words: int = 65536) -> RunSpec:
+def get_infinite_bench_en_qa_spec(max_num_words: int = 131072) -> RunSpec:
     scenario_spec = ScenarioSpec(
         class_name="helm.benchmark.scenarios.infinite_bench_en_qa_scenario.InfiniteBenchEnQAScenario",
         args={
@@ -88,7 +88,7 @@ def get_infinite_bench_en_qa_spec(max_num_words: int = 65536) -> RunSpec:
 
 
 @run_spec_function("infinite_bench_sum")
-def get_infinite_bench_sum_spec(max_num_words: int = 65536) -> RunSpec:
+def get_infinite_bench_sum_spec(max_num_words: int = 131072) -> RunSpec:
 
     scenario_spec = ScenarioSpec(
         class_name="helm.benchmark.scenarios.infinite_bench_sum_scenario.InfiniteBenchSumScenario",
@@ -110,7 +110,7 @@ def get_infinite_bench_sum_spec(max_num_words: int = 65536) -> RunSpec:
 
 
 @run_spec_function("openai_mrcr")
-def get_openai_mrcr_spec(needles: int, max_num_words: int = 65536) -> RunSpec:
+def get_openai_mrcr_spec(needles: int, max_num_words: int = 131072) -> RunSpec:
     scenario_spec = ScenarioSpec(
         class_name="helm.benchmark.scenarios.openai_mrcr_scenario.OpenAIMRCRScenario",
         args={"needles": needles, "max_num_words": max_num_words},

--- a/src/helm/benchmark/run_specs/long_context_run_specs.py
+++ b/src/helm/benchmark/run_specs/long_context_run_specs.py
@@ -68,42 +68,20 @@ def get_ruler_squad_spec(max_num_words: int = 65536) -> RunSpec:
     )
 
 
-@run_spec_function("infinite_bench_sum")
-def get_infinite_bench_sum_spec(min_num_words: int = 0, max_num_words: int = 65536) -> RunSpec:
-
+@run_spec_function("infinite_bench_en_qa")
+def get_infinite_bench_en_qa_spec(max_num_words: int = 65536) -> RunSpec:
     scenario_spec = ScenarioSpec(
-        class_name="helm.benchmark.scenarios.infinite_bench_sum_scenario.InfiniteBenchSumScenario",
+        class_name="helm.benchmark.scenarios.infinite_bench_en_qa_scenario.InfiniteBenchEnQAScenario",
         args={
-            "min_num_words": min_num_words,
             "max_num_words": max_num_words,
         },
     )
 
-    # No official number for max tokens, the average output token is 1.1k according to the paper
-    adapter_spec = _get_long_context_generation_adapter_spec(max_tokens=2000)
+    adapter_spec = _get_long_context_generation_adapter_spec(max_tokens=40)
     metric_specs = get_basic_metric_specs(["rouge_l"])
 
     return RunSpec(
-        name=f"infinite_bench_sum:min_num_words={min_num_words},max_num_words={max_num_words}",
-        scenario_spec=scenario_spec,
-        adapter_spec=adapter_spec,
-        metric_specs=metric_specs,
-        groups=["infinite_bench_sum"],
-    )
-
-
-@run_spec_function("infinite_bench_en_qa")
-def get_infinite_bench_en_qa_spec() -> RunSpec:
-    scenario_spec = ScenarioSpec(
-        class_name="helm.benchmark.scenarios.infinite_bench_en_qa_scenario.InfiniteBenchEnQAScenario",
-    )
-
-    # No official number for max tokens
-    adapter_spec = _get_long_context_generation_adapter_spec(max_tokens=100)
-    metric_specs = get_basic_metric_specs(["rouge_l"])
-
-    return RunSpec(
-        name="infinite_bench_en_qa",
+        name="infinite_bench_en_qa:max_num_words={max_num_words}",
         scenario_spec=scenario_spec,
         adapter_spec=adapter_spec,
         metric_specs=metric_specs,
@@ -111,8 +89,30 @@ def get_infinite_bench_en_qa_spec() -> RunSpec:
     )
 
 
+@run_spec_function("infinite_bench_sum")
+def get_infinite_bench_sum_spec(max_num_words: int = 65536) -> RunSpec:
+
+    scenario_spec = ScenarioSpec(
+        class_name="helm.benchmark.scenarios.infinite_bench_sum_scenario.InfiniteBenchSumScenario",
+        args={
+            "max_num_words": max_num_words,
+        },
+    )
+
+    adapter_spec = _get_long_context_generation_adapter_spec(max_tokens=1200)
+    metric_specs = get_basic_metric_specs(["rouge_l"])
+
+    return RunSpec(
+        name=f"infinite_bench_sum:max_num_words={max_num_words}",
+        scenario_spec=scenario_spec,
+        adapter_spec=adapter_spec,
+        metric_specs=metric_specs,
+        groups=["infinite_bench_sum"],
+    )
+
+
 @run_spec_function("openai_mrcr")
-def get_openai_mrcr_spec(needles: int, max_num_words: Optional[int] = None) -> RunSpec:
+def get_openai_mrcr_spec(needles: int, max_num_words: int = 65536) -> RunSpec:
     scenario_spec = ScenarioSpec(
         class_name="helm.benchmark.scenarios.openai_mrcr_scenario.OpenAIMRCRScenario",
         args={"needles": needles, "max_num_words": max_num_words},
@@ -125,13 +125,8 @@ def get_openai_mrcr_spec(needles: int, max_num_words: Optional[int] = None) -> R
         MetricSpec(class_name="helm.benchmark.metrics.openai_mrcr_metrics.OpenAIMRCRMetric")
     ]
 
-    run_spec_name = (
-        f"openai_mrcr:needles={needles},max_num_words={max_num_words}"
-        if max_num_words
-        else f"openai_mrcr:needles={needles}"
-    )
     return RunSpec(
-        name=run_spec_name,
+        name=f"openai_mrcr:needles={needles},max_num_words={max_num_words}",
         scenario_spec=scenario_spec,
         adapter_spec=adapter_spec,
         metric_specs=metric_specs,

--- a/src/helm/benchmark/scenarios/infinite_bench_en_qa_scenario.py
+++ b/src/helm/benchmark/scenarios/infinite_bench_en_qa_scenario.py
@@ -26,7 +26,7 @@ class InfiniteBenchEnQAScenario(Scenario):
     """
 
     name = "infinite_bench_en_qa"
-    description = "Answer open ended questions from InfiniteBench"
+    description = "∞Bench En.QA is a summarization task that requires generating a concise summary of a novel. ([Zhang et al., 2024](https://arxiv.org/abs/2402.13718))"  # noqa: E501
     tags = ["question_answering"]
 
     def __init__(self, max_num_words: int):

--- a/src/helm/benchmark/scenarios/infinite_bench_sum_scenario.py
+++ b/src/helm/benchmark/scenarios/infinite_bench_sum_scenario.py
@@ -27,8 +27,7 @@ class InfiniteBenchSumScenario(Scenario):
     description = "Summarize a novel from InfiniteBench"
     tags = ["summarization"]
 
-    def __init__(self, min_num_words: int, max_num_words: int):
-        self.min_num_words = min_num_words
+    def __init__(self, max_num_words: int):
         self.max_num_words = max_num_words
         super().__init__()
 
@@ -61,9 +60,9 @@ class InfiniteBenchSumScenario(Scenario):
         def count_words(text: str) -> int:
             return len(re.split(r"\s+", text.strip()))
 
-        dataset = dataset.map(
-            lambda example: {"prompt_wc": count_words(example["context"]) + count_words(example["input"])}
-        ).filter(lambda example: self.min_num_words <= example["prompt_wc"] <= self.max_num_words)
+        dataset = dataset.filter(
+            lambda example: count_words(example["context"]) + count_words(example["input"]) <= self.max_num_words
+        )
 
         # Read all instances
         instances: List[Instance] = []
@@ -75,7 +74,6 @@ class InfiniteBenchSumScenario(Scenario):
                 input=input,
                 references=[Reference(Output(text=row["answer"][0]), tags=[CORRECT_TAG])],
                 split=TEST_SPLIT,
-                extra_data={"word_count": row["prompt_wc"]},
             )
             instances.append(instance)
 

--- a/src/helm/benchmark/scenarios/infinite_bench_sum_scenario.py
+++ b/src/helm/benchmark/scenarios/infinite_bench_sum_scenario.py
@@ -24,7 +24,7 @@ class InfiniteBenchSumScenario(Scenario):
     """
 
     name = "infinite_bench_sum"
-    description = "Summarize a novel from InfiniteBench"
+    description = "∞Bench Sum is a summarization task that requires generating a concise summary of a novel. ([Zhang et al., 2024](https://arxiv.org/abs/2402.13718))"  # noqa: E501
     tags = ["summarization"]
 
     def __init__(self, max_num_words: int):

--- a/src/helm/benchmark/scenarios/ruler_qa_scenario_helper.py
+++ b/src/helm/benchmark/scenarios/ruler_qa_scenario_helper.py
@@ -133,7 +133,7 @@ def generate_samples(dataset: str, dataset_path: str, template: str, random_seed
         input_text, answer = generate_input_output(0, num_docs, template=template, random_seed=random_seed, qas=qas, docs=docs)
         # Calculate the number of tokens in the example
         total_tokens = len(_text_to_tokens(input_text + f' {answer}'))
-        print(f'Max length {max_seq_length} | Current length {total_tokens + tokens_to_generate} | Docs: {num_docs}')
+        # print(f'Max length {max_seq_length} | Current length {total_tokens + tokens_to_generate} | Docs: {num_docs}')
         if total_tokens + tokens_to_generate > max_seq_length:
             num_docs -= incremental
             break
@@ -142,7 +142,7 @@ def generate_samples(dataset: str, dataset_path: str, template: str, random_seed
         if num_docs > len(docs):
             num_docs = len(docs)
             break
-    print('Number of documents:', num_docs)
+    # print('Number of documents:', num_docs)
     
     # Generate samples
     for index in tqdm(range(num_samples)):

--- a/src/helm/benchmark/scenarios/ruler_qa_scenarios.py
+++ b/src/helm/benchmark/scenarios/ruler_qa_scenarios.py
@@ -72,7 +72,7 @@ Question: {query} Answer:"""  # noqa: E501
 
 class RULERHotpotQAScenario(_RULERQAScenario):
     name = "ruler_hotpotqa"
-    description = "The HotpotQA long-context multi-hop RAG question answering scenario from RULER"
+    description = "RULER HotPotQA is an augmented version of HotPotQA ([Yang et al., 2018](https://arxiv.org/abs/1809.09600)) introduced by [Hsieh et al., 2024](https://arxiv.org/abs/2404.06654) to simulate a multi-hop question answering as a long-context scenario."  # noqa: E501
     tags = ["long_context", "rag"]
 
     def __init__(self, max_num_words: int):
@@ -81,7 +81,7 @@ class RULERHotpotQAScenario(_RULERQAScenario):
 
 class RULERSQuADScenario(_RULERQAScenario):
     name = "ruler_squad"
-    description = "The SQuAD question answering scenario from RULER"
+    description = "RULER SQuAD is an augmented version of SQuAD ([Rajpurkar et al., 2018](https://arxiv.org/abs/1806.03822)) introduced by [Hsieh et al., 2024](https://arxiv.org/abs/2404.06654) to simulate a single-hop question answering as a long-context scenario."  # noqa: E501
     tags = ["long_context", "rag"]
 
     def __init__(self, max_num_words: int):

--- a/src/helm/benchmark/scenarios/test_infinite_bench_en_qa_scenario.py
+++ b/src/helm/benchmark/scenarios/test_infinite_bench_en_qa_scenario.py
@@ -8,7 +8,7 @@ from helm.benchmark.scenarios.scenario import CORRECT_TAG
 @pytest.mark.scenarios
 def test_infinite_bench_en_qa_scenario():
     with TemporaryDirectory() as tmpdir:
-        scenario = InfiniteBenchEnQAScenario()
+        scenario = InfiniteBenchEnQAScenario(max_num_words=10000000)
         instances = scenario.get_instances(tmpdir)
         assert len(instances) == 351
         assert instances[0].split == "test"

--- a/src/helm/benchmark/scenarios/test_infinite_bench_sum_scenario.py
+++ b/src/helm/benchmark/scenarios/test_infinite_bench_sum_scenario.py
@@ -12,7 +12,7 @@ def count_words(text: str) -> int:
 @pytest.mark.scenarios
 def test_infinite_bench_sum_scenario():
     with TemporaryDirectory() as tmpdir:
-        scenario = InfiniteBenchSumScenario(min_num_words=0, max_num_words=10000000)
+        scenario = InfiniteBenchSumScenario(max_num_words=10000000)
         instances = scenario.get_instances(tmpdir)
         assert len(instances) == 103
         assert instances[0].split == "test"
@@ -23,7 +23,7 @@ def test_infinite_bench_sum_scenario():
         assert len(references[0].output.text) == 2865
         assert references[0].tags == [CORRECT_TAG]
 
-        scenario = InfiniteBenchSumScenario(min_num_words=0, max_num_words=100000)
+        scenario = InfiniteBenchSumScenario(max_num_words=100000)
         instances = scenario.get_instances(tmpdir)
         assert len(instances) == 48
         assert instances[0].split == "test"
@@ -32,15 +32,4 @@ def test_infinite_bench_sum_scenario():
         assert instances[0].extra_data["word_count"] == 69458
         references = instances[0].references
         assert len(references[0].output.text) == 4217
-        assert references[0].tags == [CORRECT_TAG]
-
-        scenario = InfiniteBenchSumScenario(min_num_words=30000, max_num_words=80000)
-        instances = scenario.get_instances(tmpdir)
-        assert len(instances) == 32
-        assert instances[0].split == "test"
-        assert len(instances[1].input.text) == 383396
-        assert instances[1].extra_data
-        assert instances[1].extra_data["word_count"] == 68482
-        references = instances[1].references
-        assert len(references[0].output.text) == 5667
         assert references[0].tags == [CORRECT_TAG]

--- a/src/helm/benchmark/scenarios/test_infinite_bench_sum_scenario.py
+++ b/src/helm/benchmark/scenarios/test_infinite_bench_sum_scenario.py
@@ -17,8 +17,6 @@ def test_infinite_bench_sum_scenario():
         assert len(instances) == 103
         assert instances[0].split == "test"
         assert len(instances[0].input.text) == 1745528
-        assert instances[0].extra_data
-        assert instances[0].extra_data["word_count"] == 308762
         references = instances[0].references
         assert len(references[0].output.text) == 2865
         assert references[0].tags == [CORRECT_TAG]
@@ -28,8 +26,6 @@ def test_infinite_bench_sum_scenario():
         assert len(instances) == 48
         assert instances[0].split == "test"
         assert len(instances[0].input.text) == 381778
-        assert instances[0].extra_data
-        assert instances[0].extra_data["word_count"] == 69458
         references = instances[0].references
         assert len(references[0].output.text) == 4217
         assert references[0].tags == [CORRECT_TAG]

--- a/src/helm/benchmark/static/schema_long_context.yaml
+++ b/src/helm/benchmark/static/schema_long_context.yaml
@@ -184,7 +184,7 @@ metric_groups:
 run_groups:
   - name: long_context_scenarios
     display_name: Long Context Scenarios
-    description: Scenarios for the model safety
+    description: Scenarios for evaluating long context capabilities
     category: All scenarios
     subgroups:
       - ruler_hotpotqa
@@ -195,7 +195,7 @@ run_groups:
 
   - name: ruler_hotpotqa
     display_name: RULER HotPotQA
-    description: RULER HotPotQA
+    description: RULER HotPotQA is an augmented version of HotPotQA ([Yang et al., 2018](https://arxiv.org/abs/1809.09600)) introduced by [Hsieh et al., 2024](https://arxiv.org/abs/2404.06654) to simulate a multi-hop question answering as a long-context scenario.
     metric_groups:
       - accuracy
       - general_information
@@ -204,16 +204,16 @@ run_groups:
       main_name: f1_score
       main_split: valid
     taxonomy:
-      task: question answering
-      what: n/a
-      who: n/a
-      when: n/a
+      task: question answering with retrieval-augmented generation
+      what: Wikipedia articles
+      who: Wikipedia authors
+      when: Before 2018
       language: English
 
 
   - name: ruler_squad
     display_name: RULER SQuAD
-    description: RULER SQuAD
+    description: RULER SQuAD is an augmented version of SQuAD ([Rajpurkar et al., 2018](https://arxiv.org/abs/1806.03822)) introduced by [Hsieh et al., 2024](https://arxiv.org/abs/2404.06654) to simulate a single-hop question answering as a long-context scenario.
     metric_groups:
       - accuracy
       - general_information
@@ -223,31 +223,14 @@ run_groups:
       main_split: valid
     taxonomy:
       task: question answering
-      what: n/a
-      who: n/a
-      when: n/a
-      language: English
-
-  - name: infinite_bench_sum
-    display_name: ∞Bench Sum
-    description: ∞Bench Sum
-    metric_groups:
-      - accuracy
-      - general_information
-      - annotation_metrics
-    environment:
-      main_name: rouge_l
-      main_split: test
-    taxonomy:
-      task: question answering
-      what: n/a
-      who: n/a
-      when: n/a
+      what: Wikipedia articles
+      who: Wikipedia authors and crowdworkers
+      when: Before 2018
       language: English
 
   - name: infinite_bench_en_qa
     display_name: ∞Bench En.QA
-    description: ∞Bench En.QA
+    description: ∞Bench En.QA is a question answering task that requires locating and processing information within a novel, performing reasoning through aggregation or filtering to derive answers. ([Zhang et al., 2024](https://arxiv.org/abs/2402.13718))
     metric_groups:
       - accuracy
       - general_information
@@ -257,9 +240,26 @@ run_groups:
       main_split: test
     taxonomy:
       task: question answering
-      what: n/a
-      who: n/a
-      when: n/a
+      what: Novels
+      who: Novel authors
+      when: Before 2024
+      language: English
+
+  - name: infinite_bench_sum
+    display_name: ∞Bench Sum
+    description: ∞Bench En.QA is a summarization task that requires generating a concise summary of a novel. ([Zhang et al., 2024](https://arxiv.org/abs/2402.13718))
+    metric_groups:
+      - accuracy
+      - general_information
+      - annotation_metrics
+    environment:
+      main_name: rouge_l
+      main_split: test
+    taxonomy:
+      task: multi-hop question answering
+      what: Novels
+      who: Novel authors
+      when: Before 2024
       language: English
 
   - name: openai_mrcr
@@ -273,7 +273,7 @@ run_groups:
       main_split: test
     taxonomy:
       task: MRCR
-      what: n/a
-      who: n/a
-      when: n/a
+      what: Synthetic data
+      who: "None"
+      when: "2025"
       language: English

--- a/src/helm/benchmark/static/schema_long_context.yaml
+++ b/src/helm/benchmark/static/schema_long_context.yaml
@@ -247,7 +247,7 @@ run_groups:
 
   - name: infinite_bench_sum
     display_name: ∞Bench Sum
-    description: ∞Bench En.QA is a summarization task that requires generating a concise summary of a novel. ([Zhang et al., 2024](https://arxiv.org/abs/2402.13718))
+    description: ∞Bench Sum is a summarization task that requires generating a concise summary of a novel. ([Zhang et al., 2024](https://arxiv.org/abs/2402.13718))
     metric_groups:
       - accuracy
       - general_information
@@ -263,7 +263,7 @@ run_groups:
       language: English
 
   - name: openai_mrcr
-    display_name: OpenAI-MRCR
+    display_name: OpenAI MRCR
     description: OpenAI MRCR (Multi-round co-reference resolution) is a long context dataset for benchmarking an LLM's ability to distinguish between multiple needles hidden in context. This eval is inspired by the MRCR eval first introduced by [Vodrahalli et al., 2024](https://arxiv.org/pdf/2409.12640v2).
     metric_groups:
       - accuracy


### PR DESCRIPTION
- Unify the parameters for all scenarios (`max_num_words` only)
- Change OpenAI-MRCR to OpenAI MRCR
- Set up run entries file
- Reorder infinite_bench_en_qa before infinite_bench_sum
- Update scenario descriptions in code and schema
- Increase max number of words from 65536 to 131072