### PR TITLE
[DRAFT] HEIM fixes.

### DIFF
--- a/docs/heim.md
+++ b/docs/heim.md
@@ -66,3 +66,7 @@ helm-run --run-entries mscoco:model=huggingface/stable-diffusion-v1-4 --suite my
 ## Reproducing the Leaderboard
 
 To reproduce the [entire HEIM leaderboard](https://crfm.stanford.edu/helm/heim/latest/), refer to the instructions for HEIM on the [Reproducing Leaderboards](reproducing_leaderboards.md) documentation.
+
+### Note:
+
+The full HEIM leaderboard is not currently reproducible with these instructions. We are working to resolve this. In the meantime we have disabled the NSFWMetric to allow for the rest of the evaluation suite to run.

--- a/requirements.txt
+++ b/requirements.txt
@@ -205,8 +205,8 @@ onnxruntime==1.22.1 ; python_full_version >= '3.10'
 open-clip-torch==2.32.0
 openai==1.97.0
 opencc==1.1.9
-opencv-python==4.8.1.78
-opencv-python-headless==4.11.0.86
+opencv-python==4.8.1.78; python_version >= "3.10"
+opencv-python-headless==4.11.0.86; python_version < "3.10"
 openpyxl==3.1.5
 opt-einsum==3.4.0
 optax==0.2.4 ; python_full_version < '3.10'

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ dacite==1.9.2
 data==0.4
 datasets==3.6.0
 decorator==5.2.1
-diffusers==0.24.0
+diffusers==0.34.0
 dill==0.3.8
 distlib==0.4.0
 distro==1.9.0
@@ -73,7 +73,7 @@ fastavro==1.11.1
 filelock==3.18.0
 flake8==5.0.4
 flatbuffers==25.2.10
-flax==0.6.11
+flax==0.10.7
 fonttools==4.59.0
 frozenlist==1.7.0
 fsspec==2025.3.0
@@ -127,9 +127,9 @@ importlib-metadata==8.7.0
 importlib-resources==5.13.0
 iniconfig==2.1.0
 jax==0.4.30 ; python_full_version < '3.10'
-jax==0.4.38 ; python_full_version >= '3.10'
+jax==0.6.2 ; python_full_version >= '3.10'
 jaxlib==0.4.30 ; python_full_version < '3.10'
-jaxlib==0.4.38 ; python_full_version >= '3.10'
+jaxlib==0.6.2 ; python_full_version >= '3.10'
 jieba==0.42.1
 jinja2==3.1.6
 jiter==0.10.0
@@ -166,7 +166,7 @@ matplotlib==3.10.3 ; python_full_version >= '3.10'
 mccabe==0.7.0
 mdurl==0.1.2
 mistralai==1.5.2
-ml-dtypes==0.4.1
+ml-dtypes==0.5.1
 mpmath==1.3.0
 msgpack==1.1.1
 multidict==6.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -73,7 +73,8 @@ fastavro==1.11.1
 filelock==3.18.0
 flake8==5.0.4
 flatbuffers==25.2.10
-flax==0.10.7
+flax==0.8.5; python_full_version < "3.10"
+flax==0.10.7; python_full_version >= "3.10"
 fonttools==4.59.0
 frozenlist==1.7.0
 fsspec==2025.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -253,8 +253,10 @@ heim =
     # HEIM models
     diffusers~=0.34.0
     icetk~=0.0.4
-    jax~=0.6.2
-    jaxlib~=0.6.2
+    jax~=0.6.2; python_version >= "3.10"
+    jax~=0.4.30; python_version < "3.10"
+    jaxlib~=0.6.2; python_version >= "3.10"
+    jaxlib~=0.4.30; python_version < "3.10"
     crfm-helm[openai]
 
     # For model, kakaobrain/mindall-e
@@ -263,7 +265,8 @@ heim =
     pytorch-lightning~=2.0
 
     # For model, craiyon/dalle-mini and craiyon/dalle-mega
-    flax~=0.10.7
+    flax~=0.10.7; python_version >= "3.10"
+    flax~=0.8.5; python_version < "3.10"
     ftfy~=6.1
     Unidecode~=1.3
     wandb~=0.16

--- a/setup.cfg
+++ b/setup.cfg
@@ -242,7 +242,8 @@ image2struct =
     html2text~=2024.2.26
 
     # Metrics
-    opencv-python>=4.7.0.68,<4.8.2.0
+    opencv-python>=4.7.0.68,<4.8.2.0; python_version >= "3.10"
+    opencv-python-headless>=4.7.0.68,<=4.11.0.86; python_version < "3.10"
     lpips~=0.1.4
     imagehash~=4.3 # for caching
 
@@ -281,7 +282,8 @@ heim =
     lpips~=0.1.4
     multilingual-clip~=1.0
     NudeNet~=2.0
-    opencv-python>=4.7.0.68,<4.8.2.0
+    opencv-python>=4.7.0.68,<4.8.2.0; python_version >= "3.10"
+    opencv-python-headless>=4.7.0.68,<=4.11.0.86; python_version < "3.10"
     pytorch-fid~=0.3.0
     tensorflow~=2.11
     timm~=0.6.12

--- a/setup.cfg
+++ b/setup.cfg
@@ -251,10 +251,10 @@ heim =
     gdown~=5.1
 
     # HEIM models
-    diffusers~=0.24.0
+    diffusers~=0.34.0
     icetk~=0.0.4
-    jax~=0.4.13
-    jaxlib~=0.4.13
+    jax~=0.6.2
+    jaxlib~=0.6.2
     crfm-helm[openai]
 
     # For model, kakaobrain/mindall-e
@@ -263,7 +263,7 @@ heim =
     pytorch-lightning~=2.0
 
     # For model, craiyon/dalle-mini and craiyon/dalle-mega
-    flax~=0.6.11
+    flax~=0.10.7
     ftfy~=6.1
     Unidecode~=1.3
     wandb~=0.16

--- a/src/helm/benchmark/metrics/image_generation/fractal_dimension/fractal_dimension_util.py
+++ b/src/helm/benchmark/metrics/image_generation/fractal_dimension/fractal_dimension_util.py
@@ -58,6 +58,6 @@ def compute_fractal_dimension(image_path: str) -> float:
     except ModuleNotFoundError as e:
         handle_module_not_found_error(e, ["heim"])
 
-    image = cv2.imread(image_path, 0) / 255.0  # type: ignore
+    image: np.ndarray = cv2.imread(image_path, 0) / 255.0  # type: ignore
     assert image.min() >= 0 and image.max() <= 1
     return fractal_dimension(image)

--- a/src/helm/benchmark/run_specs/heim_run_specs.py
+++ b/src/helm/benchmark/run_specs/heim_run_specs.py
@@ -60,7 +60,10 @@ def get_core_heim_metric_specs() -> List[MetricSpec]:
             class_name="helm.benchmark.metrics.image_generation.fractal_dimension_metric.FractalDimensionMetric",
             args={},
         ),
