### PR TITLE
Fix AutobencherSafetyScenario parsing the file path string as JSON

### DIFF
--- a/src/helm/benchmark/scenarios/autobencher_safety_scenario.py
+++ b/src/helm/benchmark/scenarios/autobencher_safety_scenario.py
@@ -35,7 +35,8 @@ class AutobencherSafetyScenario(Scenario):
             unpack=False,
         )
 
-        json_data = json.loads(outf_path)
+        with open(outf_path) as f:
+            json_data = json.load(f)
         df = pd.DataFrame(json_data)
 
         # Read all the instances


### PR DESCRIPTION
## Bug

`AutobencherSafetyScenario.get_instances` downloads the dataset file and then does:

```python
outf_path = os.path.join(data_path, "full_dataset.json")
ensure_file_downloaded(source_url=url, target_path=outf_path, unpack=False)
json_data = json.loads(outf_path)
df = pd.DataFrame(json_data)
```

`json.loads` expects a JSON *string*, not a filesystem path. `outf_path` is a path like `benchmark_output/scenarios/autobencher_safety/data/full_dataset.json`, which is not valid JSON, so the call raises `json.JSONDecodeError: Expecting value: line 1 column 1 (char 0)` immediately on every invocation. The scenario cannot produce any instances.

## Root cause

`json.loads` (parses a string) was used where `json.load` (reads and parses a file object) was intended.

## Fix

Open the downloaded file and parse it with `json.load`, matching the pattern already used by every other JSON-reading scenario in this directory — `bird_sql_scenario.py:77`, `ci_mcqa_scenario.py:40,50`, `newsqa_scenario.py:153`, `cti_to_mitre_scenario.py:231`.