### PR TITLE
Fix MadinahQA scenario to include Context field for reading comprehension

### DIFF
--- a/src/helm/benchmark/scenarios/madinah_qa_scenario.py
+++ b/src/helm/benchmark/scenarios/madinah_qa_scenario.py
@@ -49,7 +49,16 @@ class MadinahQAScenario(Scenario):
         for split_name, dataset in dataset_splits.items():
             assert isinstance(dataset, datasets.Dataset)
             for row_index, row in enumerate(dataset):
-                input = Input(text=row["Question"])
+                # Include the Context field (reading passage) when available.
+                # The General subset has a Context passage for 602/612 questions;
+                # the Grammar subset has no Context (all null).
+                # This matches the original ArabicMMLU evaluation code and LightEval.
+                context = row.get("Context")
+                question = row["Question"]
+                if context and isinstance(context, str) and context.strip():
+                    input = Input(text=f"{context}\n\n{question}")
+                else:
+                    input = Input(text=question)
                 references: List[Reference] = []
                 correct_option_index = ord(row["Answer Key"]) - ord("A") + 1
                 for option_index in range(1, 6):


### PR DESCRIPTION
## Summary

The `MadinahQAScenario` drops the `Context` field (reading passage) when constructing the model input. This means 602/612 General subset questions are evaluated as reading comprehension **without the reading material**.

**Before (bug):**
```python
input = Input(text=row["Question"])
```

**After (fix):**
```python
context = row.get("Context")
question = row["Question"]
if context and isinstance(context, str) and context.strip():
    input = Input(text=f"{context}\n\n{question}")
else:
    input = Input(text=question)
```

## Why this is a bug

The original dataset authors and other evaluation frameworks both include the Context field:

- **MBZUAI official code** ([mbzuai-nlp/ArabicMMLU](https://github.com/mbzuai-nlp/ArabicMMLU), `util_prompt.py`):
  ```python
  question = row['Question'] if pd.isna(row['Context']) else f"{row['Context']}\n\n{row['Question']}"
  ```

- **LightEval / OALL v2 leaderboard** ([huggingface/lighteval](https://github.com/huggingface/lighteval), `arabic.py`):
  ```python
  query = f"{instruction}\nالسياق:\n{line['Context']}\nالسؤال:\n{line['Question']}\n"
  ```

Without the passage, questions like "Read the following text, then choose the correct answer for [blank]" are unanswerable since there is no text to read.

## Impact

- **General subset (612 questions):** 602 questions have a Context passage that is currently dropped. Models score ~79% by guessing from question fragments alone. Scores are not comparable to OALL v2 leaderboard results.
- **Grammar subset (365 questions):** Unaffected - Context column is entirely null, so no behavior change.

Fixes #4126