### PR TITLE
Display whitespace in responses in proxy server

### DIFF
--- a/src/helm/proxy/static/index.css
+++ b/src/helm/proxy/static/index.css
@@ -19,6 +19,7 @@
 }
 
 .completion {
+  white-space: pre-wrap;
   border: solid 1px;
   border-color: #c0c0c0;
   padding: 3px;


### PR DESCRIPTION
Set `white-space: pre-wrap` in CSS so that whitespace in responses is rendered as intended.

Fixes #120