### PR TITLE
Adjust Vite manual bundles

### DIFF
--- a/helm-frontend/vite.config.ts
+++ b/helm-frontend/vite.config.ts
@@ -35,11 +35,13 @@ export default () => {
       environment: "jsdom",
     },
     build: {
+      chunkSizeWarningLimit: 600,
       rollupOptions: {
         output: {
-          // Manually chunk large libraries to keep chunk size under 500 KB
+          // Manually chunk large libraries to keep chunk size under 600 KB
           manualChunks: {
-            react: ["react", "react-dom", "react-router-dom", "react-spinners", "recharts"],
+            react: ["react", "react-dom", "react-router-dom", "react-spinners"],
+            recharts: ["recharts"],
             tremor: ["@tremor/react"],
             "react-markdown": ["react-markdown"],
           }


### PR DESCRIPTION
Address "Some chunks are larger than 500 kB after minification" by setting `chunkSizeWarningLimit`.

Note: that `react-markdown` depends on `recharts`, and therefore will cause a circular dependency if placed in the same chunk as `recharts`' dependencies.