### PR TITLE
Skip download tests

### DIFF
--- a/src/helm/common/test_general.py
+++ b/src/helm/common/test_general.py
@@ -1,5 +1,8 @@
 import shutil
 import os
+
+import pytest
+
 from helm.common.general import (
     ensure_file_downloaded,
     format_tags,
@@ -12,6 +15,7 @@ from helm.common.general import (
 
 
 def test_ensure_file_downloaded():
+    pytest.skip("Skipping download tests because these downloads are not reliable and may be throttled")
     ensure_file_downloaded("https://ftp.gnu.org/gnu/tar/tar-1.34.tar.gz", "test-tar", unpack=True, unpack_type="untar")
     assert os.path.isdir("test-tar")
     shutil.rmtree("test-tar")


### PR DESCRIPTION
Skipping download tests because these downloads use files that are not hosted by us. The download paths are not reliable and may be throttled.