### PR TITLE
Fix AutoBencherCapabilitiesScenario excluding the requested subject instead of including it

### DIFF
--- a/src/helm/benchmark/scenarios/autobencher_capabilities_scenario.py
+++ b/src/helm/benchmark/scenarios/autobencher_capabilities_scenario.py
@@ -55,7 +55,7 @@ class AutoBencherCapabilitiesScenario(Scenario):
         )
         instances: List[Instance] = []
         for row in dataset:
-            if row["subject"] == self.subject:
+            if row["subject"] != self.subject:
                 continue
             input = Input(text=row["question"])
             # References are category ID, followed by level 2, 3 and 4 category names.


### PR DESCRIPTION
## Bug

`AutoBencherCapabilitiesScenario` is constructed with a single \`subject\` (one of \`math\`, \`mt\`, \`econ\`, \`science\`, \`history\`) and is expected to produce instances for *that* subject. Today it does the opposite: the only subject whose rows are dropped is the one the user asked for, and every instance returned belongs to a different subject. Running \`autobencher_capabilities:subject=math\` yields \`mt\`/\`econ\`/\`science\`/\`history\` questions.

## Root cause

In \`src/helm/benchmark/scenarios/autobencher_capabilities_scenario.py\`, \`get_instances\` iterates the dataset and \`continue\`s when the row's subject matches \`self.subject\`:

\`\`\`python
for row in dataset:
    if row[\"subject\"] == self.subject:
        continue
\`\`\`

The filter direction is inverted — the \`continue\` guard should skip rows that are *not* the requested subject.

## Why the fix is correct

\`__init__\` already validates that \`subject\` is in \`SUBJECTS\` and stores it as the selector for this scenario instance. Callers pass e.g. \`subject=\"math\"\` expecting math questions only, which matches the scenario's docstring and the per-subject \`run_entries_*.conf\` usage elsewhere in HELM. Flipping \`==\` to \`!=\` restores that intended filter: iterate the full multi-subject dataset and keep only the rows belonging to \`self.subject\`.