### PR TITLE
Support using chat models on vLLM

### DIFF
--- a/docs/adding_new_models.md
+++ b/docs/adding_new_models.md
@@ -82,7 +82,7 @@ model_deployments:
     tokenizer_name: EleutherAI/gpt-neox-20b
     max_sequence_length: 2048
     client_spec:
-      class_name: "helm.clients.vllm_client.VLLMClient"
+      class_name: "helm.clients.vllm_client.VLLMCompletionsClient"
       args:
         base_url:  http://mymodelserver:8000/v1/
 ```

--- a/docs/adding_new_models.md
+++ b/docs/adding_new_models.md
@@ -82,10 +82,12 @@ model_deployments:
     tokenizer_name: EleutherAI/gpt-neox-20b
     max_sequence_length: 2048
     client_spec:
-      class_name: "helm.clients.vllm_client.VLLMCompletionsClient"
+      class_name: "helm.clients.vllm_client.VLLMClient"
       args:
         base_url:  http://mymodelserver:8000/v1/
 ```
+
+For non-chat models, set `class_name` in `client_spec` to `helm.clients.vllm_client.VLLMClient`. For chat models, set `class_name` in `client_spec` to `helm.clients.vllm_client.VLLMChatClient`.
 
 Set `base_url` to the URL of your inference server. On your inference server, run vLLM's OpenAI compatible server with:
 

--- a/src/helm/clients/vllm_client.py
+++ b/src/helm/clients/vllm_client.py
@@ -6,7 +6,7 @@ from helm.clients.openai_client import OpenAIClient, OpenAILegacyCompletionsClie
 from helm.tokenizers.tokenizer import Tokenizer
 
 
-class VLLMCompletionsClient(OpenAILegacyCompletionsClient):
+class VLLMClient(OpenAILegacyCompletionsClient):
     """Sends request to a vLLM server using the OpenAI-compatible API.
 
     Only supports the legacy Text Completions API, rather than the Chat Completions API.
@@ -35,11 +35,6 @@ class VLLMCompletionsClient(OpenAILegacyCompletionsClient):
         self.tokenizer = tokenizer
         self.tokenizer_name = tokenizer_name
         self.vllm_model_name = vllm_model_name
-
-    def _get_model_for_request(self, request: Request) -> str:
-        # The `model` parameter for vLLM should be the whole model name including the creator organization,
-        # unlike OpenAI which only uses the model engine.
-        return self.vllm_model_name or request.model
 
     def _to_raw_completion_request(self, request: Request) -> Dict[str, Any]:
         raw_request = super()._to_raw_completion_request(request)
@@ -77,13 +72,9 @@ class VLLMChatClient(OpenAIClient):
             api_key="EMPTY",
             org_id=None,
             base_url=base_url,
+            openai_model_name=vllm_model_name,
             **kwargs,
         )
         self.tokenizer = tokenizer
         self.tokenizer_name = tokenizer_name
         self.vllm_model_name = vllm_model_name
-
-    def _get_model_for_request(self, request: Request) -> str:
-        # The `model` parameter for vLLM should be the whole model name including the creator organization,
-        # unlike OpenAI which only uses the model engine.
-        return self.vllm_model_name or request.model

--- a/src/helm/clients/vllm_client.py
+++ b/src/helm/clients/vllm_client.py
@@ -2,11 +2,11 @@ from typing import Any, Dict, Optional
 
 from helm.common.cache import CacheConfig
 from helm.common.request import Request
-from helm.clients.openai_client import OpenAILegacyCompletionsClient
+from helm.clients.openai_client import OpenAIClient, OpenAILegacyCompletionsClient
 from helm.tokenizers.tokenizer import Tokenizer
 
 
-class VLLMClient(OpenAILegacyCompletionsClient):
+class VLLMCompletionsClient(OpenAILegacyCompletionsClient):
     """Sends request to a vLLM server using the OpenAI-compatible API.
 
     Only supports the legacy Text Completions API, rather than the Chat Completions API.
