### PR TITLE
Change Mistral Large 2 (2407) to use Hugging Face

### DIFF
--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -2466,7 +2466,9 @@ model_deployments:
     tokenizer_name: mistralai/Mistral-Large-Instruct-2407
     max_sequence_length: 128000
     client_spec:
-      class_name: "helm.clients.mistral_client.MistralAIClient"
+      class_name: "helm.clients.huggingface_client.HuggingFaceClient"
+      args:
+        pretrained_model_name_or_path: mistralai/Mistral-Large-Instruct-2407
 
   - name: mistralai/mistral-large-2411
     model_name: mistralai/mistral-large-2411


### PR DESCRIPTION
This model has been deprecated and removed from the Mistral API, so we use the Hugging Face version instead.