### PR TITLE
Update schema_thai.yaml to remove duplicate description

### DIFF
--- a/src/helm/benchmark/static/schema_thai.yaml
+++ b/src/helm/benchmark/static/schema_thai.yaml
@@ -206,7 +206,6 @@ run_groups:
       The Exam assesses students’ professional skills requirement in medical schools.
       This subset contains reasoning and medical ethics. We collected a total of 116 questions and answers.
       The TPAT-1 consists of 5 choices per question.
-    description: TBD
     metric_groups:
       - accuracy
       - efficiency


### PR DESCRIPTION
This PR fixes an issue where the TPAT-1 description is shown as TBD on the HELM leaderboard:
<https://crfm.stanford.edu/helm/thaiexam/latest/#/leaderboard>

The cause is that the TPAT-1 entry in `schema_thai.yaml` defines the `description` field twice:

https://github.com/stanford-crfm/helm/blob/main/src/helm/benchmark/static/schema_thai.yaml#L202-L213


Because of this duplication, the placeholder value (description: TBD) ends up being used.

In this PR, I removed the unnecessary description: TBD entry, keeping the more descriptive one so that the correct description is displayed.