### PR TITLE
Add link to per_instance_stats.json on frontend

### DIFF
--- a/helm-frontend/src/routes/Run.tsx
+++ b/helm-frontend/src/routes/Run.tsx
@@ -14,6 +14,7 @@ import type MetricFieldMap from "@/types/MetricFieldMap";
 import getRunSpecByName, {
   getRunSpecByNameUrl,
 } from "@/services/getRunSpecByName";
+import { getPerInstanceStatsByNameUrl } from "@/services/getPerInstanceStatsByName";
 import { getScenarioStateByNameUrl } from "@/services/getScenarioStateByName";
 import Tab from "@/components/Tab";
 import Tabs from "@/components/Tabs";
@@ -163,6 +164,14 @@ export default function Run() {
               target="_blank"
             >
               Full JSON
+            </a>
+            <a
+              className="link link-primary link-hover"
+              href={getPerInstanceStatsByNameUrl(runSpec.name, runSuite)}
+              download="true"
+              target="_blank"
+            >
+              Per-Instance Stats JSON
             </a>
           </div>
         </div>

--- a/helm-frontend/src/services/getPerInstanceStatsByName.ts
+++ b/helm-frontend/src/services/getPerInstanceStatsByName.ts
@@ -1,0 +1,11 @@
+import getBenchmarkEndpoint from "@/utils/getBenchmarkEndpoint";
+import getBenchmarkSuite from "@/utils/getBenchmarkSuite";
+
+export function getPerInstanceStatsByNameUrl(
+  runName: string,
+  suite?: string,
+): string {
+  return getBenchmarkEndpoint(
+    `/runs/${suite || getBenchmarkSuite()}/${runName}/per_instance_stats.json`,
+  );
+}


### PR DESCRIPTION
Noticed the frontend Run page has a download link for `scenario_state.json` (Full JSON) but not for `per_instance_stats.json`. Added the missing link following the same pattern as the existing one.

- Created `getPerInstanceStatsByName.ts` service (mirrors `getScenarioStateByName.ts`)
- Added "Per-Instance Stats JSON" download link in `Run.tsx` next to "Full JSON"

Closes #1705