### PR TITLE
Fix stacklevel in logging wrapper

### DIFF
--- a/src/helm/common/hierarchical_logger.py
+++ b/src/helm/common/hierarchical_logger.py
@@ -34,22 +34,26 @@ class HierarchicalLogger(object):
     def indent(self) -> str:
         return "  " * len(self.start_times)
 
-    def track_begin(self, x: Any) -> None:
-        self.logger.info(self.indent() + str(x) + " {")
+    def track_begin(self, x: Any, **kwargs) -> None:
+        kwargs['stacklevel'] = kwargs.get('stacklevel', 1) + 1
+        self.logger.info(self.indent() + str(x) + " {", **kwargs)
         sys.stdout.flush()
         self.start_times.append(time.time())
 
-    def track_end(self) -> None:
+    def track_end(self, **kwargs) -> None:
+        kwargs['stacklevel'] = kwargs.get('stacklevel', 1) + 1
         t = time.time() - self.start_times.pop()
-        self.logger.info(self.indent() + "} [%s]" % (format_time(t)))
+        self.logger.info(self.indent() + "} [%s]" % (format_time(t)), **kwargs)
         sys.stdout.flush()
 
-    def log(self, x: Any) -> None:
-        self.logger.info(self.indent() + str(x))
+    def log(self, x: Any, **kwargs) -> None:
+        kwargs['stacklevel'] = kwargs.get('stacklevel', 1) + 1
+        self.logger.info(self.indent() + str(x), **kwargs)
         sys.stdout.flush()
 
-    def warn(self, x: Any) -> None:
-        self.logger.warning(self.indent() + str(x))
+    def warn(self, x: Any, **kwargs) -> None:
+        kwargs['stacklevel'] = kwargs.get('stacklevel', 1) + 1
+        self.logger.warning(self.indent() + str(x), **kwargs)
         sys.stdout.flush()
 
 
@@ -69,23 +73,26 @@ singleton = HierarchicalLogger()
 # Exposed public methods
 
 
-def hlog(x: Any) -> None:
-    singleton.log(x)
+def hlog(x: Any, **kwargs) -> None:
+    kwargs['stacklevel'] = kwargs.get('stacklevel', 1) + 1
+    singleton.log(x, **kwargs)
 
 
-def hwarn(x: Any) -> None:
-    singleton.warn(x)
+def hwarn(x: Any, **kwargs) -> None:
+    kwargs['stacklevel'] = kwargs.get('stacklevel', 1) + 1
+    singleton.warn(x, **kwargs)
 
 
 class htrack_block:
-    def __init__(self, x: Any) -> None:
+    def __init__(self, x: Any, stacklevel=1) -> None:
+        self._stacklevel = stacklevel + 1
         self.x = x
 
     def __enter__(self) -> None:
-        singleton.track_begin(self.x)
+        singleton.track_begin(self.x, stacklevel=self._stacklevel)
 
     def __exit__(self, tpe: Any, value: Any, callback: Any) -> None:
-        singleton.track_end()
+        singleton.track_end(stacklevel=self._stacklevel)
 
 
 class htrack:
@@ -116,7 +123,7 @@ class htrack:
                     description = description.replace("$" + k, str(v))
             else:
                 description = ""
-            with htrack_block(parent + fn.__name__ + description):
+            with htrack_block(parent + fn.__name__ + description, stacklevel=2):
                 return fn(*args, **kwargs)
 
         return wrapper


### PR DESCRIPTION
Currently, if you configure the logger with `%(pathname)s:%(lineno)d %(funcName)s: ` it will just show that all the logs are written from hierarchical_logger.py

This PR fixes it by supplying the `info` / `debug` / `warn` calls with the appropriate stacklevel value so the actual caller of the logger is introspected if that feature is requested (which is very useful to someone like me trying to understand the repo). I did this using kwargs as that was simpler to write, but a more explicit stacklevel argument could be added to avoid kwargs if desired.

This PR does not modify the default message, it just fixes the stacklevel argument such that if the user does override the default logging config with stack-aware information, you get something more reasonable. 

I did however notice this comment: 

```
    # Far too much effort to unwind every call to hlog to go via logging,
    # And is a terrible idea to inspect the stack every time hlog is called
    # to figure out the caller,
    # So just log everything under "helm".
```

And I generally agree, but if you are using Python's logger I think its unwinding the stack each time no matter what (or at least it does if you request a stack-related item in your logging formatter; not sure if its smart enough to avoid it if you don't).

But if you are using Python's logging module you may as well use it fully. I do however, have a utility I've been working on that provides a logging wrapper which gives you the choice of the logging or a print-based backend. In both cases the API is the same, but it lets the user quickly swap out full Python logging with a much simpler print-based logger, and that should 100% avoid any overhead from stack introspection. It is still experimental, but I'll put a link to it here as a reference.  

https://gitlab.kitware.com/computer-vision/kwutil/-/blob/b03b6910cc23d7b29e5d0832340506f41814644a/kwutil/util_logging.py