### PR TITLE
Fix print_summary() showing relevance scores under COHERENCE

### DIFF
--- a/src/helm/benchmark/metrics/summarization_metrics.py
+++ b/src/helm/benchmark/metrics/summarization_metrics.py
@@ -493,7 +493,7 @@ class SummarizationHumanEvalAnalyzer:
         print("=" * 40)
 
         print("COHERENCE")
-        for model, score in self._compute_average(self.relevance):
+        for model, score in self._compute_average(self.coherence):
             print(f"{model:40}: {score:.4f}")
         print("=" * 40)
 


### PR DESCRIPTION
## Summary

`SummarizationHumanEvalAnalyzer.print_summary()` has a copy-paste bug where the COHERENCE section displays relevance scores instead of coherence scores.

**Bug:** Line 496 calls `self._compute_average(self.relevance)` under the `print("COHERENCE")` heading.  
**Root cause:** The RELEVANCE block was copied to create the COHERENCE block, but `self.relevance` was not changed to `self.coherence`.  
**Evidence:** The sibling method `dump_test_result()` (line 536) correctly uses `self.coherence` for the coherence section.

**Fix:** Change `self.relevance` → `self.coherence` on line 496.

## Test plan
- [x] Verified `dump_test_result()` uses `self.coherence` — confirms intended behavior
- [x] Confirmed the three sections (faithfulness, relevance, coherence) each have distinct data dicts
- [x] One-line change, no side effects