### PR TITLE
Allow setting reference prefix characters

### DIFF
--- a/src/helm/benchmark/adaptation/adapter_spec.py
+++ b/src/helm/benchmark/adaptation/adapter_spec.py
@@ -63,6 +63,11 @@ class AdapterSpec:
     reference_prefix: str = "A. "
     """The string that is included before each reference (for multiple-choice questions)."""
 
+    # Set hash=False to make `AdapterSpec` hashable
+    reference_prefix_characters: Optional[List[str]] = field(default=None, hash=False)
+    """The characters that are used to identify choices for multiple-choice questions e.g. ["A", "B", "C", "D"].
+    If unset, defaults to the sequence of ascending characters starting from the first character of reference_prefix."""
+
     reference_suffix: str = "\n"
     """The string that is included after each reference (for multiple-choice questions)."""
 

--- a/src/helm/benchmark/adaptation/adapters/multimodal/multiple_choice_joint_multimodal_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/multimodal/multiple_choice_joint_multimodal_adapter.py
@@ -18,12 +18,20 @@ class MultipleChoiceJointMultimodalAdapter(InContextLearningMultimodalAdapter, A
     learning for multimodal models.
     """
 
-    @staticmethod
-    def get_reference_prefix(prefix: str, i: int) -> str:
+    def get_prefix_char(self, prefix: str) -> str:
+        return [char for char in prefix if char.isalnum()][0]
+
+    def get_reference_prefix(self, prefix: str, i: int) -> str:
         """
         Example: prefix = "\nA. ", i = 2, return "\nC. "
         """
-        return prefix.replace("A", chr(ord("A") + i))
+        old_prefix_char = self.get_prefix_char(prefix)
+        new_prefix_char = (
+            self.adapter_spec.reference_prefix_characters[i]
+            if self.adapter_spec.reference_prefix_characters
+            else chr(ord(old_prefix_char) + i)
+        )
+        return prefix.replace(old_prefix_char, new_prefix_char)
 
     def generate_requests(
         self, eval_instance: Instance, train_trial_index: int, training_instances: List[Instance]

--- a/src/helm/benchmark/adaptation/adapters/multiple_choice_joint_adapter.py
+++ b/src/helm/benchmark/adaptation/adapters/multiple_choice_joint_adapter.py
@@ -38,22 +38,25 @@ class MultipleChoiceJointAdapter(InContextLearningAdapter):
         <input_prefix><input><reference_prefixes[index]><reference><output_prefix><output>
     """
 
-    @staticmethod
-    def get_prefix_char(prefix: str) -> str:
+    def get_prefix_char(self, prefix: str) -> str:
         return [char for char in prefix if char.isalnum()][0]
 
-    @staticmethod
-    def get_reference_prefix(prefix: str, i: int) -> str:
+    def get_reference_prefix(self, prefix: str, i: int) -> str:
         """
         Example: prefix = "\nA. ", i = 2, return "\nC. "
         """
-        prefix_char = MultipleChoiceJointAdapter.get_prefix_char(prefix)
-        return prefix.replace(prefix_char, chr(ord(prefix_char) + i))
+        old_prefix_char = self.get_prefix_char(prefix)
+        new_prefix_char = (
+            self.adapter_spec.reference_prefix_characters[i]
+            if self.adapter_spec.reference_prefix_characters
+            else chr(ord(old_prefix_char) + i)
+        )
+        return prefix.replace(old_prefix_char, new_prefix_char)
 
     def generate_requests(
         self, eval_instance: Instance, train_trial_index: int, training_instances: List[Instance]
     ) -> List[RequestState]:
-        prefix_char = MultipleChoiceJointAdapter.get_prefix_char(self.adapter_spec.reference_prefix)
+        prefix_char = self.get_prefix_char(self.adapter_spec.reference_prefix)
         prompt = self.construct_prompt(training_instances, eval_instance, include_output=False, reference_index=None)
         output_mapping: Dict[str, str] = dict(
             (self.get_reference_prefix(prefix_char, reference_index), reference.output.text)
@@ -91,7 +94,7 @@ class MultipleChoiceJointAdapter(InContextLearningAdapter):
         # Include the references
         delimiter = ", "
         no_correct_references = "n/a"
-        prefix_char = MultipleChoiceJointAdapter.get_prefix_char(self.adapter_spec.reference_prefix)
+        prefix_char = self.get_prefix_char(self.adapter_spec.reference_prefix)
         output = no_correct_references
         for reference_index, reference in enumerate(instance.references):
             prefix = self.get_reference_prefix(self.adapter_spec.reference_prefix, reference_index)

--- a/src/helm/benchmark/run_specs/arabic_run_specs.py
+++ b/src/helm/benchmark/run_specs/arabic_run_specs.py
@@ -9,6 +9,9 @@ from helm.benchmark.run_spec import RunSpec, run_spec_function
 from helm.benchmark.scenarios.scenario import ScenarioSpec
 
 
+_ARABIC_REFERENCE_PREFIX_CHARACTERS = ["أ", "ب", "ج", "د", "هـ"]
+
+
 @run_spec_function("arabic_mmlu")
 def get_arabic_mmlu_spec() -> RunSpec:
     """EXPERIMENTAL: This run spec here may have future reverse incompatible changes."""
@@ -20,6 +23,7 @@ def get_arabic_mmlu_spec() -> RunSpec:
         input_noun="السؤال",
         output_noun="الإجابة",
         max_tokens=100,
+        reference_prefix_characters=_ARABIC_REFERENCE_PREFIX_CHARACTERS,
     )
 
     return RunSpec(
@@ -44,6 +48,7 @@ def get_alghafa_spec(subset: str) -> RunSpec:
         input_noun="السؤال",
         output_noun="الإجابة",
         max_tokens=100,
+        reference_prefix_characters=_ARABIC_REFERENCE_PREFIX_CHARACTERS,
     )
 
     return RunSpec(
@@ -108,6 +113,7 @@ def get_madinah_qa_spec() -> RunSpec:
         input_noun="السؤال",
         output_noun="الإجابة",
         max_tokens=100,
+        reference_prefix_characters=_ARABIC_REFERENCE_PREFIX_CHARACTERS,
     )
 
     return RunSpec(
@@ -131,6 +137,7 @@ def get_arabic_mmmlu_spec(subject: str) -> RunSpec:
         input_noun="السؤال",
         output_noun="الإجابة",
         max_tokens=100,
+        reference_prefix_characters=_ARABIC_REFERENCE_PREFIX_CHARACTERS,
     )
 
     return RunSpec(
@@ -155,6 +162,7 @@ def get_arabic_exams_spec(subject: str) -> RunSpec:
         input_noun="السؤال",
         output_noun="الإجابة",
         max_tokens=100,
+        reference_prefix_characters=_ARABIC_REFERENCE_PREFIX_CHARACTERS,
     )
 
     return RunSpec(


### PR DESCRIPTION
Adds `referene_prefix_characters` to `AdapterSpec`, which is used to define the characters that are used to identify choices for multiple-choice questions e.g. ["A", "B", "C", "D"]. If unset, defaults to the sequence of ascending characters starting from the first character of `reference_prefix`.

This is required for some languages such as Arabic, in which the characters used for MCQA ["أ", "ب", "ج", "د", "هـ"] are not consecutive ascending characters in Unicode codepoint space.