### PR TITLE
Fix CodeInsightsCorrectCodeScenario prompt conditional precedence

### DIFF
--- a/src/helm/benchmark/scenarios/codeinsights_correct_code_scenario.py
+++ b/src/helm/benchmark/scenarios/codeinsights_correct_code_scenario.py
@@ -47,12 +47,13 @@ class CodeInsightsCorrectCodeScenario(Scenario):
                 # If more than one test case is requested, only take the first ones
                 question_test_cases = question_test_cases[: self.num_testcases]
 
+            unit_test_block = (
+                f"Unit Test Input: {question_test_cases}\n\n" if question_test_cases else ""
+            )
             prompt = (
                 f"Question: {target['question_name']} — {target['question_text']}\n\n"
-                f"Unit Test Input: {question_test_cases}\n\n"
-                if question_test_cases
-                else ""
-                "Template:\n"
+                + unit_test_block
+                + "Template:\n"
                 f"{target['question_template']}\n\n"
                 "Provide ONLY your C++ implementation following the given template, where the answer will replace the {{ STUDENT_ANSWER }} block in the template. "
                 "DO NOT reproduce the template part as the generated code would be inserted to the template, "


### PR DESCRIPTION
## Bug

`CodeInsightsCorrectCodeScenario.get_instances` builds the prompt like:

```python
prompt = (
    f"Question: ..."
    f"Unit Test Input: {question_test_cases}\n\n"
    if question_test_cases
    else ""
    "Template:\n"
    f"{target['question_template']}\n\n"
    "Provide ONLY your C++ implementation following ..."
    ...
)
```

Python parses the whole expression as one conditional:

```
(question_header + unit_test_input) if question_test_cases else ("" + "Template:\n..." + instructions)
```

Both arms are already-concatenated string-literal blocks. So:

- When `question_test_cases` is truthy (the usual path — the scenario filters out instances with fewer than `num_testcases` test cases at line 43), the prompt becomes only `"Question: ...\nUnit Test Input: ...\n\n"` — **no template, no instructions**.
- When `question_test_cases` is falsy, the prompt becomes only `"Template:\n{template}\n\nProvide ONLY ..."` — **no question header**.

Either way, the model is asked a mangled task. Every generated prompt is missing the template and/or the instructions it was supposed to contain.

## Root cause

The conditional expression `... if question_test_cases else ...` was placed inside an implicit string-literal concatenation block, so it captured every literal before `if` and every literal after `else` instead of guarding only the "Unit Test Input: ..." line. Operator precedence / missing parentheses.

## Fix

Lift the optional "Unit Test Input" block into its own variable and use explicit `+` concatenation so the Question header, optional unit-test block, Template, and instructions are always all included:

```python
unit_test_block = (
    f"Unit Test Input: {question_test_cases}\n\n" if question_test_cases else ""
)
prompt = (
    f"Question: ... \n\n"
    + unit_test_block
    + "Template:\n"
    f"{target['question_template']}\n\n"
    "Provide ONLY your C++ implementation ..."
    ...
)
```

This matches the clearly intended behavior given the surrounding code — the scenario docstring, the `Unit Test Input` comment, and the pre-filter that requires `len(question_test_cases) >= num_testcases`.