### PR TITLE
Add per_instance_stats.json download link

### DIFF
--- a/helm-frontend/src/routes/Run.tsx
+++ b/helm-frontend/src/routes/Run.tsx
@@ -15,6 +15,7 @@ import getRunSpecByName, {
   getRunSpecByNameUrl,
 } from "@/services/getRunSpecByName";
 import { getScenarioStateByNameUrl } from "@/services/getScenarioStateByName";
+import { getPerInstanceStatsByNameUrl } from "@/services/getPerInstanceStatsByName";
 import Tab from "@/components/Tab";
 import Tabs from "@/components/Tabs";
 import Loading from "@/components/Loading";
@@ -163,6 +164,14 @@ export default function Run() {
               target="_blank"
             >
               Full JSON
+            </a>
+            <a
+              className="link link-primary link-hover"
+              href={getPerInstanceStatsByNameUrl(runSpec.name, runSuite)}
+              download="true"
+              target="_blank"
+            >
+              Per-Instance Stats JSON
             </a>
           </div>
         </div>

--- a/helm-frontend/src/services/getPerInstanceStatsByName.ts
+++ b/helm-frontend/src/services/getPerInstanceStatsByName.ts
@@ -1,0 +1,11 @@
+import getBenchmarkEndpoint from "@/utils/getBenchmarkEndpoint";
+import getBenchmarkSuite from "@/utils/getBenchmarkSuite";
+
+export function getPerInstanceStatsByNameUrl(
+  runName: string,
+  suite?: string,
+): string {
+  return getBenchmarkEndpoint(
+    `/runs/${suite || getBenchmarkSuite()}/${runName}/per_instance_stats.json`,
+  );
+}


### PR DESCRIPTION
Fixes #1705

Adds a "Per-Instance Stats JSON" download link alongside the existing "Spec JSON" and "Full JSON" links on the run page. Follows the same pattern as the existing `getScenarioStateByNameUrl` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)