### PR TITLE
Auto-generate metric groups in helm-summarize

### DIFF
--- a/src/helm/benchmark/metrics/basic_metrics.py
+++ b/src/helm/benchmark/metrics/basic_metrics.py
@@ -326,6 +326,7 @@ class BasicReferenceMetric(ReferenceMetric):
                 display_name="Max prob",
                 description="Model's average confidence in its prediction (only computed for classification tasks)",
                 lower_is_better=False,
+                group="calibration_detailed",
             ),
             MetricMetadata(
                 name="exact_match",
@@ -333,6 +334,7 @@ class BasicReferenceMetric(ReferenceMetric):
                 short_display_name="EM",
                 description="Fraction of instances that the predicted output matches a correct reference exactly.",
                 lower_is_better=False,
+                group="accuracy",
             ),
             MetricMetadata(
                 name="predicted_index",
@@ -340,6 +342,7 @@ class BasicReferenceMetric(ReferenceMetric):
                 description="Integer index of the reference (0, 1, ...) that was predicted by the model (for "
                 "multiple-choice).",
                 lower_is_better=None,
+                group=None,
             ),
         ]
 
@@ -376,6 +379,7 @@ def get_request_state_metrics_metadata(
             display_name="# ref",
             description="Number of references.",
             lower_is_better=None,
+            group=None,
         ),
         MetricMetadata(
             name="num_train_trials",
@@ -383,6 +387,7 @@ def get_request_state_metrics_metadata(
             description="Number of trials, where in each trial we choose an independent, random set of training "
             "instances.",
             lower_is_better=None,
+            group="general_information",
         ),
     ]
     return (
@@ -423,24 +428,28 @@ def _get_finish_reason_metrics_metadata():
             description="Fraction of instances where the the output was terminated because the end of text token "
             "was generated.",
             lower_is_better=None,
+            group=None,
         ),
         MetricMetadata(
             name="finish_reason_length",
             display_name="finish b/c length",
             description="Fraction of instances where the the output was terminated because of the max tokens limit.",
             lower_is_better=None,
+            group=None,
         ),
         MetricMetadata(
             name="finish_reason_stop",
             display_name="finish b/c stop",
             description="Fraction of instances where the the output was terminated because of the stop sequences.",
             lower_is_better=None,
+            group=None,
         ),
         MetricMetadata(
             name="finish_reason_unknown",
             display_name="finish b/c unknown",
             description="Fraction of instances where the the output was terminated for unknown reasons.",
             lower_is_better=None,
+            group=None,
         ),
     ]
 
@@ -609,6 +618,7 @@ def _get_calibration_metrics_metadata() -> List[MetricMetadata]:
             "tasks). Warning - not reliable for small datasets (e.g., with < 300 examples) because "
             "each bin will have very few examples.",
             lower_is_better=True,
+            group="calibration",
         ),
         MetricMetadata(
             name="ece_1_bin",
@@ -617,6 +627,7 @@ def _get_calibration_metrics_metadata() -> List[MetricMetadata]:
             description="The (absolute value) difference between the model's average confidence and accuracy "
             "(only computed for classification tasks).",
             lower_is_better=True,
+            group="calibration_detailed",
         ),
         MetricMetadata(
             name="selective_acc@10",
@@ -625,6 +636,7 @@ def _get_calibration_metrics_metadata() -> List[MetricMetadata]:
             description="The accuracy for the 10% of predictions that the model is most confident on (only "
             "computed for classification tasks).",
             lower_is_better=False,
+            group="calibration_detailed",
         ),
         MetricMetadata(
             name="selective_cov_acc_area",
@@ -633,6 +645,7 @@ def _get_calibration_metrics_metadata() -> List[MetricMetadata]:
             description="The area under the coverage-accuracy curve, a standard selective classification metric "
             "(only computed for classification tasks).",
             lower_is_better=False,
+            group="calibration_detailed",
         ),
         MetricMetadata(
             name="platt_coef",
@@ -640,13 +653,15 @@ def _get_calibration_metrics_metadata() -> List[MetricMetadata]:
             short_display_name="Platt Coef",
             description="Coefficient of the Platt scaling classifier (can compare this across tasks).",
             lower_is_better=False,
+            group="calibration_detailed",
         ),
         MetricMetadata(
             name="platt_intercept",
             display_name="Platt Scaling Intercept",
             short_display_name="Platt Intercept",
-            description="Coefficient of the Platt scaling classifier (can compare this across tasks).",
+            description="Intercept of the Platt scaling classifier (can compare this across tasks).",
             lower_is_better=False,
+            group="calibration_detailed",
         ),
         MetricMetadata(
             name="platt_ece_10_bin",
@@ -655,6 +670,7 @@ def _get_calibration_metrics_metadata() -> List[MetricMetadata]:
             description="10-bin ECE computed after applying Platt scaling to recalibrate the model's predicted "
             "probabilities.",
             lower_is_better=True,
+            group="calibration_detailed",
         ),
         MetricMetadata(
             name="platt_ece_1_bin",
@@ -663,5 +679,6 @@ def _get_calibration_metrics_metadata() -> List[MetricMetadata]:
             description="1-bin ECE computed after applying Platt scaling to recalibrate the model's predicted "
             "probabilities.",
             lower_is_better=True,
+            group="calibration_detailed",
         ),
     ]

