### PR TITLE
Fix AnnotatorResponseParseFailure forwarding kwargs dict to Exception instead of message

### DIFF
--- a/src/helm/benchmark/annotation/arabic_finance_calculation_annotator.py
+++ b/src/helm/benchmark/annotation/arabic_finance_calculation_annotator.py
@@ -11,7 +11,7 @@ from helm.proxy.retry import NonRetriableException
 class AnnotatorResponseParseFailure(NonRetriableException):
     def __init__(self, response_text: str, **kwargs):
         self.response_text = response_text
-        super().__init__(kwargs)
+        super().__init__(kwargs.get("message", ""))
 
 
 class ArabicFinanceCalculationAnnotator(Annotator):

--- a/src/helm/benchmark/annotation/arabic_legal_annotator.py
+++ b/src/helm/benchmark/annotation/arabic_legal_annotator.py
@@ -11,7 +11,7 @@ from helm.proxy.retry import NonRetriableException
 class AnnotatorResponseParseFailure(NonRetriableException):
     def __init__(self, response_text: str, **kwargs):
         self.response_text = response_text
-        super().__init__(kwargs)
+        super().__init__(kwargs.get("message", ""))
 
 
 class ArabicLegalAnnotator(Annotator):

--- a/src/helm/benchmark/annotation/autobencher_capabilities_annotator.py
+++ b/src/helm/benchmark/annotation/autobencher_capabilities_annotator.py
@@ -11,7 +11,7 @@ from helm.proxy.retry import NonRetriableException
 class AnnotatorResponseParseFailure(NonRetriableException):
     def __init__(self, response_text: str, **kwargs):
         self.response_text = response_text
-        super().__init__(kwargs)
+        super().__init__(kwargs.get("message", ""))
 
 
 class AutoBencherCapabilitiesAnnotator(Annotator):

--- a/src/helm/benchmark/annotation/autobencher_safety_annotator.py
+++ b/src/helm/benchmark/annotation/autobencher_safety_annotator.py
@@ -11,7 +11,7 @@ from helm.proxy.retry import NonRetriableException
 class AnnotatorResponseParseFailure(NonRetriableException):
     def __init__(self, response_text: str, **kwargs):
         self.response_text = response_text
-        super().__init__(kwargs)
+        super().__init__(kwargs.get("message", ""))
 
 
 class AutoBencherCapabilitiesAnnotator(Annotator):

--- a/src/helm/benchmark/annotation/helpdesk_call_summarization_annotator.py
+++ b/src/helm/benchmark/annotation/helpdesk_call_summarization_annotator.py
@@ -13,7 +13,7 @@ from helm.proxy.retry import NonRetriableException
 class AnnotatorResponseParseFailure(NonRetriableException):
     def __init__(self, response_text: str, **kwargs):
         self.response_text = response_text
-        super().__init__(kwargs)
+        super().__init__(kwargs.get("message", ""))
 
 
 class HelpdeskCallSummarizationAnnotator(Annotator):

--- a/src/helm/benchmark/annotation/model_as_judge.py
+++ b/src/helm/benchmark/annotation/model_as_judge.py
@@ -14,7 +14,7 @@ from helm.common.request import Request
 class AnnotatorResponseParseFailure(Exception):
     def __init__(self, response_text: str, **kwargs):
         self.response_text = response_text
-        super().__init__(kwargs)
+        super().__init__(kwargs.get("message", ""))
 
 
 @dataclass


### PR DESCRIPTION
## Bug

`AnnotatorResponseParseFailure`, copy-pasted into 5 annotators, forwards the entire `kwargs` dict to `Exception.__init__`:

```python
class AnnotatorResponseParseFailure(NonRetriableException):
    def __init__(self, response_text: str, **kwargs):
        self.response_text = response_text
        super().__init__(kwargs)
```

Call sites consistently pass a `message=` kwarg (e.g. `autobencher_capabilities_annotator.py` lines 94-97 and 102-105):

```python
raise AnnotatorResponseParseFailure(
    message=f"Could not parse markup in raw response: '{annotator_response_text}'",
    response_text=annotator_response_text,
)
```

## Root cause

`**kwargs` captures `{"message": "..."}`, and `super().__init__(kwargs)` forwards that **dict** as `args[0]` of the Exception. `str(e)` therefore renders a raw dict repr like `"{'message': \"Could not parse markup in raw response: '...'\"}"` instead of just the message string. Any log line, error banner, or retry path that prints the exception ends up with that mangled dict-repr, defeating the purpose of passing `message=` in the first place.

## Why the fix is correct

Pull the string out before delegating:

```python
super().__init__(kwargs.get("message", ""))
```

Now `args[0]` is the intended string, `str(e)` is the message, and call sites that do not pass `message=` (none today, but the signature keeps the option open) fall back to an empty string — equivalent to a bare `Exception("")`. No behaviour change at the successful path; only the error path starts rendering the message the way the caller intended.

## Change

The same one-line fix in each of the five annotator files that copy-pasted this class:

- `src/helm/benchmark/annotation/autobencher_capabilities_annotator.py`
- `src/helm/benchmark/annotation/autobencher_safety_annotator.py`
- `src/helm/benchmark/annotation/arabic_legal_annotator.py`
- `src/helm/benchmark/annotation/arabic_finance_calculation_annotator.py`
- `src/helm/benchmark/annotation/helpdesk_call_summarization_annotator.py`

No other edits, no signature or import changes.