### PR TITLE
Add model_deployment_generator decorator

### DIFF
--- a/src/helm/benchmark/model_deployment_registry.py
+++ b/src/helm/benchmark/model_deployment_registry.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, List
+from typing import Callable, Dict, Optional, List, TypeVar
 from dataclasses import dataclass
 
 import cattrs
@@ -123,77 +123,19 @@ def register_model_deployments_from_path(path: str) -> None:
         register_model_deployment(model_deployment)
 
 
-def auto_generate_model_deployment(name: str) -> ModelDeployment:
-    name_parts = name.split("/")
-    model_deployment_base = name_parts[0]
-    model_name = "/".join(name_parts[-2:])
-    if model_deployment_base == "together":
-        return ModelDeployment(
-            name=name, model_name=model_name, client_spec=ClientSpec("helm.clients.together_client.TogetherClient")
-        )
-    elif model_deployment_base == "litellm":
-        return ModelDeployment(
-            name=name,
-            model_name=model_name,
-            client_spec=ClientSpec(
-                "helm.clients.litellm_client.LiteLLMCompletionClient", args={"litellm_model": "/".join(name_parts[1:])}
-            ),
-        )
-    elif model_deployment_base == "huggingface":
-        from helm.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer
-
-        pretrained_model_name_or_path = "/".join(name_parts[1:])
-        with HuggingFaceTokenizer.create_tokenizer(pretrained_model_name_or_path) as tokenizer:
-            max_sequence_length = tokenizer.model_max_length
-            if max_sequence_length > 1_000_000_000:
-                hwarn(
-                    f"Hugging Face model {pretrained_model_name_or_path} does not have a configured model_max_length; "
-                    "input truncation may not work correctly; errors may result from exceeding the model's max length"
-                )
-        return ModelDeployment(
-            name=name,
-            model_name=model_name,
-            client_spec=ClientSpec(
-                "helm.clients.huggingface_client.HuggingFaceClient",
-                args={"pretrained_model_name_or_path": pretrained_model_name_or_path},
-            ),
-            tokenizer_name=name,
-            max_sequence_length=max_sequence_length,
-        )
-    elif model_deployment_base == "huggingface-inference-providers":
-        from helm.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer
-
-        pretrained_model_name_or_path = "/".join(name_parts[1:])
-        pretrained_model_name_or_path = pretrained_model_name_or_path.split(":")[0]
-        with HuggingFaceTokenizer.create_tokenizer(pretrained_model_name_or_path) as tokenizer:
-            max_sequence_length = tokenizer.model_max_length
-            if max_sequence_length > 1_000_000_000:
-                hwarn(
-                    f"Hugging Face model {pretrained_model_name_or_path} does not have a configured model_max_length; "
-                    "input truncation may not work correctly; errors may result from exceeding the model's max length"
-                )
-        return ModelDeployment(
-            name=name,
-            model_name=model_name,
-            client_spec=ClientSpec(
-                "helm.clients.huggingface_inference_providers_client.HuggingFaceInferenceProvidersClient"
-            ),
-            tokenizer_name=f"huggingface/{pretrained_model_name_or_path}",
-            max_sequence_length=max_sequence_length,
-        )
-    else:
-        raise NotImplementedError(f"Unknown model deployment base {model_deployment_base}")
-
-
 def get_model_deployment(name: str, warn_deprecated: bool = False) -> ModelDeployment:
-    if name not in DEPLOYMENT_NAME_TO_MODEL_DEPLOYMENT:
-        name_parts = name.split("/")
-        if len(name_parts) > 2:
-            return auto_generate_model_deployment(name)
+    deployment: Optional[ModelDeployment] = DEPLOYMENT_NAME_TO_MODEL_DEPLOYMENT.get(name)
+
+    if not deployment:
+        for prefix, model_deployment_generator in _REGISTERED_MODEL_DEPLOYMENT_GENERATORS.items():
+            if name.startswith(prefix):
+                deployment = model_deployment_generator(name)
+
+    if not deployment:
         raise ValueError(f"Model deployment {name} not found")
-    deployment: ModelDeployment = DEPLOYMENT_NAME_TO_MODEL_DEPLOYMENT[name]
+
     if deployment.deprecated and warn_deprecated:
-        hwarn(f"DEPLOYMENT Model deployment {name} is deprecated")
+        hwarn(f"Model deployment {name} is deprecated")
     return deployment
 
 
