### PR TITLE
Add LICA-Bench (graphic design VLM) integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The HELM framework was used in the following papers for evaluating models.
 - **Holistic Evaluation of Vision-Language Models (VHELM)** - [paper](https://arxiv.org/abs/2410.07112), [leaderboard](https://crfm.stanford.edu/helm/vhelm/latest/), [documentation](https://crfm-helm.readthedocs.io/en/latest/vhelm/)
 - **Holistic Evaluation of Text-To-Image Models (HEIM)** - [paper](https://arxiv.org/abs/2311.04287), [leaderboard](https://crfm.stanford.edu/helm/heim/latest/), [documentation](https://crfm-helm.readthedocs.io/en/latest/heim/)
 - **Image2Struct: Benchmarking Structure Extraction for Vision-Language Models** - [paper](https://arxiv.org/abs/2410.22456)
+- **LICA-Bench (graphic design layout and VLM evaluation)** - [code](https://github.com/purvanshi/lica-bench), [documentation in HELM](docs/lica_bench.md)
 - **Enterprise Benchmarks for Large Language Model Evaluation** - [paper](https://arxiv.org/abs/2410.12857), [documentation](https://crfm-helm.readthedocs.io/en/latest/enterprise_benchmark/)
 - **The Mighty ToRR: A Benchmark for Table Reasoning and Robustness** - [paper](https://arxiv.org/abs/2502.19412), [leaderboard](https://crfm.stanford.edu/helm/torr/latest/)
 - **Efficient Benchmarking of Language Models** - [paper](https://arxiv.org/abs/2308.11696), [documentation](https://crfm-helm.readthedocs.io/en/latest/efficient_benchmarking/)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -41,3 +41,4 @@ Additional steps are required for multimodal evaluations:
 
 - **HEIM (Text-to-image Model Evaluation)** - to install the additional dependencies to run HEIM (text-to-image evaluation), refer to the [HEIM documentation](heim.md).
 - **VHELM (Vision-Language Models)** - To install the additional dependencies to run VHELM (Vision-Language Models), refer to the [VHELM documentation](vhelm.md).
+- **LICA-Bench (graphic design VLM tasks)** - Install with `pip install "crfm-helm[lica-bench]"` and follow [LICA-Bench in HELM](lica_bench.md).

--- a/docs/lica_bench.md
+++ b/docs/lica_bench.md
@@ -1,0 +1,56 @@
+# LICA-Bench (HELM integration)
+
+[LICA-Bench](https://github.com/purvanshi/lica-bench) evaluates vision-language models on graphic design tasks (layout, typography, SVG, templates, temporal/video, Lottie, and category understanding). HELM exposes each task as the scenario **`lica_bench`** so you can run evaluations through `helm-run` alongside other benchmarks.
+
+## Setup
+
+1. Install HELM with the optional extra:
+
+   ```bash
+   pip install "crfm-helm[lica-bench]"
+   ```
+
+2. Download the dataset bundle (contains `lica-data/` and `benchmarks/`). From the lica-bench repository:
+
+   ```bash
+   python scripts/download_data.py
+   ```
+
+   Or unpack the release zip so you have a single root directory (referred to below as `lica-benchmarks-dataset`).
+
+3. Point HELM at that root, either:
+
+   - **Environment variable:** `export LICA_BENCH_DATASET_ROOT=/path/to/lica-benchmarks-dataset`
+   - **Run entry:** pass `dataset_root=...` (avoid commas in the path; they separate run-entry fields).
+
+## Run entries
+
+Run spec name: **`lica_bench`**.
+
+Arguments:
+
+| Argument        | Required | Description |
+|-----------------|----------|-------------|
+| `benchmark_id`  | yes      | Task id (`category-1`, `svg-3`, …). List tasks with lica-bench’s `scripts/run_benchmarks.py --list`. |
+| `dataset_root`  | no       | Overrides `LICA_BENCH_DATASET_ROOT` if set. |
+| `max_instances` | no       | Limit instances (useful for smoke tests). |
+
+Example (with env var set):
+
+```text
+lica_bench:benchmark_id=category-1,model=openai/gpt-4o
+```
+
+Example (explicit root):
+
+```text
+lica_bench:benchmark_id=svg-1,dataset_root=/data/lica-benchmarks-dataset,model=openai/gpt-4o
+```
+
+## Metrics
+
+HELM reports generic **text generation** metrics (exact match, quasi-exact match, F1, ROUGE, BLEU, CIDEr). Many lica-bench tasks define **task-specific** scores (e.g. top-5 accuracy, layout IoU, generation quality). For those official numbers, use the native lica-bench CLI or Python API as documented in the [lica-bench README](https://github.com/purvanshi/lica-bench).
+
+## Citation
+
+If you use LICA-Bench or the Lica dataset, cite the dataset as indicated in the [lica-bench repository](https://github.com/purvanshi/lica-bench#citation).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
     - downloading_raw_results.md
     - reproducing_leaderboards.md
     - benchmark.md
+    - lica_bench.md
     - huggingface_models.md
   - Papers:
     - heim.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,7 @@ seahelm = [
 
 # Graphic design / layout VLM benchmarks (https://github.com/purvanshi/lica-bench)
 lica-bench = [
-    "lica-bench>=0.1.0",
+    "lica-bench @ git+https://github.com/purvanshi/lica-bench.git",
 ]
 
 # Model extras

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,11 @@ seahelm = [
     "python-crfsuite~=0.9.11",
 ]
 
+# Graphic design / layout VLM benchmarks (https://github.com/purvanshi/lica-bench)
+lica-bench = [
+    "lica-bench>=0.1.0",
+]
+
 # Model extras
 accelerate = [
     "accelerate~=0.25",

--- a/src/helm/benchmark/run_specs/lica_bench_run_specs.py
+++ b/src/helm/benchmark/run_specs/lica_bench_run_specs.py
@@ -1,0 +1,83 @@
+"""Run spec functions for `lica-bench` (graphic design VLM benchmarks)."""
+
+from typing import List, Optional
+
+from helm.benchmark.adaptation.adapter_spec import AdapterSpec
+from helm.benchmark.adaptation.adapters.adapter_factory import ADAPT_GENERATION_MULTIMODAL
+from helm.benchmark.metrics.common_metric_specs import get_basic_metric_specs
+from helm.benchmark.metrics.metric import MetricSpec
+from helm.benchmark.run_spec import RunSpec, run_spec_function
+from helm.benchmark.scenarios.scenario import ScenarioSpec
+
+
+def _lica_bench_adapter_spec() -> AdapterSpec:
+    """Generous token budget for multi-line or structured answers (e.g. SVG snippets, lists)."""
+    return AdapterSpec(
+        method=ADAPT_GENERATION_MULTIMODAL,
+        global_prefix="",
+        instructions="Follow the prompt and answer completely. Use the format implied by the prompt.",
+        input_prefix="",
+        input_suffix="\n",
+        output_prefix="Answer: ",
+        output_suffix="\n",
+        instance_prefix="\n",
+        max_train_instances=0,
+        num_outputs=1,
+        max_tokens=2048,
+        stop_sequences=[],
+        temperature=0.0,
+        random=None,
+    )
+
+
+def _lica_bench_metric_specs() -> List[MetricSpec]:
+    return get_basic_metric_specs(
+        [
+            "exact_match",
+            "quasi_exact_match",
+            "quasi_leave_articles_exact_match",
+            "f1_score",
+            "rouge_l",
+            "bleu_1",
+            "bleu_4",
+            "cider",
+        ]
+    )
+
+
+@run_spec_function("lica_bench")
+def get_lica_bench_spec(
+    benchmark_id: str,
+    dataset_root: str = "",
+    max_instances: Optional[int] = None,
+) -> RunSpec:
+    """
+    Run a single lica-bench task (``category-1``, ``svg-2``, …).
+
+    :param benchmark_id: Task id as defined in lica-bench (see ``python -m design_benchmarks`` or
+        ``scripts/run_benchmarks.py --list`` in the lica-bench repo).
+    :param dataset_root: Path to the unpacked ``lica-benchmarks-dataset`` directory. If empty,
+        uses the ``LICA_BENCH_DATASET_ROOT`` environment variable.
+    :param max_instances: Optional cap on the number of instances (for dry runs).
+    """
+    scenario_spec = ScenarioSpec(
+        class_name="helm.benchmark.scenarios.vision_language.lica_bench_scenario.LicaBenchScenario",
+        args={
+            "benchmark_id": benchmark_id,
+            "dataset_root": dataset_root,
+            "max_instances": max_instances,
+        },
+    )
+
+    adapter_spec = _lica_bench_adapter_spec()
+    metric_specs = _lica_bench_metric_specs()
+
+    dr_part = f",dataset_root={dataset_root}" if dataset_root else ""
+    mi_part = f",max_instances={max_instances}" if max_instances is not None else ""
+    return RunSpec(
+        name=f"lica_bench:benchmark_id={benchmark_id}{dr_part}{mi_part}",
+        scenario_spec=scenario_spec,
+        adapter_spec=adapter_spec,
+        metric_specs=metric_specs,
+        groups=["lica_bench", f"lica_bench_{benchmark_id}"],
+    )

--- a/src/helm/benchmark/scenarios/vision_language/lica_bench_scenario.py
+++ b/src/helm/benchmark/scenarios/vision_language/lica_bench_scenario.py
@@ -1,0 +1,181 @@
+"""
+LICA-Bench: evaluation of vision-language models on graphic design understanding and generation.
+
+This scenario wraps tasks from `lica-bench` (import name ``design_benchmarks``): layout, typography,
+SVG, templates, animation, and related benchmarks over the
+`Lica dataset <https://github.com/purvanshi/lica-dataset>`_.
+
+Install the optional HELM extra ``crfm-helm[lica-bench]``, download the dataset bundle
+(``lica-benchmarks-dataset/``), and set ``dataset_root`` on the run entry or the environment
+variable ``LICA_BENCH_DATASET_ROOT``.
+
+References:
+
+- Benchmark code: https://github.com/purvanshi/lica-bench
+- Paper-style description: see the lica-bench README on GitHub
+
+**Metrics:** HELM reports standard text generation metrics (exact match, ROUGE, etc.). Task-specific
+scores from lica-bench (for example top-5 accuracy on category tasks) should be computed with the
+native ``lica-bench`` runner when needed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, List, Optional
+
+from helm.benchmark.scenarios.scenario import CORRECT_TAG, TEST_SPLIT, Instance, Input, Output, Reference, Scenario
+from helm.common.general import ensure_directory_exists
+from helm.common.hierarchical_logger import hlog
+from helm.common.media_object import MediaObject, MultimediaObject
+
+LICA_BENCH_DATASET_ROOT_ENV: str = "LICA_BENCH_DATASET_ROOT"
+
+# Cap appended JSON metadata so prompts stay bounded.
+_MAX_METADATA_CHARS: int = 200_000
+
+
+def _require_lica_bench():
+    try:
+        from design_benchmarks import BenchmarkRegistry  # noqa: F401
+        from design_benchmarks.models.base import ModelInput  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "The lica-bench scenario requires the optional dependency. Install with:\n"
+            '  pip install "crfm-helm[lica-bench]"'
+        ) from exc
+
+
+def _extension_to_mime(path: str) -> str:
+    ext = Path(path).suffix.lower()
+    return {
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".webp": "image/webp",
+        ".gif": "image/gif",
+        ".mp4": "video/mp4",
+        ".webm": "video/webm",
+        ".svg": "image/svg+xml",
+    }.get(ext, "image/png")
+
+
+def _serialize_ground_truth(value: Any) -> str:
+    if isinstance(value, (dict, list, tuple)):
+        return json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+    return str(value)
+
+
+def _write_bytes_image(data: bytes, tmp_dir: str, stem: str) -> str:
+    ensure_directory_exists(tmp_dir)
+    path = os.path.join(tmp_dir, f"{stem}.bin.png")
+    with open(path, "wb") as f:
+        f.write(data)
+    return path
+
+
+class LicaBenchScenario(Scenario):
+    """Scenario backed by a single lica-bench task (e.g. ``category-1``, ``svg-1``)."""
+
+    name: str = "lica_bench"
+    description: str = (
+        "Graphic design benchmarks from "
+        "[lica-bench](https://github.com/purvanshi/lica-bench) "
+        "(layout, typography, SVG, templates, temporal, Lottie, category)."
+    )
+    tags: List[str] = ["vision-language", "lica-bench"]
+
+    def __init__(self, benchmark_id: str, dataset_root: str = "", max_instances: Optional[int] = None):
+        super().__init__()
+        self._benchmark_id: str = benchmark_id
+        resolved_root = (dataset_root or "").strip() or os.environ.get(LICA_BENCH_DATASET_ROOT_ENV, "")
+        if not resolved_root:
+            raise ValueError(
+                "LicaBenchScenario needs a dataset root: pass dataset_root in the scenario args, "
+                f"or set the {LICA_BENCH_DATASET_ROOT_ENV} environment variable to your "
+                "lica-benchmarks-dataset directory."
+            )
+        self._dataset_root: str = str(Path(resolved_root).expanduser().resolve())
+        self._max_instances: Optional[int] = int(max_instances) if max_instances is not None else None
+
+    def _model_input_to_multimedia(self, model_input: Any, sample_id: str, tmp_dir: str) -> Optional[MultimediaObject]:
+        from design_benchmarks.models.base import ModelInput
+
+        if not isinstance(model_input, ModelInput):
+            hlog(f"Skipping sample {sample_id}: expected ModelInput, got {type(model_input)!r}.")
+            return None
+
+        text = model_input.text or ""
+        meta = model_input.metadata or {}
+        if meta:
+            meta_str = json.dumps(meta, ensure_ascii=False, default=str)
+            if len(meta_str) > _MAX_METADATA_CHARS:
+                meta_str = meta_str[:_MAX_METADATA_CHARS] + "\n...[truncated]"
+            text = f"{text}\n\n[benchmark_metadata JSON]\n{meta_str}" if text else f"[benchmark_metadata JSON]\n{meta_str}"
+
+        media_objects: List[MediaObject] = []
+        if text:
+            media_objects.append(MediaObject(text=text, content_type="text/plain"))
+
+        any_media_ok = False
+        for i, img in enumerate(model_input.images or []):
+            location: Optional[str] = None
+            if isinstance(img, (str, Path)):
+                location = str(Path(img).expanduser().resolve())
+                if not os.path.isfile(location):
+                    hlog(f"Skipping sample {sample_id}: missing media file: {location}")
+                    return None
+            elif isinstance(img, bytes):
+                location = _write_bytes_image(img, tmp_dir, f"{sample_id}_{i}")
+            else:
+                hlog(f"Skipping sample {sample_id}: unsupported image payload type {type(img)!r}.")
+                return None
+
+            media_objects.append(MediaObject(location=location, content_type=_extension_to_mime(location)))
+            any_media_ok = True
+
+        if not media_objects:
+            hlog(f"Skipping sample {sample_id}: empty model input.")
+            return None
+
+        # Multimodal adapter expects non-empty multimedia_content; text-only is valid.
+        if not any_media_ok and not text:
+            return None
+
+        return MultimediaObject(media_objects=media_objects)
+
+    def get_instances(self, output_path: str) -> List[Instance]:
+        _require_lica_bench()
+        from design_benchmarks import BenchmarkRegistry
+        from design_benchmarks.models.base import Modality
+
+        registry = BenchmarkRegistry()
+        registry.discover()
+        bench = registry.get(self._benchmark_id)
+
+        data_dir = bench.resolve_data_dir(self._dataset_root)
+        samples = bench.load_data(data_dir, n=self._max_instances, dataset_root=self._dataset_root)
+
+        tmp_dir = os.path.join(output_path, "lica_bench_media")
+        ensure_directory_exists(tmp_dir)
+
+        instances: List[Instance] = []
+        for sample in samples:
+            sid = str(sample.get("sample_id", f"idx_{len(instances)}"))
+            model_input = bench.build_model_input(sample, modality=Modality.TEXT_AND_IMAGE)
+            multimedia = self._model_input_to_multimedia(model_input, sid, tmp_dir)
+            if multimedia is None:
+                continue
+
+            ref_text = _serialize_ground_truth(sample.get("ground_truth", ""))
+            instances.append(
+                Instance(
+                    input=Input(text="", multimedia_content=multimedia),
+                    references=[Reference(output=Output(text=ref_text), tags=[CORRECT_TAG])],
+                    split=TEST_SPLIT,
+                    id=sid,
+                )
+            )
+        return instances


### PR DESCRIPTION
## Summary
Adds an integration with [lica-bench](https://github.com/purvanshi/lica-bench) for evaluating VLMs on graphic design tasks (layout, typography, SVG, templates, temporal, Lottie, category).

## Usage
```bash
pip install "crfm-helm[lica-bench]"
export LICA_BENCH_DATASET_ROOT=/path/to/lica-benchmarks-dataset
helm-run --run-entries 'lica_bench:benchmark_id=category-1,model=...' --suite ...
```

See docs/lica_bench.md for details.

## Checklist
- [ ] Maintainer review of lica-bench extra and scenario scope
