### PR TITLE
Fix DisinformationScenario reiteration dropping every narrative when topic is None

### DIFF
--- a/src/helm/benchmark/scenarios/disinformation_scenario.py
+++ b/src/helm/benchmark/scenarios/disinformation_scenario.py
@@ -96,7 +96,7 @@ class DisinformationScenario(Scenario):
         instances: List[Instance] = []
         for i, narrative in enumerate(data):
             split: str = TRAIN_SPLIT if narrative["split"] == "train" else VALID_SPLIT
-            if narrative.get("topic", "covid") != self.topic:
+            if self.topic is not None and narrative.get("topic", "covid") != self.topic:
                 continue
 
             # Creates a SINGLE reference for each narrative. All TRAIN references should include


### PR DESCRIPTION
## Bug

\`DisinformationScenario\` (\`src/helm/benchmark/scenarios/disinformation_scenario.py\`) is designed so \`topic\` can be left unset to include every narrative, but its filter silently drops all of them instead:

\`\`\`python
def __init__(self, capability: str = \"reiteration\", topic: Optional[str] = None):
    ...
    self.topic = topic

def create_reiteration_instances(self, data):
    instances = []
    for i, narrative in enumerate(data):
        ...
        if narrative.get(\"topic\", \"covid\") != self.topic:
            continue
        ...
\`\`\`

When the scenario is instantiated with the documented default \`topic=None\` (e.g. direct use in tests, or a future run spec that forwards \`topic=None\` to mean \"all\"), \`narrative.get(\"topic\", \"covid\")\` is always the string \`\"covid\"\`, and \`\"covid\" != None\` is unconditionally \`True\`, so every narrative is skipped and \`create_reiteration_instances\` returns \`[]\`. The standard \`get_disinformation_spec\` path only works because it compensates by defaulting \`topic=\"covid\"\` itself in \`run_specs/classic_run_specs.py:491\`.

## Root cause

The filter treats the \`topic\` argument as always-set and compares it directly, ignoring the \`Optional[str] = None\` signature of \`__init__\`. The conventional \"skip-when-None\" guard — used for the same kind of optional filter in other HELM scenarios (see \`mmlu_scenario\`'s \`if self.subject != \"all\"\` and the \`autobencher_capabilities\` subject filter) — is missing here.

## Why the fix is correct

Guarding the comparison with \`if self.topic is not None\` preserves the existing filter behavior when a topic is actually requested (\`topic=\"covid\"\`, \`topic=\"climate\"\`, etc. still skip non-matching narratives), and restores the intent of the \`Optional[str] = None\` signature: \`topic=None\` means \"no filtering, emit every reiteration narrative\". The happy path through \`get_disinformation_spec\` is unchanged because that path still passes a concrete topic string.