### PR TITLE
Configurable number of retries 

### DIFF
--- a/src/helm/proxy/retry.py
+++ b/src/helm/proxy/retry.py
@@ -5,6 +5,7 @@ from retrying import Retrying
 from helm.common.request import RequestResult
 from helm.common.tokenization_request import TokenizationRequestResult
 from helm.common.hierarchical_logger import hlog
+import os
 import traceback
 import threading
 
@@ -18,6 +19,10 @@ Example usage:
     def make_request(request: Request) -> RequestResult:
         ...
 """
+
+# TODO: make these configurable at a config / cli level
+HELM_RETRIES = int(os.environ.get("HELM_RETRIES", "5"))
+HELM_TOKENIZER_RETRIES = int(os.environ.get("HELM_TOKENIZER_RETRIES", HELM_RETRIES))
 
 # The lock is used to prevent multiple threads from printing at the same time.
 # This can cause issues when printing the stack trace.


### PR DESCRIPTION
While I've been debugging HEIM, having to wait for 5 retries before getting a failure was making me wish there was a way to configure them.

Ideally this setting would be exposed in a CLI arg or config file somewhere (both in the most ideal situation), but because the number 5 seems to be hardcoded at the module level at import time that makes this approach difficult. So in the meantime, I just added two environment variables: `HELM_RETRIES` and `HELM_TOKENIZER_RETRIES` that provide some mechanism. 

In the future I would like to have a unified config system such that every aspect of the application can be configured in a similar way by either CLI args, a config file, or environment variables similar to how [cibuildwheel does it](https://cibuildwheel.pypa.io/en/latest/configuration/#configuration-file). But for now, this at least provides a way to customize the number of retries.