@@ -19,6 +19,55 @@ class VLLMClient(OpenAILegacyCompletionsClient):
         tokenizer_name: str,
         cache_config: CacheConfig,
         base_url: Optional[str] = None,
+        vllm_model_name: Optional[str] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            tokenizer=tokenizer,
+            tokenizer_name=tokenizer_name,
+            cache_config=cache_config,
+            api_key="EMPTY",
+            org_id=None,
+            base_url=base_url,
+            openai_model_name=vllm_model_name,
+            **kwargs,
+        )
+        self.tokenizer = tokenizer
+        self.tokenizer_name = tokenizer_name
+        self.vllm_model_name = vllm_model_name
+
+    def _get_model_for_request(self, request: Request) -> str:
+        # The `model` parameter for vLLM should be the whole model name including the creator organization,
+        # unlike OpenAI which only uses the model engine.
+        return self.vllm_model_name or request.model
+
+    def _to_raw_completion_request(self, request: Request) -> Dict[str, Any]:
+        raw_request = super()._to_raw_completion_request(request)
+        # This avoids the error: best_of must be 1 when using greedy sampling
+        if (
+            "temperature" in raw_request
+            and raw_request["temperature"] == 0.0
+            and "best_of" in raw_request
+            and raw_request["best_of"] > 1
+        ):
+            raw_request["best_of"] = 1
+        return raw_request
+
+
+class VLLMChatClient(OpenAIClient):
+    """Sends request to a vLLM server using the OpenAI-compatible API.
+
+    Only uses the Chat Completions API.
+
+    See: https://docs.vllm.ai/en/latest/getting_started/quickstart.html#openai-compatible-server"""
+
+    def __init__(
+        self,
+        tokenizer: Tokenizer,
+        tokenizer_name: str,
+        cache_config: CacheConfig,
+        base_url: Optional[str] = None,
+        vllm_model_name: Optional[str] = None,
         **kwargs,
     ):
         super().__init__(
@@ -32,15 +81,9 @@ class VLLMClient(OpenAILegacyCompletionsClient):
         )
         self.tokenizer = tokenizer
         self.tokenizer_name = tokenizer_name
+        self.vllm_model_name = vllm_model_name
 
     def _get_model_for_request(self, request: Request) -> str:
         # The `model` parameter for vLLM should be the whole model name including the creator organization,
         # unlike OpenAI which only uses the model engine.
-        return request.model
-
-    def _to_raw_completion_request(self, request: Request) -> Dict[str, Any]:
-        raw_request = super()._to_raw_completion_request(request)
-        # This avoids the error: best_of must be 1 when using greedy sampling
-        if "best_of" in raw_request and raw_request["best_of"] > 1:
-            raw_request["best_of"] = 1
-        return raw_request
+        return self.vllm_model_name or request.model

--- a/src/helm/clients/vllm_granite_thinking_client.py
+++ b/src/helm/clients/vllm_granite_thinking_client.py
@@ -26,11 +26,11 @@ class VLLMGraniteThinkingClient(VLLMChatClient):
         match = re.match(r"<think>(.*)</think>\s*<response>(.*)</response>", input, re.DOTALL)
         if match:
             return (match.group(1), match.group(2))
-        
+
         match = re.match(r"<think>(.*)</think>\s*<response>(.*)</response>", input, re.DOTALL)
         if match:
             return (match.group(1), match.group(2))
-        
+
         match = re.match(r"<think>(.*)</think>\s*", input, re.DOTALL)
         if match:
             return (match.group(1), "")
@@ -46,10 +46,11 @@ class VLLMGraniteThinkingClient(VLLMChatClient):
         modified_completions: List[GeneratedOutput] = []
         for completion in request_result.completions:
             thinking, modified_text = self._parse_thinking(completion.text)
-            modified_completions.append(replace(
-                completion.text,
-                text=modified_text,
-                thinking=Thinking(text=thinking),
-            ))
+            modified_completions.append(
+                replace(
+                    completion,
+                    text=modified_text,
+                    thinking=Thinking(text=thinking),
+                )
+            )
         return replace(request_result, completions=modified_completions)
-

