### PR TITLE
fix: there are other output types the responses API can return, so don't assume everything is a message

### DIFF
--- a/src/helm/clients/openai_responses_client.py
+++ b/src/helm/clients/openai_responses_client.py
@@ -145,13 +145,18 @@ class OpenAIResponseClient(CachingClient):
             if request.echo_prompt:
                 text_output += request.prompt
             for output in response["output"]:
-                output_type = output["type"]  # one of "message" or "reasoning" from API observation
-                is_reasoning_output = output_type == "reasoning"
+                output_type = output[
+                    "type"
+                ]  # one of "message" or "reasoning" from API observation, but can also include tool calls
 
-                if is_reasoning_output:
+                if output_type == "reasoning":
                     reasoning_output += "\n".join([raw_output["text"] for raw_output in output["summary"]])
-                else:
+                elif output_type == "web_search_call":
+                    reasoning_output += f"\nMade a web search call with action: {output['action']}\n"
+                elif output_type == "message":
                     text_output += "\n".join([raw_output["text"] for raw_output in output["content"]])
+                else:
+                    reasoning_output += f"\nGot a output with an unknown type, including raw output here: {output}\n"
 
             completion = truncate_and_tokenize_response_text(
                 text_output,

--- a/src/helm/clients/openai_responses_client.py
+++ b/src/helm/clients/openai_responses_client.py
@@ -152,7 +152,7 @@ class OpenAIResponseClient(CachingClient):
                 if output_type == "reasoning":
                     reasoning_output += "\n".join([raw_output["text"] for raw_output in output["summary"]])
                 elif output_type == "web_search_call":
-                    reasoning_output += f"\nMade a web search call with action: {output['action']}\n"
+                    reasoning_output += f"\nMade a web search call with action: {output.get('action', 'No action information was provided by the API')}\n"
                 elif output_type == "message":
                     text_output += "\n".join([raw_output["text"] for raw_output in output["content"]])
                 else:

--- a/src/helm/clients/openai_responses_client.py
+++ b/src/helm/clients/openai_responses_client.py
@@ -151,12 +151,9 @@ class OpenAIResponseClient(CachingClient):
 
                 if output_type == "reasoning":
                     reasoning_output += "\n".join([raw_output["text"] for raw_output in output["summary"]])
-                elif output_type == "web_search_call":
-                    reasoning_output += f"\nMade a web search call with action: {output.get('action', 'No action information was provided by the API')}\n"
                 elif output_type == "message":
                     text_output += "\n".join([raw_output["text"] for raw_output in output["content"]])
-                else:
-                    reasoning_output += f"\nGot a output with an unknown type, including raw output here: {output}\n"
+                # (Other output types are ignored)
 
             completion = truncate_and_tokenize_response_text(
                 text_output,


### PR DESCRIPTION
Realised there was a bug (when benchmarking a web search enabled OpenAI model) with the responses API code that assumes the only valid response types were "message" and "reasoning". Turns out this is incorrect, and the type field of outputs can contains tool calls it seems.

This PR fixes that bug to prevent crashes trying to access keys that don't exist, and also inserts web search tool calls into the reasoning info.