### PR TITLE
Allow omitting the tokenizer and disabling request truncation

### DIFF
--- a/src/helm/benchmark/window_services/no_tokenizer_window_service.py
+++ b/src/helm/benchmark/window_services/no_tokenizer_window_service.py
@@ -1,4 +1,5 @@
 from typing import List, Optional
+
 from helm.benchmark.window_services.window_service import EncodeResult, WindowService
 from helm.common.tokenization_request import TokenizationToken
 

--- a/src/helm/benchmark/window_services/window_service_factory.py
+++ b/src/helm/benchmark/window_services/window_service_factory.py
@@ -28,12 +28,11 @@ class WindowServiceFactory:
                     and model_deployment.tokenizer_name is None
                 ):
                     window_service_spec = WindowServiceSpec(
-                        class_name="helm.benchmark.window_services.no_tokenizer_window_service.NoTokenizerWindowService",
-                        args={},
+                        class_name="helm.benchmark.window_services.no_tokenizer_window_service.NoTokenizerWindowService"
                     )
                 else:
                     window_service_spec = WindowServiceSpec(
-                        class_name="helm.benchmark.window_services.default_window_service.DefaultWindowService", args={}
+                        class_name="helm.benchmark.window_services.default_window_service.DefaultWindowService"
                     )
 
             # If provided, look up special tokens from TokenizerConfig.


### PR DESCRIPTION
For older models, requests were truncated within the model's context window using the tokenizer and `WindowService` class.

In many cases, newer models have larger context windows and do not require truncation for the vast majority of HELM requests. Additionally, many newer API-based models do not have an publicly available tokenizer.

This pull request allows disabling truncation for such newer models. To do so, configure a model deployment for the model that omits `max_sequence_length`, `max_request_length`, `max_sequence_and_generated_tokens_length`, `window_service_spec` and `tokenizer_name`. This will cause the new `NoTokenizerWindowService` to be used, which does not perform truncation. Alternatively, one could set `window_service_spec` explicitly to use `NoTokenizerWindowService`.