### PR TITLE
Separate the definition of the ArgumentParser from its usage

### DIFF
--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -298,8 +298,7 @@ def helm_run(args):
     hlog("Done.")
 
 
-# Separate parsing from starting HELM so we can setup logging
-def main():
+def build_parser():
     parser = argparse.ArgumentParser()
     add_service_args(parser)
     parser.add_argument(
@@ -372,6 +371,12 @@ def main():
         help="PATH to a YAML file to customize logging",
     )
     add_run_args(parser)
+    return parser
+
+
+# Separate parsing from starting HELM so we can setup logging
+def main():
+    parser = build_parser()
     args = parser.parse_args()
     setup_default_logging(args.log_config)
     return helm_run(args)


### PR DESCRIPTION
This is a modification that will help our usage of HELM. We have a use-case where we would like to wrap helm-run in a subparser, but currently the main function both defines the parser and runs the main script. We would like to be able to access the argument parser object without running the main script, and maybe invoke it separately latter. The code already has a nice way to run the main script given the results of ArgumentParser.parse_args, but we just need to be able to access the definition.

This patch adds a `build_parser` function, which does just that: builds the helm-run argument parser and returns it. The main function just calls it and then forwards the result to the actual `helm_run` function.

We have other ways of working around this, but this would help make our CLI wrapper much nicer. 