### PR TITLE
Fix _apply_output_mapping_pattern returning wrong match results

### DIFF
--- a/src/helm/benchmark/metrics/evaluate_reference_metrics.py
+++ b/src/helm/benchmark/metrics/evaluate_reference_metrics.py
@@ -402,9 +402,9 @@ def _apply_output_mapping_pattern(pattern: str, prediction: str) -> str:
     if not match:
         return ""
     elif match.groups():
-        return match.group(0)
+        return match.group(1)
     else:
-        return match.string
+        return match.group(0)
 
 
 # TODO This should probably be made into an implementation of MetricInterface. For now it lives here

--- a/src/helm/benchmark/presentation/run_display.py
+++ b/src/helm/benchmark/presentation/run_display.py
@@ -271,9 +271,9 @@ def write_run_display_json(run_path: str, run_spec: RunSpec, schema: Schema, ski
                 if not match:
                     output_to_map = ""
                 elif match.groups():
-                    output_to_map = match.group(0)
+                    output_to_map = match.group(1)
                 else:
-                    output_to_map = match.string
+                    output_to_map = match.group(0)
             mapped_output = request_state.output_mapping.get(output_to_map)
         instance_id_to_instance[(request_state.instance.id, request_state.instance.perturbation)] = (
             request_state.instance


### PR DESCRIPTION
## Summary

`_apply_output_mapping_pattern` in both `evaluate_reference_metrics.py` and `run_display.py` has two bugs that contradict the documented contract in `adapter_spec.py` (lines 149–151):

1. **With capture groups**: `match.group(0)` (the whole match) is returned instead of `match.group(1)` (the captured group). The docstring says: *"If the pattern has a group, the output mapping will be applied to the group of the first match."*

2. **Without capture groups**: `match.string` (the **entire input string**) is returned instead of `match.group(0)` (the matched substring). `re.Match.string` is a property that returns the original string passed to `re.search()`, not the match. The docstring says: *"If the pattern has no group, the output mapping will be applied to the first match."*

The bug is currently masked because the only pattern in use (`"(أ|ب|ج|د|هـ)"`) wraps the entire alternation in one group, making `match.group(0) == match.group(1)`. The `else` branch (no capture groups) has never been triggered in practice. But any pattern like `r"answer:\s*(A|B|C|D)"` would silently return the wrong value, causing the output mapping lookup to fail.

**Fix**: Return `match.group(1)` for capture groups and `match.group(0)` for no capture groups, in both files.

## Test plan

- [x] Verified `re.Match.string` returns the full input, not the matched substring
- [x] Verified the fix matches the documented contract in `adapter_spec.py`
- [ ] Existing tests should continue to pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)