### PR TITLE
Fix run_executable returning 0 for failed compilations in CodeInsights metric

### DIFF
--- a/src/helm/benchmark/metrics/codeinsights_correct_code_metrics.py
+++ b/src/helm/benchmark/metrics/codeinsights_correct_code_metrics.py
@@ -77,7 +77,7 @@ def run_executable(executable, std_in, timeout=10):
                and output is the stdout captured from the execution.
     """
     if executable is None:
-        return (0, "")  # Return 0 and empty output for failed compilations
+        return (1, "")  # Non-zero return code signals failed compilation
 
     try:
         result = subprocess.run(


### PR DESCRIPTION
## Bug

In `src/helm/benchmark/metrics/codeinsights_correct_code_metrics.py`, when `compile_code()` fails, it returns `None`. `run_executable(None, ...)` then returns `(0, "")`:

```python
if executable is None:
    return (0, "")  # Return 0 and empty output for failed compilations
```

## Root cause

This contradicts two invariants in the same module:

1. `run_executable`'s own docstring: _"return_code is 0 if successful, non-zero otherwise"_.
2. `CPPEvaluator.evaluate()` uses `executation_results[i][0] != 0` to decide the test case failed:

```python
for i, testcase in enumerate(self.testcases):
    if executation_results[i][0] != 0:
        list_result.append(0)
        continue

    expected_output = testcase["output"]
    student_output = executation_results[i][1]
    if expected_output.strip() != student_output.strip():
        list_result.append(0)
    else:
        list_result.append(1)
```

With `return_code == 0`, a compile-failed solution skips the failure branch and falls through to output comparison with `student_output == ""`. Any test case whose `expected_output.strip()` is empty is then silently counted as **correct**, inflating functional-correctness scores for solutions that never compiled.

## Fix

Return `(1, "")` so the non-zero return code correctly routes compile-failed solutions through the failure branch, matching the documented contract.