### PR TITLE
Add new benchmark in Brazilian Portuguese: BLUEX

### DIFF
--- a/src/helm/benchmark/run_specs/bluex_run_specs.py
+++ b/src/helm/benchmark/run_specs/bluex_run_specs.py
@@ -1,0 +1,40 @@
+from helm.benchmark.adaptation.adapters.adapter_factory import ADAPT_MULTIPLE_CHOICE_JOINT
+from helm.benchmark.adaptation.common_adapter_specs import get_multiple_choice_adapter_spec
+from helm.benchmark.metrics.common_metric_specs import get_exact_match_metric_specs
+from helm.benchmark.run_spec import RunSpec, run_spec_function
+from helm.benchmark.scenarios.scenario import ScenarioSpec
+
+
+@run_spec_function("bluex")
+def get_bluex_spec() -> RunSpec:
+    scenario_spec = ScenarioSpec(class_name="helm.benchmark.scenarios.bluex_scenario.BLUEX_Scenario", args={})
+
+    adapter_spec = get_multiple_choice_adapter_spec(
+        method=ADAPT_MULTIPLE_CHOICE_JOINT,
+        instructions="""
+        Escolha a alternativa correta para as questões de vestibulares (responda apenas com a letra).
+        Exemplo de Pergunta com a resposta:
+        Em um romance narrado em primeira pessoa, o narrador participa dos acontecimentos da trama,
+        relatando suas próprias experiências e sentimentos. Qual alternativa apresenta essa característica?
+
+        (A) Narrador onisciente que conhece os pensamentos de todas as personagens.
+        (B) Narrador que descreve os fatos de forma imparcial, sem envolvimento emocional.
+        (C) Narrador-personagem que vivencia e relata os eventos da história.
+        (D) Narrador observador que apenas registra as ações visíveis.
+        (E) Narrador em segunda pessoa que se dirige constantemente ao leitor.
+
+        Resposta correta: C
+
+        A partir disso, responda:
+        """,
+        input_noun="Pergunta",
+        output_noun="Resposta",
+    )
+
+    return RunSpec(
+        name="bluex",
+        scenario_spec=scenario_spec,
+        adapter_spec=adapter_spec,
+        metric_specs=get_exact_match_metric_specs(),
+        groups=["bluex"],
+    )

--- a/src/helm/benchmark/scenarios/bluex_scenario.py
+++ b/src/helm/benchmark/scenarios/bluex_scenario.py
@@ -1,0 +1,66 @@
+from typing import Any, List
+from pathlib import Path
+from datasets import load_dataset
+from helm.benchmark.scenarios.scenario import (
+    Scenario,
+    Instance,
+    Reference,
+    TEST_SPLIT,
+    CORRECT_TAG,
+    Input,
+    Output,
+)
+
+
+class BLUEX_Scenario(Scenario):
+    """
+    The BLUEX dataset is a benchmark used for evaluating natural language processing models in Brazilian Portuguese.
+    It consists of multiple-choice questions taken from official entrance exams of Unicamp (Convest) and USP (Fuvest),
+    covering various high school subjects. The questions include both textual prompts and visual elements. This dataset
+    was developed to assess the performance of models on tasks involving comprehension and reasoning, with a specific
+    focus on texts and exams originally written in Portuguese.
+    """
+
+    name = "bluex"
+    description = "MQA benchmark with questions from Brazilian entrance exams"
+    tags = ["knowledge", "multiple_choice", "pt-br"]
+
+    def get_instances(self, output_path: str) -> List[Instance]:
+        # Download the raw data and read all the dialogues
+        dataset: Any
+        # Read all the instances
+        instances: List[Instance] = []
+        cache_dir = str(Path(output_path) / "data")
+
+        dataset = load_dataset("portuguese-benchmark-datasets/BLUEX", cache_dir=cache_dir)
+        for example in dataset["questions"]:
+            # This scenario disregards issues with images
+            if example["has_associated_images"]:
+                continue
+            question = example["question"]
+            choices = example["alternatives"]
+            answer = example["answer"]
+
+            answers_dict = {}
+            for alt in choices:
+                if ")" in alt:
+                    label, text = alt.split(")", 1)
+                    label = label.strip().upper()
+                    text = text.strip()
+                    answers_dict[label] = text
+
+            if answer not in answers_dict:
+                continue
+
+            correct_answer = answers_dict[answer]
+
+            def answer_to_reference(answer: str) -> Reference:
+                return Reference(Output(text=answer), tags=[CORRECT_TAG] if answer == correct_answer else [])
+
+            instance = Instance(
+                input=Input(text=question),
+                split=TEST_SPLIT,
+                references=[answer_to_reference(text) for text in answers_dict.values()],
+            )
+            instances.append(instance)
+        return instances

