### PR TITLE
feat(frontend): add metric filters to predictions page

### DIFF
--- a/helm-frontend/src/components/Instances.tsx
+++ b/helm-frontend/src/components/Instances.tsx
@@ -10,6 +10,11 @@ import DisplayRequest from "@/types/DisplayRequest";
 import getInstances from "@/services/getInstances";
 import getDisplayPredictionsByName from "@/services/getDisplayPredictionsByName";
 import getDisplayRequestsByName from "@/services/getDisplayRequestsByName";
+import {
+  filterInstancesByMetric,
+  getFilterableMetricKeys,
+  type MetricOutcomeFilter,
+} from "@/components/instanceMetricFilters";
 
 const INSTANCES_PAGE_SIZE = 10;
 
@@ -41,6 +46,9 @@ export default function Instances({
     undefined | Record<string, Record<string, DisplayRequest[]>>
   >();
   const [currentInstancesPage, setCurrentInstancesPage] = useState<number>(1);
+  const [selectedMetric, setSelectedMetric] = useState<string>("");
+  const [selectedMetricOutcome, setSelectedMetricOutcome] =
+    useState<MetricOutcomeFilter>("all");
 
   useEffect(() => {
     const controller = new AbortController();
@@ -101,11 +109,49 @@ export default function Instances({
     return () => controller.abort();
   }, [runName, suite, userAgreed]);
 
-  const pagedInstances = instances.slice(
+  const filterableMetricKeys =
+    displayPredictionsMap === undefined
+      ? []
+      : getFilterableMetricKeys(displayPredictionsMap);
+
+  useEffect(() => {
+    if (selectedMetric && !filterableMetricKeys.includes(selectedMetric)) {
+      setSelectedMetric("");
+      setSelectedMetricOutcome("all");
+    }
+  }, [filterableMetricKeys, selectedMetric]);
+
+  const filteredInstances =
+    displayPredictionsMap === undefined
+      ? instances
+      : filterInstancesByMetric(
+          instances,
+          displayPredictionsMap,
+          selectedMetric,
+          selectedMetricOutcome,
+        );
+
+  const pagedInstances = filteredInstances.slice(
     (currentInstancesPage - 1) * INSTANCES_PAGE_SIZE,
     (currentInstancesPage - 1) * INSTANCES_PAGE_SIZE + INSTANCES_PAGE_SIZE,
   );
-  const totalInstancesPages = Math.ceil(instances.length / INSTANCES_PAGE_SIZE);
+  const totalInstancesPages = Math.max(
+    1,
+    Math.ceil(filteredInstances.length / INSTANCES_PAGE_SIZE),
+  );
+
+  useEffect(() => {
+    if (currentInstancesPage > totalInstancesPages) {
+      setCurrentInstancesPage(1);
+      searchParams.set("instancesPage", "1");
+      setSearchParams(searchParams);
+    }
+  }, [
+    currentInstancesPage,
+    searchParams,
+    setSearchParams,
+    totalInstancesPages,
+  ]);
 
   // Handle scrolling to anchored instance
   useEffect(() => {
@@ -145,6 +191,51 @@ export default function Instances({
 
   return (
     <>
+      {filterableMetricKeys.length > 0 ? (
+        <div className="mb-6 flex flex-wrap items-end gap-4 rounded-md border border-gray-200 bg-white p-4">
+          <label className="form-control w-full max-w-xs">
+            <span className="label-text mb-2 font-medium">Filter metric</span>
+            <select
+              className="select select-bordered"
+              value={selectedMetric}
+              onChange={(event) => {
+                const nextMetric = event.target.value;
+                setSelectedMetric(nextMetric);
+                setCurrentInstancesPage(1);
+                searchParams.set("instancesPage", "1");
+                setSearchParams(searchParams);
+              }}
+            >
+              <option value="">All instances</option>
+              {filterableMetricKeys.map((metricKey) => (
+                <option key={metricKey} value={metricKey}>
+                  {metricFieldMap[metricKey]?.display_name ?? metricKey}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="form-control w-full max-w-xs">
+            <span className="label-text mb-2 font-medium">Show</span>
+            <select
+              className="select select-bordered"
+              disabled={!selectedMetric}
+              value={selectedMetricOutcome}
+              onChange={(event) => {
+                setSelectedMetricOutcome(
+                  event.target.value as MetricOutcomeFilter,
+                );
+                setCurrentInstancesPage(1);
+                searchParams.set("instancesPage", "1");
+                setSearchParams(searchParams);
+              }}
+            >
+              <option value="all">All values</option>
+              <option value="correct">Correct only</option>
+              <option value="incorrect">Incorrect only</option>
+            </select>
+          </label>
+        </div>
+      ) : null}
       <div className="grid gap-8">
         {pagedInstances.map((instance, idx) => (
           <div id={"instance-" + instance.id} className="border p-4">
@@ -183,6 +274,11 @@ export default function Instances({
           </div>
         ))}
       </div>
+      {filteredInstances.length === 0 ? (
+        <div className="rounded-md border border-dashed border-gray-300 p-6 text-center text-gray-600">
+          No instances match the selected metric filter.
+        </div>
+      ) : null}
       <Pagination
         className="flex justify-center my-8"
         onNextPage={() => {

--- a/helm-frontend/src/components/instanceMetricFilters.test.ts
+++ b/helm-frontend/src/components/instanceMetricFilters.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import type Instance from "@/types/Instance";
+import type DisplayPrediction from "@/types/DisplayPrediction";
+import {
+  filterInstancesByMetric,
+  getFilterableMetricKeys,
+  type DisplayPredictionsMap,
+} from "./instanceMetricFilters";
+
+const instances: Instance[] = [
+  {
+    id: "instance-1",
+    input: { text: "Question one" },
+    references: [],
+    split: "test",
+  },
+  {
+    id: "instance-2",
+    input: { text: "Question two" },
+    references: [],
+    split: "test",
+  },
+];
+
+function createPrediction(
+  instanceId: string,
+  stats: DisplayPrediction["stats"],
+): DisplayPrediction {
+  return {
+    instance_id: instanceId,
+    predicted_text: "prediction",
+    train_trial_index: 0,
+    stats,
+    mapped_output: undefined,
+  };
+}
+
+describe("instanceMetricFilters", () => {
+  it("discovers binary metrics that can be used as filters", () => {
+    const displayPredictionsMap: DisplayPredictionsMap = {
+      "instance-1": {
+        "": [
+          createPrediction("instance-1", {
+            exact_match: 1,
+            score: 0.75,
+          }),
+        ],
+      },
+      "instance-2": {
+        "": [
+          createPrediction("instance-2", {
+            exact_match: 0,
+            score: 0.2,
+          }),
+        ],
+      },
+    };
+
+    expect(getFilterableMetricKeys(displayPredictionsMap)).toEqual([
+      "exact_match",
+    ]);
+  });
+
+  it("filters down to correct or incorrect instances for a selected metric", () => {
+    const displayPredictionsMap: DisplayPredictionsMap = {
+      "instance-1": {
+        "": [createPrediction("instance-1", { exact_match: 1 })],
+      },
+      "instance-2": {
+        "": [createPrediction("instance-2", { exact_match: 0 })],
+      },
+    };
+
+    expect(
+      filterInstancesByMetric(
+        instances,
+        displayPredictionsMap,
+        "exact_match",
+        "correct",
+      ).map((instance) => instance.id),
+    ).toEqual(["instance-1"]);
+
+    expect(
+      filterInstancesByMetric(
+        instances,
+        displayPredictionsMap,
+        "exact_match",
+        "incorrect",
+      ).map((instance) => instance.id),
+    ).toEqual(["instance-2"]);
+  });
+});

--- a/helm-frontend/src/components/instanceMetricFilters.ts
+++ b/helm-frontend/src/components/instanceMetricFilters.ts
@@ -1,0 +1,67 @@
+import type Instance from "@/types/Instance";
+import type DisplayPrediction from "@/types/DisplayPrediction";
+
+export type DisplayPredictionsMap = Record<
+  string,
+  Record<string, DisplayPrediction[]>
+>;
+
+export type MetricOutcomeFilter = "all" | "correct" | "incorrect";
+
+const BINARY_METRIC_VALUES = new Set([0, 1]);
+
+function getPredictionsForInstance(
+  displayPredictionsMap: DisplayPredictionsMap,
+  instanceId: string,
+): DisplayPrediction[] {
+  return Object.values(displayPredictionsMap[instanceId] ?? {}).flat();
+}
+
+export function getFilterableMetricKeys(
+  displayPredictionsMap: DisplayPredictionsMap,
+): string[] {
+  const metricValues = new Map<string, Set<number>>();
+
+  Object.values(displayPredictionsMap).forEach((predictionsByPerturbation) => {
+    Object.values(predictionsByPerturbation).forEach((predictions) => {
+      predictions.forEach((prediction) => {
+        Object.entries(prediction.stats).forEach(([metricKey, metricValue]) => {
+          if (typeof metricValue !== "number") {
+            return;
+          }
+          const values = metricValues.get(metricKey) ?? new Set<number>();
+          values.add(metricValue);
+          metricValues.set(metricKey, values);
+        });
+      });
+    });
+  });
+
+  return Array.from(metricValues.entries())
+    .filter(([, values]) => {
+      return (
+        values.size > 0 &&
+        Array.from(values).every((value) => BINARY_METRIC_VALUES.has(value))
+      );
+    })
+    .map(([metricKey]) => metricKey);
+}
+
+export function filterInstancesByMetric(
+  instances: Instance[],
+  displayPredictionsMap: DisplayPredictionsMap,
+  selectedMetric: string,
+  selectedOutcome: MetricOutcomeFilter,
+): Instance[] {
+  if (!selectedMetric || selectedOutcome === "all") {
+    return instances;
+  }
+
+  const expectedValue = selectedOutcome === "correct" ? 1 : 0;
+
+  return instances.filter((instance) => {
+    return getPredictionsForInstance(displayPredictionsMap, instance.id).some(
+      (prediction) => prediction.stats[selectedMetric] === expectedValue,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- add a compact metric filter UI above the instances/predictions list
- let users filter to correct or incorrect instances for binary metrics such as exact_match
- cover binary metric discovery and filtering behavior with focused frontend tests

## Testing
- npm test -- --run src/components/instanceMetricFilters.test.ts
- npx prettier --write src/components/Instances.tsx src/components/instanceMetricFilters.ts src/components/instanceMetricFilters.test.ts