### PR TITLE
Disable Flake8 E501 Line too long

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -410,7 +410,8 @@ exclude =
 # E731 - do not assign a lambda expression, use a def
 # W503 - line break before binary operator, (conflicts with black)
 # W605 - invalid escape sequence '\', (causes failures)
-ignore = E203,E231,E731,W503,W605
+# E501 - Line too long
+ignore = E203,E231,E731,W503,W605,E501
 
 # Settings for Mypy: static type checker for Python 3
 [mypy]


### PR DESCRIPTION
Flake8 E501 "line too long" confuses new contributes frequently, and doesn't seem that valuable, so let's just disable it.