### PR TITLE
Support more models and thinking output for LiteLLM

### DIFF
--- a/src/helm/clients/litellm_client.py
+++ b/src/helm/clients/litellm_client.py
@@ -122,7 +122,11 @@ class LiteLLMCompletionClient(CachingClient):
                 if output_text is None:
                     raise ValueError("Response content was `None`, possibly due to content blocking")
                 completion = GeneratedOutput(
-                    text=output_text, logprob=0.0, tokens=[], finish_reason={"reason": choice.finish_reason}, thinking=thinking,
+                    text=output_text,
+                    logprob=0.0,
+                    tokens=[],
+                    finish_reason={"reason": choice.finish_reason},
+                    thinking=thinking,
                 )
                 completions.append(completion)
 


### PR DESCRIPTION
Made some changes to support more models:

- Set `drop_params=true` in LiteLLM so that the model API's unsupported parameters are dropped
- Set `top_p` to `None` and `logprobs` to `False` because many models do not support these

Also, return thinking output from thinking models.