### PR TITLE
Fix duplicate entries in med_dialog dataset (#3746)

### DIFF
--- a/src/helm/benchmark/scenarios/med_dialog_scenario.py
+++ b/src/helm/benchmark/scenarios/med_dialog_scenario.py
@@ -133,10 +133,15 @@ class MedDialogScenario(Scenario):
 
                 with open(split_path, "r") as f:
                     examples: List = json.load(f)["data"]
+                    seen_sources: set = set()
                     for example in examples:
+                        src_text = example["src"]
+                        if src_text in seen_sources:
+                            continue
+                        seen_sources.add(src_text)
                         instances.append(
                             Instance(
-                                input=Input(text=example["src"]),
+                                input=Input(text=src_text),
                                 references=[Reference(Output(text=example["tgt"]), tags=[CORRECT_TAG])],
                                 split=split,
                             )


### PR DESCRIPTION
## Summary
- Fixes #3746: The med_dialog dataset (especially the icliniq split) contains many duplicate question entries
- Adds deduplication logic in `MedDialogScenario.get_instances()` that filters out duplicate entries based on the `src` (source question) field, keeping the first occurrence of each unique source text

## Test plan
- [ ] Verify that the icliniq and healthcaremagic splits no longer contain duplicate `src` entries
- [ ] Confirm instance counts are reduced as expected after deduplication
- [ ] Run existing med_dialog scenario tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)