### PR TITLE
Allow using Hugging Face models without configuration

### DIFF
--- a/src/helm/benchmark/tokenizer_config_registry.py
+++ b/src/helm/benchmark/tokenizer_config_registry.py
@@ -52,5 +52,34 @@ def register_tokenizer_configs_from_path(path: str) -> None:
         register_tokenizer_config(tokenizer_config)
 
 
+def auto_generate_tokenizer_config(name: str) -> TokenizerConfig:
+    name_parts = name.split("/")
+    name_base = name_parts[0]
+    if name_base == "huggingface":
+        from helm.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer
+
+        pretrained_model_name_or_path = "/".join(name_parts[1:])
+        with HuggingFaceTokenizer.create_tokenizer(pretrained_model_name_or_path) as tokenizer:
+            end_of_text_token = tokenizer.eos_token or ""
+            prefix_token = tokenizer.bos_token or ""
+        return TokenizerConfig(
+            name=name,
+            tokenizer_spec=TokenizerSpec(
+                "helm.tokenizers.huggingface_tokenizer.HuggingFaceTokenizer",
+                args={"pretrained_model_name_or_path": pretrained_model_name_or_path},
+            ),
+            end_of_text_token=end_of_text_token,
+            prefix_token=prefix_token,
+        )
+    else:
+        raise NotImplementedError(f"Could not auto generate tokenizer config for tokenizer {name}")
+
+
 def get_tokenizer_config(name: str) -> Optional[TokenizerConfig]:
-    return TOKENIZER_NAME_TO_CONFIG.get(name)
+    tokenizer_config = TOKENIZER_NAME_TO_CONFIG.get(name)
+    if tokenizer_config:
+        return tokenizer_config
+    name_parts = name.split("/")
+    if len(name_parts) > 2:
+        return auto_generate_tokenizer_config(name)
+    return None


### PR DESCRIPTION
This allows running a Hugging Face model on Hugging Face hub on the local machine without explicitly configuring the model in `model_deployments.yaml`.

This can be done by specifying `--models-to-run` (this is the preferred way):

```sh
helm-run -m 10 -r mmlu_pro --models-to-run huggingface/HuggingFaceTB/SmolLM2-135M-Instruct --suite default
```

This can be also done by specifying `model=`:

```sh
helm-run -m 10 -r mmlu_pro:model=huggingface/HuggingFaceTB/SmolLM2-135M-Instruct --suite default
```