### PR TITLE
Fix GenderPerturbation regex to match words at text boundaries

### DIFF
--- a/src/helm/benchmark/augmentations/gender_perturbation.py
+++ b/src/helm/benchmark/augmentations/gender_perturbation.py
@@ -194,8 +194,8 @@ class GenderPerturbation(TextPerturbation):
 
     def substitute_word(self, text: str, word: str, synonym: str, rng: Random) -> str:
         """Substitute the occurences of word in text with its synonym with self.probability"""
-        # Pattern capturing any occurence of given word in the text, surrounded by non-alphanumeric characters
-        pattern = f"[^\\w]({word})[^\\w]"
+        # Pattern capturing any occurence of given word in the text, using word boundaries
+        pattern = f"\\b({word})\\b"
 
         # Substitution function
         def sub_func(m: re.Match):


### PR DESCRIPTION
## Summary
- Fixes #1732: `GenderPerturbation` failed to perturb gendered words at the beginning or end of text
- Changed the regex pattern in `substitute_word()` from `[^\w](word)[^\w]` (which requires non-alphanumeric characters on both sides) to `\b(word)\b` (which uses zero-width word boundaries)
- This allows matching words like "dad" in "dad said it is okay" and "son" in "Sure he did son"

## Test plan
- [x] Verified manually that `\b` correctly matches words at start, end, and middle of text
- [x] Verified that `\b` does not match substrings (e.g., "dad" in "granddad")
- [x] Existing test `test_gender_term_perturbation_edge_word` covers this exact scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)