### PR TITLE
Add doctests and enable them

### DIFF
--- a/install-dev.sh
+++ b/install-dev.sh
@@ -13,4 +13,4 @@ fi
 # Install all pinned dependencies
 pip install -r requirements.txt
 # Install HELM in edit mode
-pip install -e .[all]
+pip install -e .[all,dev]

--- a/requirements.txt
+++ b/requirements.txt
@@ -362,6 +362,7 @@ wrapt==1.17.2
 writer-sdk==2.2.0
 writerai==4.0.1
 wsproto==1.2.0
+xdoctest==1.2.0
 xlrd==2.0.2
 xxhash==3.5.0
 yarl==1.20.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -437,6 +437,7 @@ addopts =
     # - https://docs.pytest.org/en/latest/how-to/mark.html#mark
     # - https://docs.pytest.org/en/latest/example/markers.html#mark-examples
     -m 'not models and not scenarios'
+    --doctest-modules
 markers =
     # Marker for model tests that make real model requests
     models

--- a/setup.cfg
+++ b/setup.cfg
@@ -439,6 +439,7 @@ addopts =
     # - https://docs.pytest.org/en/latest/example/markers.html#mark-examples
     -m 'not models and not scenarios'
     --xdoctest-modules
+    --xdoctest-style=google
 markers =
     # Marker for model tests that make real model requests
     models

--- a/setup.cfg
+++ b/setup.cfg
@@ -372,6 +372,7 @@ all =
 # Do not include in all
 dev =
     pytest~=7.2.0
+    xdoctest~=1.2.0
     pre-commit~=2.20.0
     # Errors produced by type checkers and linters are very version-specific
     # so they are pinned to an exact version.
@@ -437,7 +438,7 @@ addopts =
     # - https://docs.pytest.org/en/latest/how-to/mark.html#mark
     # - https://docs.pytest.org/en/latest/example/markers.html#mark-examples
     -m 'not models and not scenarios'
-    --doctest-modules
+    --xdoctest-modules
 markers =
     # Marker for model tests that make real model requests
     models

