### PR TITLE
Add missing name entry for WinoGrande in schema_mmlu_winogrande_afr.yaml

### DIFF
--- a/src/helm/benchmark/static/schema_mmlu_winogrande_afr.yaml
+++ b/src/helm/benchmark/static/schema_mmlu_winogrande_afr.yaml
@@ -208,6 +208,7 @@ run_groups:
       - mmlu_clinical_afr_college_medicine_zu
       - mmlu_clinical_afr_virology_zu
 
+  - name: winogrande_afr_by_language
     display_name: WinoGrande
     description: Results for WinoGrande by language.
     category: Results by benchmark


### PR DESCRIPTION
This PR fixes an issue in the **Select a group** dropdown on the MMLU–WinoGrande AFR leaderboard:

https://crfm.stanford.edu/helm/mmlu-winogrande-afr/latest/#/leaderboard

Under Results by Language, there should be benchmarks for 11 languages, but currently only 10 are shown.
Specifically, the **Zulu Benchmarks** entry is missing.

The root cause is a malformed entry in the schema file:

https://github.com/frogcat/helm/blob/main/src/helm/benchmark/static/schema_mmlu_winogrande_afr.yaml#L201-L213

In this section, the line:

```yaml
- name: winogrande_afr_by_language
```

is missing, which causes the WinoGrande entry to be merged with the previous one.

This PR adds the missing name entry, restoring the correct grouping and ensuring that all 11 language benchmarks (including Zulu) appear as expected.