### PR TITLE
Fix regular expression query handling in run predictions frontend

### DIFF
--- a/helm-frontend/src/components/RowValue.tsx
+++ b/helm-frontend/src/components/RowValue.tsx
@@ -19,19 +19,9 @@ function formatNumber(value: string | number): string {
 }
 
 function escapeRegExp(rawString: string): string {
-  // Otherwise do our homebrew best-effort escaping
-  let escapedString = rawString;
-  if ("escape" in RegExp) {
-    return RegExp.escape(rawString); // eslint-disable-line @typescript-eslint/no-unsafe-return
-  }
-  const specialCharacters = "^$\\.*+?()[]{}|".split("");
-  specialCharacters.forEach(function (specialCharacter) {
-    escapedString = escapedString.replace(
-      specialCharacter,
-      `\\${specialCharacter}`,
-    );
-  });
-  return escapedString;
+  // Homebrew best-effort escaping
+  // TODO: Replace with RegExp.escape after it is widely available
+  return rawString.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 export default function RowValue({ value, title, hideIcon }: Props) {

--- a/helm-frontend/src/routes/Runs.tsx
+++ b/helm-frontend/src/routes/Runs.tsx
@@ -16,7 +16,7 @@ export default function Runs() {
   const [currentPage, setCurrentPage] = useState<number>(
     Number(searchParams.get("page") || 1),
   );
-  const [useRegex, setUseRegex] = useState<boolean>(false);
+  const [useRegex, setUseRegex] = useState<boolean>(true);
   const [searchQuery, setSearchQuery] = useState<string>(
     searchParams.get("q") || "",
   );


### PR DESCRIPTION
- When linking to the run predictions page from the leaderboard tables page, generate a correctly escaped link if the run name contains special characters
- Fix a page crash the occurred when a malformed regular expression query was entered on the run predictions page