### PR TITLE
Clarify documentation for private benchmarks access

### DIFF
--- a/docs/medhelm.md
+++ b/docs/medhelm.md
@@ -95,12 +95,14 @@ These benchmarks are publicly available but require special permissions or crede
 
 ### 🔒 Private Benchmarks
 
-These benchmarks are based on proprietary or restricted datasets that are only available to specific organizations.
+These benchmarks are based on proprietary or restricted datasets that are only available to the respective organizations.
+
+For evaluating models against private benchmarks, either the model weights must be shared with Stanford, or the model/system has to be made available via an API that has a BAA with Stanford for use with data containing PHI.
 
 - **Access requirements**: Organization-specific authorization
 - **Example use case**: Internal clinical datasets available only to the originating institution
 - **Run entries file**: `run_entries_medhelm_private_{organization}.conf` (_e.g., `run_entries_medhelm_private_stanford.conf`_)
-- **Reproducibility**: Only authorized users within the organization can reproduce results from these benchmarks.
+- **Reproducibility**: Only authorized users within the organization (data owners) can reproduce results from these benchmarks.
 
 ---
 


### PR DESCRIPTION
Upon first reading the docs, I understood as if private benchmarks could be shared with selected organizations, as if there was a process for getting access to the actual private data. Upon clarifying with Nigam and Tommy Wang, I suggest we modify the docs to make it clear that evaluation against private benchmarks is only possible by either sharing the model weights with stanford or wrapping models/systems with an API, so that the data owners can run the benchmarks themselves.

I would also suggest sharing notes with API requirements, model format and anything else that may help people through this process.