### PR TITLE
Fix numpy version issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -312,6 +312,7 @@ heim = [
     "lpips~=0.1.4",
     "multilingual-clip~=1.0",
     "NudeNet~=2.0",
+    "numpy>=1.26,<2",
     "opencv-python>=4.7.0.68,<4.8.2.0; python_version >= '3.10'",
     "opencv-python-headless>=4.7.0.68,<=4.11.0.86; python_version < '3.10'",
     "pytorch-fid~=0.3.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -215,8 +215,7 @@ nodeenv==1.9.1
 nudenet==2.0.9
 numba==0.60.0 ; python_full_version < '3.10'
 numba==0.61.2 ; python_full_version >= '3.10'
-numpy==1.26.4 ; python_full_version < '3.10' or (python_full_version >= '3.11' and python_full_version < '3.13')
-numpy==2.2.6 ; python_full_version == '3.10.*' or python_full_version >= '3.13'
+numpy==1.26.4
 nvidia-cublas-cu12==12.4.5.8 ; platform_machine == 'x86_64' and sys_platform == 'linux'
 nvidia-cuda-cupti-cu12==12.4.127 ; platform_machine == 'x86_64' and sys_platform == 'linux'
 nvidia-cuda-nvrtc-cu12==12.4.127 ; platform_machine == 'x86_64' and sys_platform == 'linux'


### PR DESCRIPTION
Fix breakages by reverting numpy from 2.2.6 to 1.26.4:

```
FAILED src/helm/benchmark/metrics/image_generation/fractal_dimension/test_fractal_dimension_util.py::test_compute_fractal_dimension_cloud - ImportError: numpy.core.multiarray failed to import
FAILED src/helm/benchmark/metrics/image_generation/fractal_dimension/test_fractal_dimension_util.py::test_compute_fractal_dimension_sea_anemone - ImportError: numpy.core.multiarray failed to import
FAILED src/helm/benchmark/metrics/image_generation/fractal_dimension/test_fractal_dimension_util.py::test_compute_fractal_dimension_snowflake - ImportError: numpy.core.multiarray failed to import
FAILED src/helm/benchmark/metrics/image_generation/fractal_dimension/test_fractal_dimension_util.py::test_compute_fractal_dimension_convergence - ImportError: numpy.core.multiarray failed to import
```