### PR TITLE
Documentation: Remove redundant words at EOL

### DIFF
--- a/docs/heim.md
+++ b/docs/heim.md
@@ -6,10 +6,10 @@
 
 <img src="https://github.com/stanford-crfm/helm/raw/heim/src/helm/benchmark/static/heim/images/heim-logo.png" alt=""  width="800"/>
 
-Significant effort has recently been made in developing text-to-image generation models, which take textual prompts asmy-suite
-input and generate images. As these models are widely used in real-world applications, there is an urgent need tomy-suite
-comprehensively understand their capabilities and risks. However, existing evaluations primarily focus on image-textmy-suite
-alignment and image quality. To address this limitation, we introduce a new benchmark,my-suite
+Significant effort has recently been made in developing text-to-image generation models, which take textual prompts as 
+input and generate images. As these models are widely used in real-world applications, there is an urgent need to 
+comprehensively understand their capabilities and risks. However, existing evaluations primarily focus on image-text 
+alignment and image quality. To address this limitation, we introduce a new benchmark, 
 **Holistic Evaluation of Text-To-Image Models (HEIM)**.
 
 We identify 12 different aspects that are important in real-world model deployment, including:
@@ -27,9 +27,9 @@ We identify 12 different aspects that are important in real-world model deployme
 - multilinguality
 - efficiency
 
-By curating scenarios encompassing these aspects, we evaluate state-of-the-art text-to-image models using this benchmark.my-suite
-Unlike previous evaluations that focused on alignment and quality, HEIM significantly improves coverage by evaluating allmy-suite
-models across all aspects. Our results reveal that no single model excels in all aspects, with different modelsmy-suite
+By curating scenarios encompassing these aspects, we evaluate state-of-the-art text-to-image models using this benchmark. 
+Unlike previous evaluations that focused on alignment and quality, HEIM significantly improves coverage by evaluating all 
+models across all aspects. Our results reveal that no single model excels in all aspects, with different models 
 demonstrating strengths in different aspects.
 
 ## References
@@ -47,8 +47,8 @@ To install the additional dependencies to run HEIM, run:
 pip install "crfm-helm[heim]"
 ```
 
-Some models (e.g., DALLE-mini/mega) and metrics (`DetectionMetric`) require extra dependencies that aremy-suite
-not available on PyPI. To install these dependencies, download and run themy-suite
+Some models (e.g., DALLE-mini/mega) and metrics (`DetectionMetric`) require extra dependencies that are 
+not available on PyPI. To install these dependencies, download and run the 
 [extra install script](https://github.com/stanford-crfm/helm/blob/main/install-heim-extras.sh):
 
 ```sh


### PR DESCRIPTION
In `docs/heim.md`, multiple lines erroneously ended in "my-suite" instead of a space which disrupted reading flow.