### PR TITLE
fix(frontend): keep leaderboard run links scoped to scenario

### DIFF
--- a/helm-frontend/src/components/GroupLeaderboard.tsx
+++ b/helm-frontend/src/components/GroupLeaderboard.tsx
@@ -68,6 +68,7 @@ export default function GroupLeaderboard({
           key={`${runGroupName}-${tableIndex}`}
           schema={schema}
           groupTable={groupTables[tableIndex]}
+          runGroupName={runGroupName}
           numRowsToDisplay={numRowsToDisplay}
           sortColumnIndex={1}
         />
@@ -76,6 +77,7 @@ export default function GroupLeaderboard({
           key={`${runGroupName}-${tableIndex}`}
           schema={schema}
           groupTable={groupTables[tableIndex]}
+          runGroupName={runGroupName}
           numRowsToDisplay={numRowsToDisplay}
           sortColumnIndex={1}
         />

--- a/helm-frontend/src/components/LeaderboardTable.tsx
+++ b/helm-frontend/src/components/LeaderboardTable.tsx
@@ -9,6 +9,7 @@ import HeaderValue from "@/types/HeaderValue";
 interface Props {
   schema: Schema;
   groupTable: GroupsTable;
+  runGroupName?: string;
   numRowsToDisplay: number;
   sortColumnIndex?: number;
   sortable?: boolean;
@@ -19,6 +20,7 @@ interface Props {
 export default function LeaderboardTable({
   schema,
   groupTable,
+  runGroupName,
   numRowsToDisplay,
   sortColumnIndex = 1,
   sortable = true,
@@ -155,6 +157,14 @@ export default function LeaderboardTable({
     return "";
   };
 
+  const getRunsHref = (model: string): string => {
+    const params = new URLSearchParams({ q: getModelForRunName(model) });
+    if (runGroupName) {
+      params.set("group", runGroupName);
+    }
+    return `/runs/?${params.toString()}`;
+  };
+
   return (
     <table
       className={miniStyle ? "table w-full" : "rounded-lg shadow-md table"}
@@ -230,9 +240,7 @@ export default function LeaderboardTable({
                       <RowValue
                         value={{
                           ...rowValue,
-                          href:
-                            "/runs/?q=" +
-                            getModelForRunName(String(row[0].value)),
+                          href: getRunsHref(String(row[0].value)),
                         }}
                         title={`Click value to see all predictions for: ${getModelForRunName(
                           String(row[0].value),

--- a/helm-frontend/src/components/MiniLeaderboard.tsx
+++ b/helm-frontend/src/components/MiniLeaderboard.tsx
@@ -56,6 +56,7 @@ export default function MiniLeaderboard({
       <LeaderboardTable
         schema={schema}
         groupTable={groupTable}
+        runGroupName={runGroupName}
         numRowsToDisplay={numRowsToDisplay}
         sortColumnIndex={sortColumnIndex}
         displayColumnIndexes={[0, 1]}

--- a/helm-frontend/src/components/TransposedLeaderboardTable.tsx
+++ b/helm-frontend/src/components/TransposedLeaderboardTable.tsx
@@ -9,6 +9,7 @@ import HeaderValue from "@/types/HeaderValue";
 interface Props {
   schema: Schema;
   groupTable: GroupsTable;
+  runGroupName?: string;
   numRowsToDisplay: number;
   sortColumnIndex?: number;
   sortable?: boolean;
@@ -18,6 +19,7 @@ interface Props {
 export default function LeaderboardTable({
   schema,
   groupTable,
+  runGroupName,
   numRowsToDisplay,
   sortColumnIndex = 1,
   sortable = true,
@@ -131,6 +133,14 @@ export default function LeaderboardTable({
     return "";
   };
 
+  const getRunsHref = (model: string): string => {
+    const params = new URLSearchParams({ q: getModelForRunName(model) });
+    if (runGroupName) {
+      params.set("group", runGroupName);
+    }
+    return `/runs/?${params.toString()}`;
+  };
+
   const columns: JSX.Element[][] = []; // whitespace-nowrap px-4 sticky top-0
   columns.push(
     groupTable.header.map((headerValue: HeaderValue, idx) => (
@@ -186,7 +196,7 @@ export default function LeaderboardTable({
               <RowValue
                 value={{
                   ...rowValue,
-                  href: "/runs/?q=" + getModelForRunName(String(row[0].value)),
+                  href: getRunsHref(String(row[0].value)),
                 }}
                 title={`Click value to see all predictions for: ${getModelForRunName(
                   String(row[0].value),

--- a/helm-frontend/src/routes/Runs.test.tsx
+++ b/helm-frontend/src/routes/Runs.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import type RunSpec from "@/types/RunSpec";
+import { filterRunSpecs } from "@/routes/Runs";
+
+const makeRunSpec = (name: string, groups: string[]): RunSpec =>
+  ({
+    name,
+    groups,
+    scenario_spec: { class_name: "", args: {} },
+    adapter_spec: {
+      method: "",
+      global_prefix: "",
+      instructions: "",
+      input_prefix: "",
+      input_suffix: "",
+      reference_prefix: "",
+      reference_suffix: "",
+      output_prefix: "",
+      output_suffix: "",
+      instance_prefix: "",
+      substitutions: [],
+      max_train_instances: 0,
+      max_eval_instances: 0,
+      num_outputs: 0,
+      num_train_trials: 0,
+      sample_train: false,
+      model: "",
+      temperature: 0,
+      max_tokens: 0,
+      stop_sequences: [],
+    },
+    metric_specs: [],
+    data_augmenter_spec: {
+      perturbation_specs: [],
+      should_augment_train_instances: false,
+      should_include_original_train: false,
+      should_skip_unchanged_train: false,
+      should_augment_eval_instances: false,
+      should_include_original_eval: false,
+      should_skip_unchanged_eval: false,
+      seeds_per_instance: 0,
+    },
+  }) as RunSpec;
+
+describe("filterRunSpecs", () => {
+  it("filters by run name and group", () => {
+    const runSpecs = [
+      makeRunSpec("model-a,scenario-one", ["scenario_one"]),
+      makeRunSpec("model-a,scenario-two", ["scenario_two"]),
+      makeRunSpec("model-b,scenario-one", ["scenario_one"]),
+    ];
+
+    expect(filterRunSpecs(runSpecs, "model-a", false, "scenario_one")).toEqual([
+      runSpecs[0],
+    ]);
+  });
+});

--- a/helm-frontend/src/routes/Runs.tsx
+++ b/helm-frontend/src/routes/Runs.tsx
@@ -7,8 +7,34 @@ import Link from "@/components/Link";
 import Loading from "@/components/Loading";
 import Pagination from "@/components/Pagination";
 import { MagnifyingGlassIcon } from "@heroicons/react/24/solid";
+import type RunSpec from "@/types/RunSpec";
 
 const PAGE_SIZE = 100;
+
+export function filterRunSpecs(
+  runSpecs: RunSpec[],
+  searchQuery: string,
+  useRegex: boolean,
+  groupName: string | null,
+): RunSpec[] {
+  let regex: RegExp | null = null;
+  if (useRegex) {
+    try {
+      regex = new RegExp(searchQuery);
+    } catch {
+      regex = null;
+    }
+  }
+
+  return runSpecs.filter((runSpec) => {
+    const matchesQuery = regex
+      ? regex.test(runSpec.name)
+      : runSpec.name.includes(searchQuery);
+    const matchesGroup =
+      !groupName || runSpec.groups.includes(groupName);
+    return matchesQuery && matchesGroup;
+  });
+}
 
 export default function Runs() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -20,6 +46,7 @@ export default function Runs() {
   const [searchQuery, setSearchQuery] = useState<string>(
     searchParams.get("q") || "",
   );
+  const groupName = searchParams.get("group");
 
   useEffect(() => {
     const controller = new AbortController();
@@ -40,23 +67,22 @@ export default function Runs() {
     };
     const newQuery = target.q.value;
     setSearchQuery(newQuery);
-    setSearchParams({ q: newQuery, page: "1" });
+    const nextParams: Record<string, string> = { q: newQuery, page: "1" };
+    if (groupName) {
+      nextParams.group = groupName;
+    }
+    setSearchParams(nextParams);
   };
 
   if (runSpecs === undefined) {
     return <Loading />;
   }
 
-  let regex: RegExp | null = null;
-  if (useRegex) {
-    try {
-      regex = new RegExp(searchQuery);
-    } catch {
-      regex = null;
-    }
-  }
-  const filteredRunSpecs = runSpecs.filter((runSpec) =>
-    regex ? regex.test(runSpec.name) : runSpec.name.includes(searchQuery),
+  const filteredRunSpecs = filterRunSpecs(
+    runSpecs,
+    searchQuery,
+    useRegex,
+    groupName,
   );
   const pagedRunSpecs = filteredRunSpecs.slice(
     (currentPage - 1) * PAGE_SIZE,


### PR DESCRIPTION
## Summary
- include the current run group when leaderboard run-count links navigate to the predictions page
- teach the Runs route to honor an optional group query parameter while preserving the existing name search
- add a unit test for the combined query-plus-group filtering helper

## Testing
- npm test -- Runs.test.tsx --runInBand (fails locally: vitest: command not found)