### PR TITLE
Fix invalid escape sequences in strings

### DIFF
--- a/src/helm/benchmark/annotation/air_bench_annotator.py
+++ b/src/helm/benchmark/annotation/air_bench_annotator.py
@@ -37,7 +37,7 @@ class AIRBench2024Annotator(Annotator):
         )
         self._category_id_to_judge_prompt = {row["cate-idx"]: row["judge_prompt"] for row in dataset}
         # Regex pattern is lenient to allow for typos e.g. extra whitespace
-        self._pattern = re.compile("##\s*short_reasoning\s*:(.*)##\s*the_score\s*:(.*)", re.DOTALL)
+        self._pattern = re.compile(r"##\s*short_reasoning\s*:(.*)##\s*the_score\s*:(.*)", re.DOTALL)
         self._model = model or self._DEFAULT_MODEL
         self._model_deployment = model_deployment or self._DEFAULT_MODEL_DEPLOYMENT
 

--- a/src/helm/benchmark/annotation/live_qa_annotator.py
+++ b/src/helm/benchmark/annotation/live_qa_annotator.py
@@ -50,7 +50,7 @@ class LiveQAAnnotator(Annotator):
         cache_dir = os.path.join(file_storage_path, "data")
         ensure_directory_exists(cache_dir)
         # Regex pattern is lenient to allow for typos e.g. extra whitespace
-        self._pattern = re.compile("##\s*short_reasoning\s*:(.*)##\s*the_score\s*:(.*)", re.DOTALL)
+        self._pattern = re.compile(r"##\s*short_reasoning\s*:(.*)##\s*the_score\s*:(.*)", re.DOTALL)
 
     def annotate(self, request_state: RequestState) -> Any:
         assert request_state.result

--- a/src/helm/benchmark/metrics/comet_metric.py
+++ b/src/helm/benchmark/metrics/comet_metric.py
@@ -16,7 +16,7 @@ from helm.common.request import RequestResult
 
 
 class CometMetric(Metric):
-    """COMET machine translation metric using a regression model.
+    r"""COMET machine translation metric using a regression model.
     The model takes a triplet of source sentence, translation, and reference
     and computes a score in the range [0, 1] reflecting the quality of the predicted
     translation.

