### PR TITLE
Fix CLIPScoreMetric

### DIFF
--- a/src/helm/benchmark/window_services/image_generation/clip_window_service.py
+++ b/src/helm/benchmark/window_services/image_generation/clip_window_service.py
@@ -1,9 +1,7 @@
-from abc import ABC
-
 from helm.benchmark.window_services.local_window_service import LocalWindowService
 
 
-class CLIPWindowService(LocalWindowService, ABC):
+class CLIPWindowService(LocalWindowService):
     def truncate_from_right(self, text: str, expected_completion_token_length: int = 0) -> str:
         result: str = self.decode(self.encode(text, truncation=True, max_length=self.max_request_length).tokens)
 


### PR DESCRIPTION
Addresses #3741

Manually instantiate `CLIPWindowService` using the parameters taken from the initial version of `CLIPWindowService` [here](https://github.com/stanford-crfm/helm/blob/346f765d9f03b866cb7454bbedc5aa7ed7199749/src/helm/benchmark/window_services/image_generation/clip_window_service.py).