### PR TITLE
Fix GenderPerturbation to match words at text boundaries

### DIFF
--- a/src/helm/benchmark/augmentations/gender_perturbation.py
+++ b/src/helm/benchmark/augmentations/gender_perturbation.py
@@ -194,19 +194,15 @@ class GenderPerturbation(TextPerturbation):
 
     def substitute_word(self, text: str, word: str, synonym: str, rng: Random) -> str:
         """Substitute the occurences of word in text with its synonym with self.probability"""
-        # Pattern capturing any occurence of given word in the text, surrounded by non-alphanumeric characters
-        pattern = f"[^\\w]({word})[^\\w]"
+        # Pattern capturing any occurence of given word in the text using word boundaries
+        pattern = f"\\b({word})\\b"
 
         # Substitution function
         def sub_func(m: re.Match):
-            match_str = m.group(0)  # The full match (e.g. " Man ", " Man,", " Man.", "-Man.")
             match_word = m.group(1)  # Captured group (e.g. "Man")
             if rng.uniform(0, 1) < self.prob:
-                syn = match_case(match_word, synonym)  # Synoynm with matching case (e.g. "Woman")
-                match_str = match_str.replace(
-                    match_word, syn
-                )  # Synonym placed in the matching group (e.g. " Woman ", " Woman,", " Woman.", "-Woman")
-            return match_str
+                return match_case(match_word, synonym)  # Synonym with matching case (e.g. "Woman")
+            return match_word
 
         # Execute the RegEx
         return re.sub(pattern, sub_func, text, flags=re.IGNORECASE)


### PR DESCRIPTION
## Summary
- Fixed regex pattern in `GenderPerturbation.substitute_word` that failed to match words at the beginning or end of text
- Changed pattern from `[^\w](word)[^\w]` (requires surrounding non-alphanumeric chars) to `\b(word)\b` (word boundaries)
- Simplified the substitution function since `\b` doesn't capture surrounding characters

## Test plan
- [ ] Verify words at the start of text are now perturbed (e.g., `"Man went home"` -> `"Woman went home"`)
- [ ] Verify words at the end of text are now perturbed (e.g., `"I am a man"` -> `"I am a woman"`)
- [ ] Verify mid-text words continue to be perturbed as before
- [ ] Verify case matching still works correctly
- [ ] Run existing test suite: `pytest src/helm/benchmark/augmentations/test_gender_perturbation.py`

Fixes #1732

🤖 Generated with [Claude Code](https://claude.com/claude-code)