--- a/src/helm/benchmark/metrics/gpqa_chain_of_thought_metric.py
+++ b/src/helm/benchmark/metrics/gpqa_chain_of_thought_metric.py
@@ -110,5 +110,6 @@ class GPQAChainOfThoughtMetric(Metric):
                 short_display_name="COT correct",
                 description="Fraction of correct answers after chain of thought",
                 lower_is_better=False,
-            )
+                group="accuracy",
+            ),
         ]

--- a/src/helm/benchmark/metrics/ifeval_metrics.py
+++ b/src/helm/benchmark/metrics/ifeval_metrics.py
@@ -62,5 +62,6 @@ class IFEvalMetric(Metric):
                 short_display_name="IFEval Strict Acc",
                 description="Fraction of instructions in the instance that are correctly followed.",
                 lower_is_better=False,
-            )
+                group="accuracy",
+            ),
         ]

--- a/src/helm/benchmark/metrics/metric.py
+++ b/src/helm/benchmark/metrics/metric.py
@@ -104,6 +104,9 @@ class MetricMetadata:
     """Whether a lower vaue for this metric corresponds to a better model
     (e.g., False for accuracy, True for perplexity, None for num_trials)"""
 
+    group: Optional[str] = None
+    """Name of the default metric group for this metric"""
+
 
 class MetricInterface(ABC):
     """Interface for all Metrics."""

--- a/src/helm/benchmark/metrics/omni_math_metrics.py
+++ b/src/helm/benchmark/metrics/omni_math_metrics.py
@@ -39,5 +39,6 @@ class OmniMATHMetric(Metric):
                 short_display_name="Acc",
                 description="Accuracy of the AI output judged by GPT-4.",
                 lower_is_better=False,
-            )
+                group="accuracy",
+            ),
         ]

--- a/src/helm/benchmark/metrics/wildbench_metrics.py
+++ b/src/helm/benchmark/metrics/wildbench_metrics.py
@@ -41,6 +41,7 @@ class WildBenchScoreMetric(Metric):
                 short_display_name="WB Score",
                 description="Score of the AI output judged by GPT-4o.",
                 lower_is_better=False,
+                group="accuracy",
             ),
             MetricMetadata(
                 name="wildbench_score_rescaled",
@@ -48,5 +49,6 @@ class WildBenchScoreMetric(Metric):
                 short_display_name="WB Score",
                 description="Score of the AI output judged by GPT-4o, rescaled to be between 0 and 1.",
                 lower_is_better=False,
+                group="accuracy",
             ),
         ]

--- a/src/helm/benchmark/presentation/schema.py
+++ b/src/helm/benchmark/presentation/schema.py
@@ -199,7 +199,7 @@ class Schema:
     """Specifies information about what to display on the frontend."""
 
     # Information about each field
-    metrics: List[Field]
+    metrics: List[Field] = field(default_factory=list)
 
     # Information about each perturbation
     perturbations: List[Field] = field(default_factory=list)


### PR DESCRIPTION
- Works similarly to #3814 but for metric groups
- Adds a `group` field in the `MetricMetadata`  which is used to auto-generate the metric groups