--- a/src/helm/benchmark/metrics/decodingtrust_stereotype_bias_metrics.py
+++ b/src/helm/benchmark/metrics/decodingtrust_stereotype_bias_metrics.py
@@ -24,7 +24,7 @@ AGREE_PHRASES = [
     "fully agree",
     "could not agree more",
     "i 100% agree",
-    "i 100\% agree",
+    "i 100\\% agree",
     "i actually agree",
     "couldn't possibly agree more",
     "couldn't possibly agree more",

--- a/src/helm/benchmark/scenarios/audio_language/casual_conversations2_scenario.py
+++ b/src/helm/benchmark/scenarios/audio_language/casual_conversations2_scenario.py
@@ -19,7 +19,7 @@ from helm.common.audio_utils import extract_audio
 
 
 class CasualConversations2Scenario(Scenario):
-    """
+    r"""
     Casual Conversation v2 (Porgali et al, 2023) is composed of over 5,567 participants (26,467 videos).
     The videos feature paid individuals who agreed to participate in the project and explicitly provided
     Age, Gender, Language/Dialect, Geo-location, Disability, Physical adornments, Physical attributes labels

--- a/src/helm/benchmark/scenarios/audio_language/mustard_scenario.py
+++ b/src/helm/benchmark/scenarios/audio_language/mustard_scenario.py
@@ -19,7 +19,7 @@ from helm.common.general import ensure_directory_exists, ensure_file_downloaded
 
 
 class MUStARDScenario(Scenario):
-    """
+    r"""
     MUStARD: Multimodal Sarcasm Detection Dataset
 
     A multimodal video corpus for research in automated sarcasm discovery. The dataset is compiled from popular

--- a/src/helm/benchmark/scenarios/cleva_scenario.py
+++ b/src/helm/benchmark/scenarios/cleva_scenario.py
@@ -1549,7 +1549,7 @@ class CLEVALanguageModelingScenario(CLEVAScenario):
 
 
 class CLEVACodeSynthesisScenario(CLEVAScenario):
-    """
+    r"""
     The code synthesis task of CLEVA benchmark.
 
     An example is:

--- a/src/helm/benchmark/scenarios/melt_scenarios.py
+++ b/src/helm/benchmark/scenarios/melt_scenarios.py
@@ -439,13 +439,13 @@ class MELTMATHScenario(Scenario):
         for split, split_name in zip([TRAIN_SPLIT, TEST_SPLIT], ["train", "test"]):
             if split == TRAIN_SPLIT and self.use_official_examples:
                 train_instances = [
-                    ("Kết quả của $\left(\\frac{7}{8}\\right)^3 \cdot \left(\\frac{7}{8}\\right)^{-3}$ là gì?", "1"),
+                    ("Kết quả của $\\left(\\frac{7}{8}\\right)^3 \\cdot \\left(\\frac{7}{8}\\right)^{-3}$ là gì?", "1"),
                     (
                         "Có bao nhiêu cách chọn 4 quyển sách từ một kệ sách có 6 quyển,"
                         + " nếu thứ tự các cuốn sách được chọn không quan trọng?",
                         "15",
                     ),
-                    ("Tìm khoảng cách giữa các điểm $(2,1,-4)$ và $(5,8,-3).$", "\sqrt{59}"),
+                    ("Tìm khoảng cách giữa các điểm $(2,1,-4)$ và $(5,8,-3).$", "\\sqrt{59}"),
                     (
                         "Các mặt của khối xúc xắc bát diện được dán nhãn bằng các số từ $1$ đến $8$."
                         + " Xác suất tung một cặp xúc xắc bát diện để được tổng số bằng $15$ là bao nhiêu?"

--- a/src/helm/benchmark/scenarios/mimic_bhc_scenario.py
+++ b/src/helm/benchmark/scenarios/mimic_bhc_scenario.py
@@ -14,7 +14,7 @@ from helm.benchmark.scenarios.scenario import (
 
 
 class MIMICBHCScenario(Scenario):
-    """
+    r"""
     MIMIC-IV-BHC presents a curated collection of preprocessed discharge notes with labeled brief hospital
     course (BHC) summaries. This dataset is derived from MIMIC-IV (https://doi.org/10.1093/jamia/ocae312).
 

--- a/src/helm/benchmark/scenarios/seahelm_scenario.py
+++ b/src/helm/benchmark/scenarios/seahelm_scenario.py
@@ -1750,7 +1750,7 @@ class LINDSEAPragmaticsPresuppositionsScenario(Scenario):
                 text_noun = self.prompt_components["text_noun"]
                 instruction = self.prompt_components["single_instruction"]
 
-                passage = "{question}\{text_noun}: {text}\n{instruction}".format(
+                passage = "{question}\\{text_noun}: {text}\n{instruction}".format(
                     question=question.format(row["question_translated"]),
                     text_noun=text_noun,
                     text=row["text"],
@@ -1898,7 +1898,7 @@ class LINDSEAPragmaticsScalarImplicaturesScenario(Scenario):
                 text_noun = self.prompt_components["text_noun"]
                 instruction = self.prompt_components["single_instruction"]
 
-                passage = "{question}\{text_noun}: {text}\n{instruction}".format(
+                passage = "{question}\\{text_noun}: {text}\n{instruction}".format(
                     question=question.format(row["question_translated"]),
                     text_noun=text_noun,
                     text=row["text"],

--- a/src/helm/benchmark/slurm_jobs.py
+++ b/src/helm/benchmark/slurm_jobs.py
@@ -80,7 +80,7 @@ def get_slurm_job_state(job_id: int) -> str:
     except subprocess.CalledProcessError as e:
         # Default CalledProcessError message doesn't have output, so re-raise here to include the output.
         raise Exception(f"{str(e)} output: {e.output}")
-    search_result = re.search("JobState=(\w+)", scontrol_output.decode())
+    search_result = re.search(r"JobState=(\w+)", scontrol_output.decode())
     if not search_result:
         raise Exception(f"Could not extract JobState from scontrol: {scontrol_output.decode()}")
     return search_result.group(1)

--- a/src/helm/proxy/cli.py
+++ b/src/helm/proxy/cli.py
@@ -123,7 +123,7 @@ def do_create_update_command(service: RemoteService, auth: Authentication, args)
 
     # Update quotas
     for quota_str in args.quotas:
-        m = re.match(f"(\w+)\.(\w+)=(\d+|{UNLIMITED_QUOTA})", quota_str)
+        m = re.match(fr"(\w+)\.(\w+)=(\d+|{UNLIMITED_QUOTA})", quota_str)
         if not m:
             raise Exception(
                 f"Invalid format: {quota_str}, expect <model_group>.<granularity>=<quota> "

--- a/src/helm/proxy/cli.py
+++ b/src/helm/proxy/cli.py
@@ -123,7 +123,7 @@ def do_create_update_command(service: RemoteService, auth: Authentication, args)
 
     # Update quotas
     for quota_str in args.quotas:
-        m = re.match(fr"(\w+)\.(\w+)=(\d+|{UNLIMITED_QUOTA})", quota_str)
+        m = re.match(rf"(\w+)\.(\w+)=(\d+|{UNLIMITED_QUOTA})", quota_str)
         if not m:
             raise Exception(
                 f"Invalid format: {quota_str}, expect <model_group>.<granularity>=<quota> "


### PR DESCRIPTION
This should be a fairly simple PR where I fix invalid escape sequence warnings.

When I was working on doctests I noticed a lot of warning messages about incorrectly escaped strings. This was usually due to a bare backslash being used in a plain string, which currently is interpreted as a plain backslash, but that can't be guaranteed in future versions of Python, so many linters will flag it as a warning.

When possible, I just added the "r" prefix to make it a raw string. There were some cases where this didn't make sense (e.g. the newline `\n` or proper backslash `\\` character was used), so those cases I escaped the naked backslashes.

This does not fix the errors in math_scenario.py as I fixed those in [the doctest PR](https://github.com/stanford-crfm/helm/pull/3745). 