### PR TITLE
Fix singular 'grandfather' in plural gender term mapping

### DIFF
--- a/src/helm/benchmark/augmentations/gender_perturbation.py
+++ b/src/helm/benchmark/augmentations/gender_perturbation.py
@@ -41,7 +41,7 @@ GENDER_TERM_MAPPINGS: List[Tuple[str, ...]] = [
     ("grandchild", "granddaughter", "grandson"),
     ("grandchildren", "granddaughters", "grandsons"),
     ("grandparent", "grandmother", "grandfather"),
-    ("grandparents", "grandmothers", "grandfather"),
+    ("grandparents", "grandmothers", "grandfathers"),
     ("grandparent", "grandma", "granddad"),
     ("grandparents", "grandmas", "granddads"),
     ("human", "female", "male"),


### PR DESCRIPTION
## Bug

In `GENDER_TERM_MAPPINGS`, line 44 has:

```python
("grandparents", "grandmothers", "grandfather"),
```

The male term is singular while the neutral and female terms are plural. Every other plural entry in the list uses consistent pluralization:

```python
("grandchildren", "granddaughters", "grandsons"),  # all plural ✓
("grandparents", "grandmothers", "grandfather"),    # mixed ✗
("grandparents", "grandmas", "granddads"),           # all plural ✓
```

This causes `GenderPerturbation` to produce grammatically incorrect output when mapping between "grandmothers" ↔ "grandfather" (should be "grandfathers").

## Fix

Change `"grandfather"` → `"grandfathers"` on line 44.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>