### PR TITLE
Set extra-build-dependencies for openai-whisper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -462,7 +462,7 @@ override-dependencies = [
 ]
 
 [tool.uv.extra-build-dependencies]
-openai-whisper = ["setuptools>=80.8.0"]
+openai-whisper = ["setuptools==80.10.2"]
 
 [tool.setuptools]
 package-dir = { "" = "src" }


### PR DESCRIPTION
Reverts #4157 (because it adds `pkg_resources`, but that is provided by `setuptools` rather than being its own package)