### PR TITLE
Handle Gemini responses with max tokens reached during thinking

### DIFF
--- a/src/helm/clients/vertexai_client.py
+++ b/src/helm/clients/vertexai_client.py
@@ -276,9 +276,11 @@ class VertexAIChatClient(VertexAIClient):
                     if not candidate.content:
                         raise VertexAIContentBlockedError(f"No content in candidate: {candidate}")
                     if not candidate.content.parts:
-                        # if candidate.finish_reason == 2:  # MAX_TOKENS
-                        #     predictions.append({"text": ""})
-                        # else:
+                        if candidate.finish_reason == 2:  # MAX_TOKENS
+                            # This means that there is no text output because the maximum number of tokens were
+                            # reached during thinking.
+                            predictions.append({"text": ""})
+                        else:
                             raise VertexAIContentBlockedError(f"No content parts in candidate: {candidate}")
                     else:
                         predictions.append({"text": candidate.content.text})


### PR DESCRIPTION
Recent Gemini models that support thinking can reach the max token limit during thinking, resulting in a response with no output text. Previously, we treated such as response as a "Content blocked: No content parts in candidate" error, because this was indicative of a content safety filter for older Gemini models. Now, we treat it as a successful response with an empty string as the output text.