### PR TITLE
Allow using Anthropic models without configuration

### DIFF
--- a/src/helm/benchmark/model_deployment_registry.py
+++ b/src/helm/benchmark/model_deployment_registry.py
@@ -127,6 +127,7 @@ def get_model_deployment(name: str, warn_deprecated: bool = False) -> ModelDeplo
     deployment: Optional[ModelDeployment] = DEPLOYMENT_NAME_TO_MODEL_DEPLOYMENT.get(name)
 
     if not deployment:
+        import helm.benchmark.model_deployments.anthropic_model_deployments  # noqa: F401
         import helm.benchmark.model_deployments.huggingface_model_deployments  # noqa: F401
         import helm.benchmark.model_deployments.huggingface_inference_providers_model_deployments  # noqa: F401
         import helm.benchmark.model_deployments.litellm_model_deployments  # noqa: F401

--- a/src/helm/benchmark/model_deployments/anthropic_model_deployments.py
+++ b/src/helm/benchmark/model_deployments/anthropic_model_deployments.py
@@ -1,0 +1,12 @@
+from helm.benchmark.model_deployment_registry import ClientSpec, ModelDeployment, model_deployment_generator
+
+
+@model_deployment_generator("anthropic")
+def get_anthropic_model_deployment(name: str):
+    name_parts = name.split("/")
+    model_name = "/".join(name_parts[-2:])
+    return ModelDeployment(
+        name=name,
+        model_name=model_name,
+        client_spec=ClientSpec("helm.clients.anthropic_client.AnthropicMessagesClient"),
+    )


### PR DESCRIPTION
This allows using an Anthropic model without explicitly configuring the model in `model_deployments.yaml`.

This can be done by specifying `--models-to-run` (this is the preferred way):

```sh
helm-run -m 10 -r mmlu_pro --models-to-run anthropic/anthropic/claude-haiku-4-5 --suite default
```

This can be also done by specifying `model=`:

```sh
helm-run -m 10 -r mmlu_pro:model=anthropic/anthropic/claude-haiku-4-5 --suite default
```

For now, the prefix must be repeated e.g. `anthropic/anthropic/claude-haiku-4-5`, but we will support better names like `anthropic/claude-haiku-4-5` in the future.