### PR TITLE
Add jfinqa: Japanese Financial Numerical Reasoning QA

### DIFF
--- a/src/helm/benchmark/presentation/run_entries_finance.conf
+++ b/src/helm/benchmark/presentation/run_entries_finance.conf
@@ -1,6 +1,7 @@
 # HELM Finance leaderboard
 "entries": [
     {description: "fin_qa:model=text", priority: 2}
+    {description: "jfinqa:model=text", priority: 2}
     {description: "financebench:model=text", priority: 2}
     {description: "raft:subset=banking_77,model=text", priority: 2}
 ]

--- a/src/helm/benchmark/run_specs/finance_run_specs.py
+++ b/src/helm/benchmark/run_specs/finance_run_specs.py
@@ -82,6 +82,30 @@ def get_financebench_spec() -> RunSpec:
     )
 
 
+@run_spec_function("jfinqa")
+def get_jfinqa_spec() -> RunSpec:
+    scenario_spec = ScenarioSpec(class_name="helm.benchmark.scenarios.jfinqa_scenario.JFinQAScenario", args={})
+    adapter_spec = get_generation_adapter_spec(
+        instructions=(
+            "以下の財務データを読み、質問に正確な数値で答えてください。\n"
+            "Read the following financial data and answer the question with the exact numeric value.\n"
+        ),
+        input_noun=None,
+        output_noun="Answer",
+        max_tokens=50,
+    )
+    metric_specs = get_basic_metric_specs([]) + [
+        MetricSpec(class_name="helm.benchmark.metrics.conv_fin_qa_calc_metrics.ConvFinQACalcMetric")
+    ]
+    return RunSpec(
+        name="jfinqa",
+        scenario_spec=scenario_spec,
+        adapter_spec=adapter_spec,
+        metric_specs=metric_specs,
+        groups=["jfinqa"],
+    )
+
+
 @run_spec_function("banking77")
 def get_banking77_spec() -> RunSpec:
     from helm.benchmark.scenarios.raft_scenario import get_raft_instructions

--- a/src/helm/benchmark/scenarios/jfinqa_scenario.py
+++ b/src/helm/benchmark/scenarios/jfinqa_scenario.py
@@ -1,0 +1,116 @@
+"""JFinQA: Japanese Financial Numerical Reasoning QA Benchmark.
+
+Data source:
+https://huggingface.co/datasets/ajtgjmdjp/jfinqa
+
+JFinQA is a benchmark for numerical reasoning over Japanese corporate
+financial disclosures. It contains 1,000 questions across three subtasks
+—numerical reasoning (550), consistency checking (200), and temporal
+reasoning (250)—drawn from 68 companies' EDINET filings covering
+J-GAAP, IFRS, and US-GAAP.
+"""
+
+import os
+from typing import Any, Dict, List
+
+from datasets import load_dataset
+
+from helm.benchmark.presentation.taxonomy_info import TaxonomyInfo
+from helm.benchmark.scenarios.scenario import (
+    CORRECT_TAG,
+    TEST_SPLIT,
+    Input,
+    Instance,
+    Output,
+    Reference,
+    Scenario,
+    ScenarioMetadata,
+)
+from helm.common.general import ensure_directory_exists
+
+
+class JFinQAScenario(Scenario):
+    """Japanese Financial Numerical Reasoning QA."""
+
+    name = "jfinqa"
+    description = (
+        "JFinQA: Japanese Financial Numerical Reasoning QA — "
+        "1,000 questions across numerical reasoning, consistency checking, "
+        "and temporal reasoning from 68 companies' EDINET filings."
+    )
+    tags = ["question_answering", "finance", "japanese"]
+
+    HF_DATASET_ID = "ajtgjmdjp/jfinqa"
+    SUBSETS = ("numerical_reasoning", "consistency_checking", "temporal_reasoning")
+
+    @staticmethod
+    def _format_table(headers: List[str], rows: List[List[str]]) -> str:
+        header_line = "| " + " | ".join(str(h) for h in headers) + " |"
+        sep_line = "| " + " | ".join("---" for _ in headers) + " |"
+        row_lines = ["| " + " | ".join(str(c) for c in row) + " |" for row in rows]
+        return "\n".join([header_line, sep_line, *row_lines])
+
+    @staticmethod
+    def _build_input(row: Dict[str, Any]) -> str:
+        parts: List[str] = []
+
+        pre_text = row.get("pre_text", [])
+        if pre_text:
+            parts.append("\n".join(pre_text))
+
+        headers = row.get("table_headers", [])
+        rows = row.get("table_rows", [])
+        if headers:
+            parts.append(JFinQAScenario._format_table(headers, rows))
+
+        post_text = row.get("post_text", [])
+        if post_text:
+            parts.append("\n".join(post_text))
+
+        question = row.get("question", "")
+        parts.append(f"Question: {question}")
+
+        return "\n\n".join(parts)
+
+    def get_instances(self, output_path: str) -> List[Instance]:
+        cache_dir = os.path.join(output_path, "data")
+        ensure_directory_exists(cache_dir)
+
+        instances: List[Instance] = []
+        for subset in self.SUBSETS:
+            dataset = load_dataset(
+                self.HF_DATASET_ID,
+                subset,
+                split="test",
+                cache_dir=cache_dir,
+                trust_remote_code=True,
+            )
+            for row in dataset:
+                input_text = self._build_input(row)
+                answer = str(row["answer"])
+                instances.append(
+                    Instance(
+                        input=Input(text=input_text),
+                        references=[Reference(Output(text=answer), tags=[CORRECT_TAG])],
+                        split=TEST_SPLIT,
+                        id=str(row.get("id", "")),
+                    )
+                )
+        return instances
+
+    def get_metadata(self) -> ScenarioMetadata:
+        return ScenarioMetadata(
+            name="jfinqa",
+            display_name="JFinQA",
+            short_display_name="JFinQA",
+            description=self.description,
+            taxonomy=TaxonomyInfo(
+                task="question answering with numeric reasoning",
+                what="Japanese corporate financial reports (EDINET/XBRL)",
+                when="2023 to 2024",
+                who="financial experts",
+                language="Japanese",
+            ),
+            main_metric="float_equiv",
+            main_split="test",
+        )

