### PR TITLE
Switch llama-4-scout-17b-16e-instruct to use Vertex AI instead of Together

### DIFF
--- a/src/helm/config/model_deployments.yaml
+++ b/src/helm/config/model_deployments.yaml
@@ -1360,6 +1360,7 @@ model_deployments:
       class_name: "helm.clients.vertexai_client.VertexAIChatClient"
       args:
         vertexai_model: publishers/meta/models/llama-4-scout-17b-16e-instruct-maas
+        genai_use_vertexai: False
 
   ## Gemma
   - name: together/gemma-2b


### PR DESCRIPTION
`llama-4-scout-17b-16e-instruct` has been removed from Together serverless models.