--- a/src/helm/benchmark/scenarios/math_scenario.py
+++ b/src/helm/benchmark/scenarios/math_scenario.py
@@ -18,13 +18,14 @@ from helm.benchmark.scenarios.scenario import (
 
 
 def remove_boxed(string: str) -> Optional[str]:
-    """Source: https://github.com/hendrycks/math
+    r"""Source: https://github.com/hendrycks/math
 
-    Extract the text within a \\boxed{...} environment.
+    Extract the text within a \boxed{...} environment.
 
     Example:
-    >>> remove_boxed(\\boxed{\\frac{2}{3}})
-    \\frac{2}{3}
+        >>> from helm.benchmark.scenarios.math_scenario import *  # NOQA
+        >>> remove_boxed(r'\boxed{\frac{2}{3}}')
+        \frac{2}{3}
     """
     left = "\\boxed{"
     try:
@@ -68,17 +69,17 @@ def last_boxed_only_string(string: str) -> Optional[str]:
 
 
 def _fix_fracs(string: str) -> str:
-    """Source: https://github.com/hendrycks/math
+    r"""Source: https://github.com/hendrycks/math
 
     Reformat fractions.
 
     Examples:
-    >>> _fix_fracs("\\frac1b")
-    \frac{1}{b}
-    >>> _fix_fracs("\\frac12")
-    \frac{1}{2}
-    >>> _fix_fracs("\\frac1{72}")
-    \frac{1}{72}
+        >>> _fix_fracs(r"\frac1b")
+        \frac{1}{b}
+        >>> _fix_fracs(r"\frac12")
+        \frac{1}{2}
+        >>> _fix_fracs(r"\frac1{72}")
+        \frac{1}{72}
     """
     substrs = string.split("\\frac")
     new_str = substrs[0]
@@ -112,13 +113,13 @@ def _fix_fracs(string: str) -> str:
 
 
 def _fix_a_slash_b(string: str) -> str:
-    """Source: https://github.com/hendrycks/math
+    r"""Source: https://github.com/hendrycks/math
 
     Reformat fractions formatted as a/b to \\frac{a}{b}.
 
     Example:
-    >>> _fix_a_slash_b("2/3")
-    \frac{2}{3}
+        >>> _fix_a_slash_b(r"2/3")
+        \frac{2}{3}
     """
     if len(string.split("/")) != 2:
         return string
@@ -149,13 +150,13 @@ def _remove_right_units(string: str) -> str:
 
 
 def _fix_sqrt(string: str) -> str:
-    """Source: https://github.com/hendrycks/math
+    r"""Source: https://github.com/hendrycks/math
 
     Reformat square roots.
 
     Example:
-    >>> _fix_sqrt("\\sqrt3")
-    \sqrt{3}
+        >>> _fix_sqrt("\\sqrt3")
+        \sqrt{3}
     """
     if "\\sqrt" not in string:
         return string
@@ -210,7 +211,7 @@ def _strip_string(string: str) -> str:
 
     # remove percentage
     string = string.replace("\\%", "")
-    string = string.replace("\%", "")
+    string = string.replace(r"\%", "")
 
     # " 0." equivalent to " ." and "{0." equivalent to "{." Alternatively, add "0" if "." is the start of the string
     string = string.replace(" .", " 0.")
@@ -391,13 +392,13 @@ class MATHScenario(Scenario):
         for split, split_name in zip([TRAIN_SPLIT, TEST_SPLIT], ["train", "test"]):
             if split == TRAIN_SPLIT and self.use_official_examples:
                 train_instances = [
-                    ("What is $\left(\\frac{7}{8}\\right)^3 \cdot \left(\\frac{7}{8}\\right)^{-3}$?", "1"),
+                    ("What is $\\left(\\frac{7}{8}\\right)^3 \\cdot \\left(\\frac{7}{8}\\right)^{-3}$?", "1"),
                     (
                         "In how many ways can 4 books be selected from a shelf of 6 books"
                         + " if the order in which the books are selected does not matter?",
                         "15",
                     ),
-                    ("Find the distance between the points $(2,1,-4)$ and $(5,8,-3).$", "\sqrt{59}"),
+                    ("Find the distance between the points $(2,1,-4)$ and $(5,8,-3).$", "\\sqrt{59}"),
                     (
                         "The faces of an octahedral die are labeled with digits $1$ through $8$."
                         + " What is the probability, expressed as a common fraction,"

--- a/src/helm/benchmark/scenarios/math_scenario.py
+++ b/src/helm/benchmark/scenarios/math_scenario.py
@@ -25,7 +25,7 @@ def remove_boxed(string: str) -> Optional[str]:
     Example:
         >>> from helm.benchmark.scenarios.math_scenario import *  # NOQA
         >>> remove_boxed(r'\boxed{\frac{2}{3}}')
-        \frac{2}{3}
+        '\\frac{2}{3}'
     """
     left = "\\boxed{"
     try:
@@ -75,11 +75,11 @@ def _fix_fracs(string: str) -> str:
 
     Examples:
         >>> _fix_fracs(r"\frac1b")
-        \frac{1}{b}
+        '\\frac{1}{b}'
         >>> _fix_fracs(r"\frac12")
-        \frac{1}{2}
+        '\\frac{1}{2}'
         >>> _fix_fracs(r"\frac1{72}")
-        \frac{1}{72}
+        '\\frac{1}{72}'
     """
     substrs = string.split("\\frac")
     new_str = substrs[0]
@@ -119,7 +119,7 @@ def _fix_a_slash_b(string: str) -> str:
 
     Example:
         >>> _fix_a_slash_b(r"2/3")
-        \frac{2}{3}
+        '\\frac{2}{3}'
     """
     if len(string.split("/")) != 2:
         return string
@@ -156,7 +156,7 @@ def _fix_sqrt(string: str) -> str:
 
     Example:
         >>> _fix_sqrt("\\sqrt3")
-        \sqrt{3}
+        '\\sqrt{3}'
     """
     if "\\sqrt" not in string:
         return string

--- a/src/helm/clients/audio_language/qwen_omni/configuration_qwen2_5_omni.py
+++ b/src/helm/clients/audio_language/qwen_omni/configuration_qwen2_5_omni.py
@@ -62,19 +62,15 @@ class Qwen2_5OmniVisionEncoderConfig(PretrainedConfig):
             The size used for patches along the temporal dimension.
 
     Example:
-
-    ```python
-    >>> from transformers import Qwen2_5OmniVisionEncoderConfig, Qwen2_5OmniVisionEncoder
-
-    >>> # Initializing a Qwen2_5OmniVisionEncoderConfig
-    >>> configuration = Qwen2_5OmniVisionEncoderConfig()
-
-    >>> # Initializing a Qwen2_5OmniVisionEncoder (with random weights)
-    >>> model = Qwen2_5OmniVisionEncoder(configuration)
-
-    >>> # Accessing the model configuration
-    >>> configuration = model.config
-    ```"""
+        >>> # xdoctest: +SKIP
+        >>> from transformers import Qwen2_5OmniVisionEncoderConfig, Qwen2_5OmniVisionEncoder
+        >>> # Initializing a Qwen2_5OmniVisionEncoderConfig
+        >>> configuration = Qwen2_5OmniVisionEncoderConfig()
+        >>> # Initializing a Qwen2_5OmniVisionEncoder (with random weights)
+        >>> model = Qwen2_5OmniVisionEncoder(configuration)
+        >>> # Accessing the model configuration
+        >>> configuration = model.config
+    """
 
     model_type = "qwen2_5_omni_vision_encoder"
     base_config_key = "vision_config"

--- a/src/helm/common/object_spec.py
+++ b/src/helm/common/object_spec.py
@@ -55,14 +55,23 @@ def inject_object_spec_args(
     This is loosely based on instance (constant) bindings and provider bindings in Guice dependency injection.
 
     Example:
-
-    class MyClass:
-        def __init__(a: int, b: int, c: int, d: int = 0):
-            pass
-
-    old_object_spec = ObjectSpec(class_name="MyClass", args={"a": 11})
-    new_object_spec = inject_object_spec_args(old_object_spec, {"b": 12}, {"c": lambda: 13})
-    # new_object_spec is now ObjectSpec(class_name="MyClass", args={"a": 11, "b": 12, "c": 13})
+        >>> from helm.common.object_spec import *  # NOQA
+        >>> import sys, types
+        >>> # Given a custom class with hashable arguments
+        >>> class MyClass:
+        ...     def __init__(a: int, b: int, c: int, d: int = 0):
+        ...         pass
+        >>> #
+        >>> # <boilerplate>: make a dummy module for MyClass to make this doctest exectuable
+        >>> sys.modules["my_module"] = type("MyModule", (types.ModuleType,), {"MyClass": MyClass})("my_module")
+        >>> # </boilerplate>
+        >>> #
+        >>> # Define new style and old style object specs
+        >>> old_object_spec = ObjectSpec(class_name="my_module.MyClass", args={"a": 11})
+        >>> new_object_spec = inject_object_spec_args(old_object_spec, {"b": 12}, {"c": lambda: 13})
+        >>> # new_object_spec is now
+        >>> print(new_object_spec)
+        ObjectSpec(class_name='my_module.MyClass', args={'a': 11, 'b': 12, 'c': 13})
     """
     cls = get_class_by_name(spec.class_name)
     init_signature = inspect.signature(cls.__init__)
@@ -93,6 +102,12 @@ def parse_object_spec(description: str) -> ObjectSpec:
         <class_name>:<key>=<value>,<key>=<value>
     Usually, the description is something that's succinct and can be typed on the command-line.
     Here, value defaults to string.
+
+    Example:
+        >>> from helm.common.object_spec import *  # NOQA
+        >>> description = 'mscoco:model=huggingface_stable-diffusion-v1-4'
+        >>> parse_object_spec(description)
+        ObjectSpec(class_name='mscoco', args={'model': 'huggingface_stable-diffusion-v1-4'})
     """
 
     def parse_arg(arg: str) -> Tuple[str, Any]:


### PR DESCRIPTION
I'm a big fan of doctests. Not only do they provide great documentation examples, they give developers a quick and easy way to get an entrypoint into a function, and you can run them to enhance your test suite and ensure examples continue to work.

In this PR I noticed something that was almost a doctest, and I turned it into a fully fledged one. It adds a little bit of boilerplate, but I think the ability to copy / paste the snippet into IPython and play with it is invaluable.

I also added a doctest to `parse_object_spec`, that I wrote when I was playing with it to understand it. 

In addition to adding these doctests here I added `--doctest-modules` to the default pytest config in `setup.cfg` (which should probably be ported to fully use `pyproject.toml`, but that will be a different PR). This will enable these tests on the CI.

As I continue to use / learn about this repo I'm likely to add more doctests as I debug / understand. This PR ensures that they will be tested if I push them upstream.

For now I'm using the stdlib doctest, but in the future we could use [xdoctest](https://github.com/Erotemic/xdoctest) if we want a more flexible doctest syntax. 