--- a/src/helm/benchmark/static/schema_finance.yaml
+++ b/src/helm/benchmark/static/schema_finance.yaml
@@ -82,6 +82,11 @@ metrics:
     short_display_name: EM
     description: Fraction of instances that the predicted output matches a correct reference up to light processing.
     lower_is_better: false
+  - name: float_equiv
+    display_name: Float Equivalence
+    short_display_name: Float Equiv
+    description: Fraction of instances where the predicted numeric value matches the gold value within a small tolerance.
+    lower_is_better: false
 
   # Efficiency metrics:
   - name: inference_runtime
@@ -135,6 +140,7 @@ run_groups:
     category: All scenarios
     subgroups:
       - fin_qa
+      - jfinqa
       - financebench
       - banking77
 
@@ -171,6 +177,24 @@ run_groups:
       who: financial experts
       when: 2015 to 2023
       language: English
+
+  - name: jfinqa
+    display_name: JFinQA
+    short_display_name: JFinQA
+    description: JFinQA is a benchmark for numerical reasoning over Japanese corporate financial disclosures (EDINET filings). It contains 1,000 questions across numerical reasoning, consistency checking, and temporal reasoning from 68 companies.
+    metric_groups:
+      - accuracy
+      - efficiency
+      - general_information
+    environment:
+      main_name: float_equiv
+      main_split: test
+    taxonomy:
+      task: question answering with numeric reasoning
+      what: Japanese corporate financial reports (EDINET/XBRL)
+      who: financial experts
+      when: 2023 to 2024
+      language: Japanese
 
   - name: banking77
     display_name: BANKING77


### PR DESCRIPTION
## Summary

Adds **jfinqa** as a new finance scenario — the first non-English finance benchmark in HELM.

- **1,000 questions** across numerical reasoning, consistency checking, and temporal reasoning
- **68 companies** from Japanese EDINET filings (J-GAAP / IFRS / US-GAAP)
- Dataset: [ajtgjmdjp/jfinqa](https://huggingface.co/datasets/ajtgjmdjp/jfinqa)

## Changes

- `src/helm/benchmark/scenarios/jfinqa_scenario.py`: New scenario loading from HuggingFace
- `src/helm/benchmark/run_specs/finance_run_specs.py`: Run spec function using `float_equiv` metric
- `src/helm/benchmark/static/schema_finance.yaml`: Added jfinqa to finance leaderboard
- `src/helm/benchmark/presentation/run_entries_finance.conf`: Added run entry

## Test plan

- [x] `black --check` passes
- [x] `flake8` passes
- [ ] End-to-end run with a small model

🤖 Generated with [Claude Code](https://claude.com/claude-code)