### PR TITLE
Add short_description to RunGroup in schema

### DIFF
--- a/helm-frontend/src/routes/Scenarios.tsx
+++ b/helm-frontend/src/routes/Scenarios.tsx
@@ -118,7 +118,7 @@ export default function Scenarios() {
                 <td>{runGroup.taxonomy?.when || ""}</td>
                 <td>{runGroup.taxonomy?.language || ""}</td>
                 <td>
-                  <MarkdownValue value={runGroup.description} />
+                  <MarkdownValue value={runGroup.short_description || runGroup.description} />
                 </td>
                 <td>
                   <MarkdownValue value={getMetricForRunGroup(runGroup)} />

--- a/helm-frontend/src/routes/Scenarios.tsx
+++ b/helm-frontend/src/routes/Scenarios.tsx
@@ -118,7 +118,9 @@ export default function Scenarios() {
                 <td>{runGroup.taxonomy?.when || ""}</td>
                 <td>{runGroup.taxonomy?.language || ""}</td>
                 <td>
-                  <MarkdownValue value={runGroup.short_description || runGroup.description} />
+                  <MarkdownValue
+                    value={runGroup.short_description || runGroup.description}
+                  />
                 </td>
                 <td>
                   <MarkdownValue value={getMetricForRunGroup(runGroup)} />

--- a/helm-frontend/src/types/RunGroup.ts
+++ b/helm-frontend/src/types/RunGroup.ts
@@ -19,4 +19,5 @@ export default interface RunGroup {
   category?: string;
   subgroups?: string[];
   visibility?: string;
+  short_description?: string;
 }

--- a/src/helm/benchmark/presentation/schema.py
+++ b/src/helm/benchmark/presentation/schema.py
@@ -205,7 +205,9 @@ class RunGroup(Field):
     # TODO: remove when we don't want helm-summarize to support runs before November 2023 anymore.
     adapter_keys_shown: List[str] = field(default_factory=lambda: ["model_deployment", "model"])
 
-    # Optional short description of the run group. If unset, the description field will be used instead.
+    # Optional short description of the run group.
+    # This description is used in some space-constrained places in frontend tables.
+    # If unset, the description field will be used instead.
     short_description: Optional[str] = None
 
 

--- a/src/helm/benchmark/presentation/schema.py
+++ b/src/helm/benchmark/presentation/schema.py
@@ -205,6 +205,9 @@ class RunGroup(Field):
     # TODO: remove when we don't want helm-summarize to support runs before November 2023 anymore.
     adapter_keys_shown: List[str] = field(default_factory=lambda: ["model_deployment", "model"])
 
+    # Optional short description of the run group. If unset, the description field will be used instead.
+    short_description: Optional[str] = None
+
 
 @dataclass
 class Schema:

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -838,7 +838,8 @@ class Summarizer:
                 }
 
                 header_name = header_field.get_short_display_name()
-                description = (run_group.description + "\n\n" if run_group.description is not None else "") + (
+                run_group_short_description = run_group.short_description or run_group.description or ""
+                description = (run_group_short_description + "\n\n" if run_group_short_description else "") + (
                     (header_field.display_name if header_field.display_name else header_field.name)
                     + ": "
                     + (header_field.description if header_field.description is not None else "")


### PR DESCRIPTION
`short_description` is an optional short description of the run group. This description is used in some space-constrained places in frontend tables. If unset, the description field will be used instead.

This supports use cases in which the regular `description` can be very long.

Addresses #3757