--- a/src/helm/clients/vllm_granite_thinking_client.py
+++ b/src/helm/clients/vllm_granite_thinking_client.py
@@ -1,7 +1,9 @@
-from typing import Any, Dict
+from dataclasses import replace
+import re
+from typing import Any, Dict, List, Tuple
 
 from helm.clients.vllm_client import VLLMChatClient
-from helm.common.request import Request
+from helm.common.request import GeneratedOutput, Request, RequestResult, Thinking
 
 
 class VLLMGraniteThinkingClient(VLLMChatClient):
@@ -18,3 +20,36 @@ class VLLMGraniteThinkingClient(VLLMChatClient):
         raw_request = super()._make_chat_raw_request(request)
         raw_request["extra_body"] = {"chat_template_kwargs": {"thinking": True}}
         return raw_request
+
+    def _parse_thinking(self, input: str) -> Tuple[str, str]:
+        """Return a tuple of thinking text and output text."""
+        match = re.match(r"<think>(.*)</think>\s*<response>(.*)</response>", input, re.DOTALL)
+        if match:
+            return (match.group(1), match.group(2))
+        
+        match = re.match(r"<think>(.*)</think>\s*<response>(.*)</response>", input, re.DOTALL)
+        if match:
+            return (match.group(1), match.group(2))
+        
+        match = re.match(r"<think>(.*)</think>\s*", input, re.DOTALL)
+        if match:
+            return (match.group(1), "")
+
+        match = re.match(r"<think>(.*)", input, re.DOTALL)
+        if match:
+            return (match.group(1), "")
+
+        return (input, "")
+
+    def _make_chat_request(self, request: Request) -> RequestResult:
+        request_result = super()._make_chat_request(request)
+        modified_completions: List[GeneratedOutput] = []
+        for completion in request_result.completions:
+            thinking, modified_text = self._parse_thinking(completion.text)
+            modified_completions.append(replace(
+                completion.text,
+                text=modified_text,
+                thinking=Thinking(text=thinking),
+            ))
+        return replace(request_result, completions=modified_completions)
+

--- a/src/helm/clients/vllm_granite_thinking_client.py
+++ b/src/helm/clients/vllm_granite_thinking_client.py
@@ -16,5 +16,5 @@ class VLLMGraniteThinkingClient(VLLMChatClient):
 
     def _make_chat_raw_request(self, request: Request) -> Dict[str, Any]:
         raw_request = super()._make_chat_raw_request(request)
-        raw_request["chat_template_kwargs"] = {"chat_template_kwargs": {"thinking": True}}
+        raw_request["extra_body"] = {"chat_template_kwargs": {"thinking": True}}
         return raw_request

--- a/src/helm/clients/vllm_granite_thinking_client.py
+++ b/src/helm/clients/vllm_granite_thinking_client.py
@@ -1,10 +1,10 @@
 from typing import Any, Dict
 
-from helm.clients.vllm_client import VLLMClient
+from helm.clients.vllm_client import VLLMChatClient
 from helm.common.request import Request
 
 
-class VLLMGraniteThinkingClient(VLLMClient):
+class VLLMGraniteThinkingClient(VLLMChatClient):
     """Sends request to a Granite model on vLLM server with thinking enabled.
 
     From vLLM documentation at

--- a/src/helm/clients/vllm_granite_thinking_client.py
+++ b/src/helm/clients/vllm_granite_thinking_client.py
@@ -27,7 +27,7 @@ class VLLMGraniteThinkingClient(VLLMChatClient):
         if match:
             return (match.group(1), match.group(2))
 
-        match = re.match(r"<think>(.*)</think>\s*<response>(.*)</response>", input, re.DOTALL)
+        match = re.match(r"<think>(.*)</think>\s*<response>(.*)", input, re.DOTALL)
         if match:
             return (match.group(1), match.group(2))
 


### PR DESCRIPTION
- Add `VLLMChatClient` for chat models on VLLM
- Change `VLLMGraniteThinkingClient` to inherit from `VLLMChatClient`
- Simplify logic for overriding the model name in vLLM clients