### PR TITLE
fix(medhelm): use quasi match for PubMedQA

### DIFF
--- a/src/helm/benchmark/scenarios/pubmed_qa_scenario.py
+++ b/src/helm/benchmark/scenarios/pubmed_qa_scenario.py
@@ -205,6 +205,6 @@ class PubMedQAScenario(Scenario):
                 who="Researcher",
                 language="English",
             ),
-            main_metric="exact_match",
+            main_metric="quasi_exact_match",
             main_split="test",
         )

--- a/src/helm/benchmark/scenarios/test_pubmed_qa_scenario.py
+++ b/src/helm/benchmark/scenarios/test_pubmed_qa_scenario.py
@@ -1,0 +1,7 @@
+from helm.benchmark.scenarios.pubmed_qa_scenario import PubMedQAScenario
+
+
+def test_pubmed_qa_main_metric_uses_quasi_exact_match():
+    scenario = PubMedQAScenario()
+
+    assert scenario.get_metadata().main_metric == "quasi_exact_match"

--- a/src/helm/benchmark/static/schema_medhelm.yaml
+++ b/src/helm/benchmark/static/schema_medhelm.yaml
@@ -995,7 +995,7 @@ run_groups:
       - efficiency
       - general_information
     environment:
-      main_name: exact_match
+      main_name: quasi_exact_match
       main_split: test
     taxonomy:
       task: Question answering


### PR DESCRIPTION
## Summary
- switch PubMedQA to quasi_exact_match so punctuation-only differences do not count as wrong answers
- update the checked-in MedHELM schema metadata to keep the leaderboard config in sync
- add a regression test for the scenario main metric

## Testing
- python3 -m compileall src/helm/benchmark/scenarios/pubmed_qa_scenario.py src/helm/benchmark/scenarios/test_pubmed_qa_scenario.py
- PYTHONPATH=src python3 -m pytest /tmp/helm-user/src/helm/benchmark/scenarios/test_pubmed_qa_scenario.py (fails locally: ModuleNotFoundError: No module named cattrs from repo test setup)