--- a/src/helm/benchmark/scenarios/test_bluex_scenario.py
+++ b/src/helm/benchmark/scenarios/test_bluex_scenario.py
@@ -28,28 +28,28 @@ def test_bluex_scenario():
         ),
         Reference(
             output=Output(
-                text='a presença de um narrador-personagem, como se lê em "em verdade vos digo que pensava em outra'
-                'coisa".'
+                text='a presença de um narrador-personagem, como se lê em "em verdade vos digo que pensava em '
+                'outra coisa".'
             ),
             tags=[],
         ),
         Reference(
             output=Output(
-                text='a sobriedade do protagonista ao avaliar o seu percurso, como se lê em "Cotejava o passado com o'
-                "presente."
+                text='a sobriedade do protagonista ao avaliar o seu percurso, como se lê em "Cotejava o passado com '
+                "o presente."
             ),
             tags=[],
         ),
         Reference(
             output=Output(
-                text='o sentido místico e fatalista que rege os destinos, como se lê em "Deus escreve direito por'
-                ' linhas tortas".'
+                text='o sentido místico e fatalista que rege os destinos, como se lê em "Deus escreve direito por '
+                'linhas tortas".'
             ),
             tags=[],
         ),
         Reference(
             output=Output(
-                text='a reversibilidade entre o cômico e o trágico, como se lê em "de modo que o que parecia uma'
+                text='a reversibilidade entre o cômico e o trágico, como se lê em "de modo que o que parecia uma '
                 'desgraça...".'
             ),
             tags=[CORRECT_TAG],

--- a/src/helm/benchmark/scenarios/test_bluex_scenario.py
+++ b/src/helm/benchmark/scenarios/test_bluex_scenario.py
@@ -1,0 +1,59 @@
+import pytest
+from tempfile import TemporaryDirectory
+
+from helm.benchmark.scenarios.bluex_scenario import BLUEX_Scenario
+from helm.benchmark.scenarios.scenario import TEST_SPLIT, CORRECT_TAG, Output, Reference
+
+
+@pytest.mark.scenarios
+def test_bluex_scenario():
+    scenario = BLUEX_Scenario()
+    with TemporaryDirectory() as tmpdir:
+        instances = scenario.get_instances(tmpdir)
+
+    assert len(instances) > 100
+
+    assert instances[100].split == TEST_SPLIT
+
+    assert instances[0].input.text.startswith("Rubião fitava a enseada, - eram oito horas da manhã Quem o visse")
+
+    assert len(instances[0].input.text) == 1011
+
+    assert instances[0].references == [
+        Reference(
+            output=Output(
+                text='a contemplação das paisagens naturais, como se lê em "ele admirava aquele pedaço de água quieta".'
+            ),
+            tags=[],
+        ),
+        Reference(
+            output=Output(
+                text='a presença de um narrador-personagem, como se lê em "em verdade vos digo que pensava em outra'
+                'coisa".'
+            ),
+            tags=[],
+        ),
+        Reference(
+            output=Output(
+                text='a sobriedade do protagonista ao avaliar o seu percurso, como se lê em "Cotejava o passado com o'
+                "presente."
+            ),
+            tags=[],
+        ),
+        Reference(
+            output=Output(
+                text='o sentido místico e fatalista que rege os destinos, como se lê em "Deus escreve direito por'
+                ' linhas tortas".'
+            ),
+            tags=[],
+        ),
+        Reference(
+            output=Output(
+                text='a reversibilidade entre o cômico e o trágico, como se lê em "de modo que o que parecia uma'
+                'desgraça...".'
+            ),
+            tags=[CORRECT_TAG],
+        ),
+    ]
+
+    assert instances[0].references[4].is_correct


### PR DESCRIPTION
## Description
This PR aims to add the BLUEX benchmark, composed of 1,260 Brazilian university entrance exam questions in Brazilian Portuguese, of which 723 were selected for not containing images. The benchmark includes multiple-choice questions taken from the official exams of Unicamp (Convest) and USP (Fuvest), covering a wide range of high school subjects. While the original questions include both textual prompts and visual elements, this version includes only those without images. This addition is important for evaluating the models' ability to understand and answer more complex questions in Brazilian Portuguese.