### PR TITLE
Allow using OpenRouter models without configuration

### DIFF
--- a/src/helm/benchmark/model_deployment_registry.py
+++ b/src/helm/benchmark/model_deployment_registry.py
@@ -132,6 +132,7 @@ def get_model_deployment(name: str, warn_deprecated: bool = False) -> ModelDeplo
         import helm.benchmark.model_deployments.huggingface_inference_providers_model_deployments  # noqa: F401
         import helm.benchmark.model_deployments.litellm_model_deployments  # noqa: F401
         import helm.benchmark.model_deployments.openai_model_deployments  # noqa: F401
+        import helm.benchmark.model_deployments.openrouter_model_deployments  # noqa: F401
         import helm.benchmark.model_deployments.together_model_deployments  # noqa: F401
 
         for prefix, model_deployment_generator in _REGISTERED_MODEL_DEPLOYMENT_GENERATORS.items():

--- a/src/helm/benchmark/model_deployments/openrouter_model_deployments.py
+++ b/src/helm/benchmark/model_deployments/openrouter_model_deployments.py
@@ -1,0 +1,17 @@
+from helm.benchmark.model_deployment_registry import ClientSpec, ModelDeployment, model_deployment_generator
+
+
+@model_deployment_generator("openrouter")
+def get_openrouter_model_deployment(name: str):
+    name_parts = name.split("/")
+    model_name = "/".join(name_parts[-2:])
+    return ModelDeployment(
+        name=name,
+        model_name=model_name,
+        client_spec=ClientSpec(
+            "helm.clients.openrouter_client.OpenRouterClient",
+            args={
+                "openrouter_model_name": model_name,
+            },
+        ),
+    )

--- a/src/helm/benchmark/model_metadata_registry.py
+++ b/src/helm/benchmark/model_metadata_registry.py
@@ -191,7 +191,11 @@ def get_model_names_with_tag(tag: str) -> List[str]:
 
 def model_has_tag(model_name: str, tag: str) -> bool:
     """Return True if the model has the given tag. False otherwise."""
-    return tag in get_model_metadata(model_name).tags
+    try:
+        tags = get_model_metadata(model_name).tags
+    except ValueError:
+        tags = []
+    return tag in tags
 
 
 def get_all_text_models() -> List[str]:


### PR DESCRIPTION
This allows using an OpenRoutermodel without explicitly configuring the model in `model_deployments.yaml`.

This can be done by specifying `--models-to-run` (this is the preferred way):

```sh
helm-run -m 10 -r mmlu_pro --models-to-run openrouter/arcee-ai/trinity-large-preview:free --suite default
```

This can be also done by specifying `model=`:

```sh
helm-run -m 10 -r mmlu_pro:model=openrouter/arcee-ai/trinity-large-preview:free --suite default
```
