### PR TITLE
Backport StrEnum

### DIFF
--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -53,6 +53,7 @@ from helm.benchmark.config_registry import register_builtin_configs_from_helm_pa
 from helm.benchmark.presentation.run_display import write_run_display_json
 from helm.benchmark.model_metadata_registry import ModelMetadata, get_model_metadata, get_all_models
 from helm.common.object_spec import get_class_by_name
+from helm.common.backports.strenum import StrEnum
 
 
 MODEL_HEADER_CELL_VALUE = "Model"
@@ -293,8 +294,7 @@ def compute_aggregate_row_means(table: Table) -> List[Optional[float]]:
     return row_means
 
 
-class AggregationStrategy:
-    # TODO: Convert to StrEnum after upgrading to Python 3.11
+class AggregationStrategy(StrEnum):
     WIN_RATE = "win_rate"
     MEAN = "mean"
 

--- a/src/helm/benchmark/slurm_jobs.py
+++ b/src/helm/benchmark/slurm_jobs.py
@@ -5,6 +5,7 @@ from typing import Mapping, Set, Union
 from retrying import retry
 
 from helm.common.optional_dependencies import handle_module_not_found_error
+from helm.common.backports.strenum import StrEnum
 
 try:
     from simple_slurm import Slurm
@@ -12,8 +13,7 @@ except ModuleNotFoundError as e:
     handle_module_not_found_error(e, ["slurm"])
 
 
-class SlurmJobState:
-    # TODO: Convert to StrEnum after upgrading to Python 3.11
+class SlurmJobState(StrEnum):
     # Non-exhaustive list of Slurm job states.
     # See: https://slurm.schedmd.com/squeue.html#SECTION_JOB-STATE-CODES
 

--- a/src/helm/clients/together_client.py
+++ b/src/helm/clients/together_client.py
@@ -14,6 +14,7 @@ from helm.common.object_spec import get_class_by_name
 from helm.common.optional_dependencies import handle_module_not_found_error
 from helm.common.request import Thinking, wrap_request_time, Request, RequestResult, GeneratedOutput, Token
 from helm.clients.client import CachingClient, truncate_sequence, cleanup_str
+from helm.common.backports.strenum import StrEnum
 
 try:
     from together import Together
@@ -22,10 +23,8 @@ except ModuleNotFoundError as e:
     handle_module_not_found_error(e, ["together"])
 
 
-class _RewriteRequestTags:
+class _RewriteRequestTags(StrEnum):
     """Tags that indicate that the request for the model must be rewritten before sending to Together."""
-
-    # TODO: Convert to StrEnum after upgrading to Python 3.11
 
     ADD_EOS_TOKEN_AS_STOP_SEQUENCE = "ADD_EOS_TOKEN_AS_STOP_SEQUENCE"
     """Indicates that the EOS token should be added as an extra stop sequence.

--- a/src/helm/common/backports/strenum.py
+++ b/src/helm/common/backports/strenum.py
@@ -1,0 +1,67 @@
+"""
+Backports :class:`enum.StrEnum` to Python < 3.11.
+
+This can be removed once the minimum python becomes >= 3.11
+"""
+import enum
+
+
+class _StrEnumBase(str, enum.Enum):
+    """
+    Base class mimicking :py:class:`enum.StrEnum` in Python 3.11+.
+
+    Example
+    -------
+    >>> import enum
+    >>> class MyEnum(_StrEnumBase):
+    ...     foo = enum.auto()
+    ...     BAR = enum.auto()
+    >>> MyEnum.foo
+    <MyEnum.foo: 'foo'>
+    >>> MyEnum('bar')
+    <MyEnum.BAR: 'bar'>
+    >>> MyEnum('baz')
+    Traceback (most recent call last):
+      ...
+    ValueError: 'baz' is not a valid MyEnum
+    """
+    @staticmethod
+    def _generate_next_value_(name, *_, **__):
+        return name.lower()
+
+    def __eq__(self, other):
+        return self.value == other
+
+    def __str__(self):
+        return self.value
+
+
+class StrEnum(getattr(enum, 'StrEnum', _StrEnumBase)):
+    """
+    Enum where members are also (and must be) strings
+
+    Example
+    -------
+    >>> import enum
+    >>> class MyEnum(StrEnum):
+    ...     foo = enum.auto()
+    ...     BAR = enum.auto()
+    >>> MyEnum.foo
+    <MyEnum.foo: 'foo'>
+    >>> MyEnum('bar')
+    <MyEnum.BAR: 'bar'>
+    >>> bar = MyEnum('BAR')  # Case-insensitive
+    >>> bar
+    <MyEnum.BAR: 'bar'>
+    >>> assert isinstance(bar, str)
+    >>> assert bar == 'bar'
+    >>> str(bar)
+    'bar'
+    """
+    @classmethod
+    def _missing_(cls, value):
+        if not isinstance(value, str):
+            return None
+        members = {name.casefold(): instance
+                   for name, instance in cls.__members__.items()}
+        return members.get(value.casefold())

--- a/src/helm/common/critique_request.py
+++ b/src/helm/common/critique_request.py
@@ -1,12 +1,12 @@
 from dataclasses import dataclass
 from typing import Dict, List, Union, Optional
 from helm.common.media_object import MediaObject
+from helm.common.backports.strenum import StrEnum
 
 
-class QuestionType:
+class QuestionType(StrEnum):
     """String enum of question types."""
 
-    # TODO: Make this a StrEnum after upgrading to Python 3.11
     MULTIPLE_CHOICE: str = "multiple_choice"
     CHECKBOX: str = "checkbox"
     FREE_RESPONSE: str = "free_response"


### PR DESCRIPTION
As I was browsing the code I saw a repeated comment: `TODO: Convert to StrEnum after upgrading to Python 3.11`. 

StrEnum is a useful class, and its possible to use it in Python 3.9 and 3.10 with a simple backport that remains compatible with the 3.11+ version. This is borrowed from a strategy we used in [line_profiler](https://github.com/pyutils/line_profiler/blob/e842d23697668ebeeeac06059d7762cdbd27b60e/line_profiler/line_profiler_utils.py).

If you want StrEnums now, then this is a great way to do it. Once you change the minimum to Python 3.11, you can remove the backports module and just use `from enum import StrEnum`. 

Or close this PR and just wait for a 3.11 update and keep the TODOs as-is. But this PR was easy for me to make, so I just went ahead and did it. 