### PR TITLE
Add OpenRouterClient implementation and tests

### DIFF
--- a/src/helm/clients/openrouter_client.py
+++ b/src/helm/clients/openrouter_client.py
@@ -28,4 +28,4 @@ class OpenRouterClient(OpenAIClient):
         self.model_name = model_name
 
     def _get_model_for_request(self, request):
-        return self.model_name or request.model_engine
+        return self.model_name or request.model

--- a/src/helm/clients/openrouter_client.py
+++ b/src/helm/clients/openrouter_client.py
@@ -1,0 +1,34 @@
+import os
+from typing import Optional
+from helm.clients.openai_client import OpenAIClient
+
+
+class OpenRouterClient(OpenAIClient):
+    def __init__(
+        self,
+        tokenizer,
+        tokenizer_name,
+        cache_config,
+        api_key: Optional[str] = None,
+        model_name: Optional[str] = None,
+        output_processor: Optional[str] = None,
+    ):
+        self.api_key = api_key or os.getenv("OPENROUTER_API_KEY")
+        self.base_url = "https://openrouter.ai/api/v1/"
+        super().__init__(
+            tokenizer,
+            tokenizer_name,
+            cache_config=cache_config,
+            output_processor=output_processor,
+            base_url=self.base_url,
+            api_key=self.api_key,
+        )
+        self.model_name = model_name
+
+    def _get_model_for_request(self, request):
+        if self.model_name:
+            return self.model_name
+        elif len(request.model_deployment.split("/")) > 1:
+            return request.model_deployment.replace("openrouter/", "")
+
+        return self.model_name or request.model_engine

--- a/src/helm/clients/openrouter_client.py
+++ b/src/helm/clients/openrouter_client.py
@@ -1,14 +1,16 @@
 import os
 from typing import Optional
 from helm.clients.openai_client import OpenAIClient
+from helm.common.cache import CacheConfig
+from helm.tokenizers.tokenizer import Tokenizer
 
 
 class OpenRouterClient(OpenAIClient):
     def __init__(
         self,
-        tokenizer,
-        tokenizer_name,
-        cache_config,
+        tokenizer_name: str,
+        tokenizer: Tokenizer,
+        cache_config: CacheConfig,
         api_key: Optional[str] = None,
         model_name: Optional[str] = None,
         output_processor: Optional[str] = None,
@@ -28,7 +30,6 @@ class OpenRouterClient(OpenAIClient):
     def _get_model_for_request(self, request):
         if self.model_name:
             return self.model_name
-        elif len(request.model_deployment.split("/")) > 1:
-            return request.model_deployment.replace("openrouter/", "")
-
+        # elif len(request.model_deployment.split("/")) > 1:
+        #     return request.model_deployment.replace("openrouter/", "")
         return self.model_name or request.model_engine

--- a/src/helm/clients/openrouter_client.py
+++ b/src/helm/clients/openrouter_client.py
@@ -28,8 +28,4 @@ class OpenRouterClient(OpenAIClient):
         self.model_name = model_name
 
     def _get_model_for_request(self, request):
-        if self.model_name:
-            return self.model_name
-        # elif len(request.model_deployment.split("/")) > 1:
-        #     return request.model_deployment.replace("openrouter/", "")
         return self.model_name or request.model_engine

--- a/src/helm/clients/test_openrouter_client.py
+++ b/src/helm/clients/test_openrouter_client.py
@@ -35,8 +35,8 @@ class TestOpenRouterClient:
             ),
             (
                 None,
-                Request(model="openai/gpt-oss-20b:free", model_deployment="openai/gpt-oss-20b:free"),
-                "gpt-oss-20b:free",
+                Request(model="openai/gpt-oss-20b:free", model_deployment="openrouter/gpt-oss-20b:free"),
+                "openai/gpt-oss-20b:free",
             ),
         ],
     )

