### PR TITLE
Disable logging propagation

### DIFF
--- a/src/helm/common/hierarchical_logger.py
+++ b/src/helm/common/hierarchical_logger.py
@@ -143,6 +143,7 @@ def setup_default_logging():
 
     logger = logging.getLogger("helm")
     logger.setLevel(logging.INFO)
+    logger.propagate = False
     handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(formatter)
     logger.addHandler(handler)


### PR DESCRIPTION
This addresses the double logging issue due to absl logging installing a root handler when it is imported. See #3595 for more explanation.

Fixes #3595