@@ -277,3 +219,101 @@ def get_default_model_deployment_for_model(
     # Some models are added but have no deployments yet.
     # In this case, we return None.
     return None
+
+
+ModelDeploymentGenerator = Callable[[str], ModelDeployment]
+"""A function that takes in a model name and returns a ModelDeployment"""
+
+
+_REGISTERED_MODEL_DEPLOYMENT_GENERATORS: Dict[str, ModelDeploymentGenerator] = {}
+"""Dict of prefixes to ModelDeploymentGenerators."""
+
+
+F = TypeVar("F", bound=ModelDeploymentGenerator)
+
+
+def model_deployment_generator(prefix: str) -> Callable[[F], F]:
+    """Register the ModelDeploymentGenerator for the given model name prefix."""
+
+    def wrap(func: F) -> F:
+        key = prefix.strip("/") + "/"
+        if key in _REGISTERED_MODEL_DEPLOYMENT_GENERATORS:
+            raise ValueError(f"A ModelDeploymentGenerator with prefix {key} already exists")
+        _REGISTERED_MODEL_DEPLOYMENT_GENERATORS[key] = func
+        return func
+
+    return wrap
+
+
+@model_deployment_generator("together")
+def get_together_model_deployment(name: str):
+    name_parts = name.split("/")
+    model_name = "/".join(name_parts[-2:])
+    return ModelDeployment(
+        name=name, model_name=model_name, client_spec=ClientSpec("helm.clients.together_client.TogetherClient")
+    )
+
+
+@model_deployment_generator("litellm")
+def get_litellm_model_deployment(name: str):
+    name_parts = name.split("/")
+    model_name = "/".join(name_parts[-2:])
+    return ModelDeployment(
+        name=name,
+        model_name=model_name,
+        client_spec=ClientSpec(
+            "helm.clients.litellm_client.LiteLLMCompletionClient", args={"litellm_model": "/".join(name_parts[1:])}
+        ),
+    )
+
+
+@model_deployment_generator("huggingface")
+def get_huggingface_model_deployment(name: str):
+    from helm.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer
+
+    name_parts = name.split("/")
+    model_name = "/".join(name_parts[-2:])
+    pretrained_model_name_or_path = "/".join(name_parts[1:])
+    with HuggingFaceTokenizer.create_tokenizer(pretrained_model_name_or_path) as tokenizer:
+        max_sequence_length = tokenizer.model_max_length
+        if max_sequence_length > 1_000_000_000:
+            hwarn(
+                f"Hugging Face model {pretrained_model_name_or_path} does not have a configured model_max_length; "
+                "input truncation may not work correctly; errors may result from exceeding the model's max length"
+            )
+    return ModelDeployment(
+        name=name,
+        model_name=model_name,
+        client_spec=ClientSpec(
+            "helm.clients.huggingface_client.HuggingFaceClient",
+            args={"pretrained_model_name_or_path": pretrained_model_name_or_path},
+        ),
+        tokenizer_name=name,
+        max_sequence_length=max_sequence_length,
+    )
+
+
+@model_deployment_generator("huggingface-inference-providers")
+def get_huggingface_inference_providers_model_deployment(name: str):
+    from helm.tokenizers.huggingface_tokenizer import HuggingFaceTokenizer
+
+    name_parts = name.split("/")
+    model_name = "/".join(name_parts[-2:])
+    pretrained_model_name_or_path = "/".join(name_parts[1:])
+    pretrained_model_name_or_path = pretrained_model_name_or_path.split(":")[0]
+    with HuggingFaceTokenizer.create_tokenizer(pretrained_model_name_or_path) as tokenizer:
+        max_sequence_length = tokenizer.model_max_length
+        if max_sequence_length > 1_000_000_000:
+            hwarn(
+                f"Hugging Face model {pretrained_model_name_or_path} does not have a configured model_max_length; "
+                "input truncation may not work correctly; errors may result from exceeding the model's max length"
+            )
+    return ModelDeployment(
+        name=name,
+        model_name=model_name,
+        client_spec=ClientSpec(
+            "helm.clients.huggingface_inference_providers_client.HuggingFaceInferenceProvidersClient"
+        ),
+        tokenizer_name=f"huggingface/{pretrained_model_name_or_path}",
+        max_sequence_length=max_sequence_length,
+    )


### PR DESCRIPTION
The `model_deployment_generator` decorator allows registering a `ModelDeploymentGenerator`, which is a function that takes in a model deployment name and returns a `ModelDeployment` for a given model deployment name prefix. This can be used to register plugins that allow auto-configuring models for a given a model platform, rather than requiring the user to configure each model individually.