### PR TITLE
Lazily load model in HuggingFaceClient

### DIFF
--- a/src/helm/clients/huggingface_client.py
+++ b/src/helm/clients/huggingface_client.py
@@ -325,16 +325,16 @@ class HuggingFaceClient(CachingClient):
         pretrained_model_name_or_path = (
             self._pretrained_model_name_or_path if self._pretrained_model_name_or_path else request.model
         )
-        huggingface_model: HuggingFaceServer = HuggingFaceServerFactory.get_server(
-            helm_model_name=request.model,
-            pretrained_model_name_or_path=pretrained_model_name_or_path,
-            wrapped_tokenizer=self._wrapped_tokenizer,
-            **self._kwargs,
-        )
 
         try:
 
             def do_it() -> Dict[str, Any]:
+                huggingface_model: HuggingFaceServer = HuggingFaceServerFactory.get_server(
+                    helm_model_name=request.model,
+                    pretrained_model_name_or_path=pretrained_model_name_or_path,
+                    wrapped_tokenizer=self._wrapped_tokenizer,
+                    **self._kwargs,
+                )
                 return huggingface_model.serve_request(raw_request)
 
             cache_key = CachingClient.make_cache_key(raw_request, request)


### PR DESCRIPTION
This allows using cached responses without having to load the model first.