### PR TITLE
Allow using auto-generated model deployments for models with two-part names

### DIFF
--- a/src/helm/benchmark/model_deployment_registry.py
+++ b/src/helm/benchmark/model_deployment_registry.py
@@ -227,9 +227,13 @@ def get_default_model_deployment_for_model(
             hlog("If you want to use a different model deployment, please specify it explicitly.")
         return chosen_deployment.name
 
-    # Some models are added but have no deployments yet.
-    # In this case, we return None.
-    return None
+    # See if we can auto-generate a model deployment for this model.
+    # Use the model deployment as the default model deployment if so.
+    # Otherwise, return None.
+    try:
+        return get_model_deployment(model_name).name
+    except ValueError:
+        return None
 
 
 ModelDeploymentGenerator = Callable[[str], ModelDeployment]

--- a/src/helm/benchmark/run.py
+++ b/src/helm/benchmark/run.py
@@ -24,6 +24,7 @@ from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.executor import ExecutionSpec
 from helm.benchmark.runner import Runner, RunSpec, set_benchmark_output_path
 from helm.benchmark.run_spec_factory import construct_run_specs
+from helm.benchmark.model_deployment_registry import get_model_deployment
 
 
 def run_entries_to_run_specs(
@@ -323,8 +324,9 @@ def helm_run(args):
         all_models = set(model_metadata_registry.get_all_models())
         for model_to_run in args.models_to_run:
             if model_to_run not in all_models:
-                name_parts = model_to_run.split("/")
-                if len(name_parts) <= 2:
+                try:
+                    get_model_deployment(model_to_run)
+                except ValueError:
                     raise Exception(f"Unknown model '{model_to_run}' passed to --models-to-run")
     else:
         model_expander_wildcard_pattern = re.compile(


### PR DESCRIPTION
Previously, pull requests such as #4107 allowed using models with >2 part names without explicitly configuring the model deployments in `model_deployments.yaml`. For example:

```sh
helm-run -m 10 -r mmlu_pro --models-to-run openai/openai/gpt-4.1 --suite default
# Or alternatively:
helm-run -m 10 -r mmlu_pro:model=openai/openai/gpt-4.1 --suite default
```

This pull requests allows doing so while using two-part model names e.g. `openai/gpt-4.1` instead of `openai/openai/gpt-4.1`. For example:

```sh
helm-run -m 10 -r mmlu_pro --models-to-run openai/gpt-4.1 --suite default
# Or alternatively:
helm-run -m 10 -r mmlu_pro:model=openai/gpt-4.1 --suite default
```