--- a/src/helm/clients/test_openrouter_client.py
+++ b/src/helm/clients/test_openrouter_client.py
@@ -1,0 +1,62 @@
+import os
+import pytest
+import tempfile
+
+from helm.common.cache import BlackHoleCacheConfig, SqliteCacheConfig
+from helm.common.request import Request
+from helm.clients.openrouter_client import OpenRouterClient
+
+
+class TestOpenRouterClient:
+    def setup_method(self, method):
+        cache_file = tempfile.NamedTemporaryFile(delete=False)
+        self.cache_path: str = cache_file.name
+
+    def teardown_method(self, method):
+        os.remove(self.cache_path)
+
+    @pytest.mark.parametrize(
+        "model_name,test_input,expected_model",
+        [
+            (
+                "openrouter/mistralai/mistral-medium-3.1",
+                Request(
+                    model="openrouter/mistralai/mistral-medium-3.1",
+                    model_deployment="openrouter/mistralai/mistral-medium-3.1",
+                ),
+                "openrouter/mistralai/mistral-medium-3.1",
+            ),
+            (
+                None,
+                Request(model="openai/gpt-oss-20b:free", model_deployment="openrouter/openai/gpt-oss-20b:free"),
+                "openai/gpt-oss-20b:free",
+            ),
+        ],
+    )
+    def test_get_model_for_request(self, model_name, test_input, expected_model):
+        client = OpenRouterClient(
+            tokenizer=None,
+            tokenizer_name=None,
+            cache_config=SqliteCacheConfig(self.cache_path),
+            model_name=model_name,
+            api_key="test_key",
+        )
+        assert client._get_model_for_request(test_input) == expected_model
+
+    def test_api_key_env_var(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test_key")
+        client = OpenRouterClient(
+            tokenizer=None,
+            tokenizer_name=None,
+            cache_config=SqliteCacheConfig(self.cache_path),
+        )
+        assert client.api_key == "test_key"
+
+    def test_api_key_argument(self):
+        client = OpenRouterClient(
+            tokenizer=None,
+            tokenizer_name=None,
+            cache_config=BlackHoleCacheConfig(),
+            api_key="explicit_key",
+        )
+        assert client.api_key == "explicit_key"

--- a/src/helm/clients/test_openrouter_client.py
+++ b/src/helm/clients/test_openrouter_client.py
@@ -6,11 +6,18 @@ from helm.common.cache import BlackHoleCacheConfig, SqliteCacheConfig
 from helm.common.request import Request
 from helm.clients.openrouter_client import OpenRouterClient
 
+from helm.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer
+
 
 class TestOpenRouterClient:
     def setup_method(self, method):
         cache_file = tempfile.NamedTemporaryFile(delete=False)
         self.cache_path: str = cache_file.name
+        self.tokenizer_name = "mistralai/Mistral-7B-v0.1"
+        self.tokenizer = HuggingFaceTokenizer(
+            cache_config=BlackHoleCacheConfig(),
+            tokenizer_name=self.tokenizer_name,
+        )
 
     def teardown_method(self, method):
         os.remove(self.cache_path)
@@ -19,24 +26,24 @@ class TestOpenRouterClient:
         "model_name,test_input,expected_model",
         [
             (
-                "openrouter/mistralai/mistral-medium-3.1",
+                "mistralai/mistral-medium-3.1",
                 Request(
-                    model="openrouter/mistralai/mistral-medium-3.1",
-                    model_deployment="openrouter/mistralai/mistral-medium-3.1",
+                    model="mistralai/mistral-medium-3.1",
+                    model_deployment="openrouter/mistral-medium-3.1",
                 ),
-                "openrouter/mistralai/mistral-medium-3.1",
+                "mistralai/mistral-medium-3.1",
             ),
             (
                 None,
-                Request(model="openai/gpt-oss-20b:free", model_deployment="openrouter/openai/gpt-oss-20b:free"),
-                "openai/gpt-oss-20b:free",
+                Request(model="openai/gpt-oss-20b:free", model_deployment="openai/gpt-oss-20b:free"),
+                "gpt-oss-20b:free",
             ),
         ],
     )
     def test_get_model_for_request(self, model_name, test_input, expected_model):
         client = OpenRouterClient(
-            tokenizer=None,
-            tokenizer_name=None,
+            tokenizer_name=self.tokenizer_name,
+            tokenizer=self.tokenizer,
             cache_config=SqliteCacheConfig(self.cache_path),
             model_name=model_name,
             api_key="test_key",
@@ -46,16 +53,16 @@ class TestOpenRouterClient:
     def test_api_key_env_var(self, monkeypatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "test_key")
         client = OpenRouterClient(
-            tokenizer=None,
-            tokenizer_name=None,
+            tokenizer_name=self.tokenizer_name,
+            tokenizer=self.tokenizer,
             cache_config=SqliteCacheConfig(self.cache_path),
         )
         assert client.api_key == "test_key"
 
     def test_api_key_argument(self):
         client = OpenRouterClient(
-            tokenizer=None,
-            tokenizer_name=None,
+            tokenizer_name=self.tokenizer_name,
+            tokenizer=self.tokenizer,
             cache_config=BlackHoleCacheConfig(),
             api_key="explicit_key",
         )

--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -4656,10 +4656,10 @@ model_deployments:
       args:
         pretrained_model_name_or_path: nicholasKluge/TeenyTinyLlama-460m
 
-  - name: openrouter/mistralai/mistral-medium-3.1
-    model_name: openrouter/mistralai/mistral-medium-3.1
+  - name: openrouter/mistral-medium-3.1
+    model_name: mistralai/mistral-medium-3.1
     tokenizer_name: mistralai/Mistral-7B-v0.1
-    max_sequence_length: 2048
+    max_sequence_length: 128000
     client_spec:
       class_name: "helm.clients.openrouter_client.OpenRouterClient"
       args:

--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -4655,3 +4655,12 @@ model_deployments:
       class_name: "helm.clients.huggingface_client.HuggingFaceClient"
       args:
         pretrained_model_name_or_path: nicholasKluge/TeenyTinyLlama-460m
+
+  - name: openrouter/mistralai/mistral-medium-3.1
+    model_name: openrouter/mistralai/mistral-medium-3.1
+    tokenizer_name: mistralai/Mistral-7B-v0.1
+    max_sequence_length: 2048
+    client_spec:
+      class_name: "helm.clients.openrouter_client.OpenRouterClient"
+      args:
+        model_name: mistralai/mistral-medium-3.1


### PR DESCRIPTION
This pull request introduces support for the OpenRouter API by adding a new client implementation, corresponding configuration, and tests to ensure correct behavior. The most important changes are grouped below:

**OpenRouter Client Implementation**

* Added new `OpenRouterClient` class in `src/helm/clients/openrouter_client.py`, inheriting from `OpenAIClient`, with logic to select the appropriate model and handle API key configuration via argument or environment variable.

**Configuration Updates**

* Added a new model deployment entry for `openrouter/mistral-medium-3.1` in `src/helm/config/model_deployments.yaml`, specifying the new client and its parameters.

**Testing**

* Added `src/helm/clients/test_openrouter_client.py` with tests for model selection logic and API key handling in `OpenRouterClient`, covering both environment variable and explicit argument cases.