### PR TITLE
Fix operator precedence skipping robustness metric group check

### DIFF
--- a/src/helm/benchmark/presentation/torr_robustness_summarizer.py
+++ b/src/helm/benchmark/presentation/torr_robustness_summarizer.py
@@ -101,7 +101,7 @@ class ToRRRobustnessSummarizer(Summarizer):
 
     def write_groups(self):
         for run_group in self.schema.run_groups:
-            if self.ROBUSTNESS_METRIC_GROUP_NAME and self.PERFORMANCE_METRIC_GROUP_NAME in run_group.metric_groups:
+            if self.ROBUSTNESS_METRIC_GROUP_NAME in run_group.metric_groups and self.PERFORMANCE_METRIC_GROUP_NAME in run_group.metric_groups:
                 self.run_group_to_model_name_to_robustness[run_group.name] = self._compute_robustness_for_run_group(
                     run_group
                 )


### PR DESCRIPTION
## Bug

In `ToRRRobustnessSummarizer.write_groups()`, line 104:

```python
if self.ROBUSTNESS_METRIC_GROUP_NAME and self.PERFORMANCE_METRIC_GROUP_NAME in run_group.metric_groups:
```

Due to Python operator precedence, this evaluates as:

```python
if ("robustness_metrics") and ("performance_metrics" in run_group.metric_groups):
```

`"robustness_metrics"` is a non-empty string (always truthy), so the `in` check is only performed for `PERFORMANCE_METRIC_GROUP_NAME`. The `ROBUSTNESS_METRIC_GROUP_NAME` membership test never happens.

## Root cause

Missing `in run_group.metric_groups` after the first operand.

## Fix

```python
if self.ROBUSTNESS_METRIC_GROUP_NAME in run_group.metric_groups and self.PERFORMANCE_METRIC_GROUP_NAME in run_group.metric_groups:
```

🤖 Generated with [Claude Code](https://claude.ai/code)