### PR TITLE
Revert to using pypa/gh-action-pypi-publish in GHA for publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -44,5 +44,5 @@ jobs:
       run: uv run --isolated --no-project --with dist/*.tar.gz helm-summarize --suite test
     - name: helm-server (source distribution)
       run: uv run --isolated --no-project --with dist/*.tar.gz helm-server --help
-    - name: Publish
-      run: uv publish
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
`pypa/gh-action-pypi-publish` is preferred because it supports attestations, whereas `uv publish` does not.