### PR TITLE
Allow using OpenAI models without configuration

### DIFF
--- a/src/helm/benchmark/model_deployment_registry.py
+++ b/src/helm/benchmark/model_deployment_registry.py
@@ -130,6 +130,7 @@ def get_model_deployment(name: str, warn_deprecated: bool = False) -> ModelDeplo
         import helm.benchmark.model_deployments.huggingface_model_deployments  # noqa: F401
         import helm.benchmark.model_deployments.huggingface_inference_providers_model_deployments  # noqa: F401
         import helm.benchmark.model_deployments.litellm_model_deployments  # noqa: F401
+        import helm.benchmark.model_deployments.openai_model_deployments  # noqa: F401
         import helm.benchmark.model_deployments.together_model_deployments  # noqa: F401
 
         for prefix, model_deployment_generator in _REGISTERED_MODEL_DEPLOYMENT_GENERATORS.items():

--- a/src/helm/benchmark/model_deployments/openai_model_deployments.py
+++ b/src/helm/benchmark/model_deployments/openai_model_deployments.py
@@ -1,0 +1,12 @@
+from helm.benchmark.model_deployment_registry import ClientSpec, ModelDeployment, model_deployment_generator
+
+
+@model_deployment_generator("openai")
+def get_openai_model_deployment(name: str):
+    name_parts = name.split("/")
+    model_name = "/".join(name_parts[-2:])
+    return ModelDeployment(
+        name=name,
+        model_name=model_name,
+        client_spec=ClientSpec("helm.clients.openai_responses_client.OpenAIResponseClient"),
+    )


### PR DESCRIPTION
This allows using an OpenAI model without explicitly configuring the model in `model_deployments.yaml`.

This can be done by specifying `--models-to-run` (this is the preferred way):

```sh
helm-run -m 10 -r mmlu_pro --models-to-run openai/openai/gpt-4.1 --suite default
```

This can be also done by specifying `model=`:

```sh
helm-run -m 10 -r mmlu_pro:model=openai/openai/gpt-4.1 --suite default
```

For now, the prefix must be repeated e.g. `openai/openai/gpt-4.1`, but we will support better names like `openai/gpt-4.1` in the future.