### PR TITLE
Calculate win rates for auto-generated main metric group

### DIFF
--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -566,7 +566,6 @@ class Summarizer:
                 name="main_metric",
                 display_name="Main Metric",
                 description="Main Metric",
-                aggregation_strategies=[],
                 metrics=[MetricNameMatcher(name="${main_name}", split="${main_split}")],
             )
         ]

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -1368,14 +1368,13 @@ class Summarizer:
 
         ensure_directory_exists(self.run_release_path)
 
-        self.write_run_display_json(skip_completed)
-
         # Must happen after self.read_runs()
         # because it uses self.runs
         self.fix_up_schema()
         self.check_metrics_defined()
         self.write_schema()
 
+        self.write_run_display_json(skip_completed)
         self.write_executive_summary()
         self.write_runs()
         self.write_run_specs()


### PR DESCRIPTION
Also move `write_run_display_json()` to after schema auto-generation so that metrics are correctly displayed in the run predictions view.