### PR TITLE
Remove tokenization from AnthropicMessagesClient

### DIFF
--- a/src/helm/clients/anthropic_client.py
+++ b/src/helm/clients/anthropic_client.py
@@ -1,4 +1,3 @@
-import dataclasses
 from typing import Any, Dict, List, Optional, TypedDict, Union, cast
 import json
 import os
@@ -28,7 +27,7 @@ from helm.common.tokenization_request import (
 )
 from helm.proxy.retry import NonRetriableException
 from helm.tokenizers.tokenizer import Tokenizer
-from helm.clients.client import CachingClient, truncate_sequence, truncate_and_tokenize_response_text
+from helm.clients.client import CachingClient, truncate_sequence
 
 try:
     from anthropic import Anthropic, BadRequestError
@@ -258,8 +257,6 @@ class AnthropicMessagesClient(CachingClient):
 
     def __init__(
         self,
-        tokenizer: Tokenizer,
-        tokenizer_name: str,
         cache_config: CacheConfig,
         thinking_budget_tokens: Optional[int] = None,
         anthropic_model_name: Optional[str] = None,
@@ -267,8 +264,6 @@ class AnthropicMessagesClient(CachingClient):
         stream: Optional[bool] = None,
     ):
         super().__init__(cache_config=cache_config)
-        self.tokenizer = tokenizer
-        self.tokenizer_name = tokenizer_name
         self.client = Anthropic(api_key=api_key)
         self.api_key: Optional[str] = api_key
         self.anthropic_model_name: Optional[str] = anthropic_model_name
@@ -450,21 +445,25 @@ class AnthropicMessagesClient(CachingClient):
                 )
 
             response_message: Message = Message.model_validate(raw_response)
-            response_text: Optional[str] = None
-            response_thinking: Optional[str] = None
+            text_blocks: List[str] = []
+            thinking_blocks: List[str] = []
             for content in response_message.content:
                 if isinstance(content, TextBlock):
-                    response_text = content.text
+                    text_blocks.append(content.text)
                 elif isinstance(content, ThinkingBlock):
-                    response_thinking = content.thinking
-            if response_text is None:
-                raise Exception("Anthropic response did not contain text block")
-            completion = truncate_and_tokenize_response_text(
-                response_text, request, self.tokenizer, self.tokenizer_name, original_finish_reason=""
+                    thinking_blocks.append(content.thinking)
+            if not text_blocks:
+                raise Exception("Anthropic response did not contain text blocks")
+            text_output = "".join(text_blocks)
+            thinking = Thinking(text="".join(thinking_blocks)) if thinking_blocks else None
+            completions.append(
+                GeneratedOutput(
+                    text=text_output,
+                    logprob=0.0,
+                    tokens=[],
+                    thinking=thinking,
+                )
             )
-            if response_thinking is not None:
-                completion = dataclasses.replace(completion, thinking=Thinking(text=response_thinking))
-            completions.append(completion)
 
         return RequestResult(
             success=True,


### PR DESCRIPTION
The Anthropic Claude API responses do not contain tokens. Previously, we did the tokenization locally, and then returned the tokens in HELM's response. This makes it so that we do not do the tokenization locally, and we do not return tokens in the HELM responses. This saves us from returning redundant information in HELM's response.