### PR TITLE
Remove stop sequences in ALRAGE scenario

### DIFF
--- a/src/helm/benchmark/run_specs/arabic_run_specs.py
+++ b/src/helm/benchmark/run_specs/arabic_run_specs.py
@@ -105,6 +105,7 @@ def get_alrage_spec() -> RunSpec:
         input_noun="السؤال",
         output_noun="الإجابة",
         max_tokens=100,
+        stop_sequences=[],
     )
 
     annotator_specs = [AnnotatorSpec(class_name="helm.benchmark.annotation.alrage_annotator.ALRAGEAnnotator")]


### PR DESCRIPTION
The default stop sequence causes some model outputs to get truncated early unexpectedly.