-        MetricSpec(class_name="helm.benchmark.metrics.image_generation.nsfw_metrics.NSFWMetric", args={}),
+
+        # Disabled due to keras issue.
+        # See: https://github.com/stanford-crfm/helm/issues/3741#issuecomment-3109478877
+        # MetricSpec(class_name="helm.benchmark.metrics.image_generation.nsfw_metrics.NSFWMetric", args={}),
         MetricSpec(class_name="helm.benchmark.metrics.image_generation.nudity_metrics.NudityMetric", args={}),
         MetricSpec(class_name="helm.benchmark.metrics.image_generation.watermark_metrics.WatermarkMetric", args={}),
     ] + get_basic_metric_specs(names=[])

--- a/src/helm/benchmark/run_specs/heim_run_specs.py
+++ b/src/helm/benchmark/run_specs/heim_run_specs.py
@@ -60,7 +60,6 @@ def get_core_heim_metric_specs() -> List[MetricSpec]:
             class_name="helm.benchmark.metrics.image_generation.fractal_dimension_metric.FractalDimensionMetric",
             args={},
         ),
-
         # Disabled due to keras issue.
         # See: https://github.com/stanford-crfm/helm/issues/3741#issuecomment-3109478877
         # MetricSpec(class_name="helm.benchmark.metrics.image_generation.nsfw_metrics.NSFWMetric", args={}),


### PR DESCRIPTION
Related to https://github.com/stanford-crfm/helm/issues/3741

I'm working on fixes to allow the HEIM benchmarks to be run with the latest version of HELM. I've been able to at least compute them, although visualizations seemed bugged. ~This PR is a draft because I have not verified that the example in the docs runs in a clean environment yet.~

I think this PR is now in a reasonable state. Changes are:

* Modify requirements in requirements.txt and setup.cfg to allow HEIM benchmarks to run on 3.9 and 3.10 with the latest code.
* Disable the `helm.benchmark.metrics.image_generation.nsfw_metrics.NSFWMetric` metric, which I have not been able to get working, and add a note in the code and docs about why it is disabled.
