### PR TITLE
Fix broken boolq url

### DIFF
--- a/src/helm/benchmark/scenarios/boolq_scenario.py
+++ b/src/helm/benchmark/scenarios/boolq_scenario.py
@@ -146,15 +146,9 @@ class BoolQScenario(Scenario):
         instances: List[Instance] = []
         split_to_filename: Dict[str, str] = {TRAIN_SPLIT: "train", VALID_SPLIT: "dev"}
 
-        # NOTE: As of 2026-01-15, the google storage URL no longer works. We
-        # are now pointing at an IPFS mirror, which has advantages but also
-        # relies on peers hosting the dataset. A better solution may be to use
-        # the huggingface version of the dataset, and use IPFS as a fallback.
-        # For now we just use the IPFS url as a simple fix.  For details see:
-        # https://github.com/stanford-crfm/helm/issues/4019
-
-        # base_url = "https://storage.googleapis.com/boolq"
-        base_url = "https://ipfs.io/ipfs/bafybeido2w4vlhmnzj5hyzimaviby7bozsipgrkcf4unkkf5me4tivunwq"
+        # base_url = "https://storage.googleapis.com/boolq"  # Original URL is broken as of 2026-01-15
+        # base_url = "https://ipfs.io/ipfs/bafybeido2w4vlhmnzj5hyzimaviby7bozsipgrkcf4unkkf5me4tivunwq"  # IPFS URL could be used as a fallback
+        base_url = "https://huggingface.co/datasets/stanford-crfm/helm-scenarios/resolve/main/boolq"
 
         # First, ensure all splits are downloaded
         for split, filename in split_to_filename.items():


### PR DESCRIPTION
Fixes https://github.com/stanford-crfm/helm/issues/4019

I'm not doing anything fancy here, but this is an improvement over pointing at a dead URL. Like I mention in the issue, this URL depends on someone hosting the data on a public IPFS node. Currently that is me at home, and Kitware. If anyone else starts pinning the data, this code becomes a lot more robust. But given only 2 peers it is still a little flaky. However it's better than the dead URL.

I thought about doing a try / except in case the google storage URL ever came back online (currently its a 403, so maybe you just need credentials now), but I wanted to keep this low effort and just get the fix in. If it breaks or causes issues it can be revisited.  