### PR TITLE
Fix missing context in ArabicMMLU scenario

### DIFF
--- a/src/helm/benchmark/scenarios/arabic_mmlu_scenario.py
+++ b/src/helm/benchmark/scenarios/arabic_mmlu_scenario.py
@@ -59,8 +59,9 @@ class ArabicMMLUScenario(Scenario):
             assert isinstance(dataset, datasets.Dataset)
             for row_index, row in enumerate(dataset):
                 # Include the Context field (reading passage) when available.
-                # The Arabic Language (General) subset has context passages;
-                # most other subsets have no Context (all null).
+                # Some subsets (e.g. Arabic Language (General)) and individual
+                # examples across other subsets include a context passage;
+                # rows without context have a null/empty Context field.
                 context = row.get("Context")
                 question = row["Question"]
                 if context and isinstance(context, str) and context.strip():

--- a/src/helm/benchmark/scenarios/arabic_mmlu_scenario.py
+++ b/src/helm/benchmark/scenarios/arabic_mmlu_scenario.py
@@ -58,7 +58,15 @@ class ArabicMMLUScenario(Scenario):
         for split_name, dataset in dataset_splits.items():
             assert isinstance(dataset, datasets.Dataset)
             for row_index, row in enumerate(dataset):
-                input = Input(text=row["Question"])
+                # Include the Context field (reading passage) when available.
+                # The Arabic Language (General) subset has context passages;
+                # most other subsets have no Context (all null).
+                context = row.get("Context")
+                question = row["Question"]
+                if context and isinstance(context, str) and context.strip():
+                    input = Input(text=f"{context}\n\n{question}")
+                else:
+                    input = Input(text=question)
                 references: List[Reference] = []
                 correct_option_index = ord(row["Answer Key"]) - ord("A") + 1
                 for option_index in range(1, 6):


### PR DESCRIPTION
**Summary**

  ArabicMMLUScenario was ignoring the Context field (reading passage) present in the dataset, causing passage-dependent questions to be evaluated without the passage they refer to. This leads to inaccurate evaluation results.                                                                                                                                                                                                           
   
  The Context field is non-null for a number of examples across multiple subsets (most notably Arabic Language (General), but not limited to it). The fix reads the Context field per row and prepends it to the question when present and non-empty.                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                          
  This mirrors the fix already applied to [MadinahQAScenario](https://github.com/stanford-crfm/helm/pull/4127) in 0.5.14, which shares the same dataset schema (MBZUAI/ArabicMMLU vs MBZUAI/MadinahQA).                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                          
**Changes**                                                                                                                                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                                                                                          
  - In arabic_mmlu_scenario.py, read the Context field per row and prepend it to the question (separated by \n\n) when non-null and non-empty.                                                                                                                                                                                                                                                                                              
  - Rows without a context passage are unaffected (falls back to Question only).
                                                                                                                                                                                                                                                                                                                                                                                                                                            
**Impact**                                                                                                                                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                                                                            
  - Fixes evaluation for all examples across any subset that includes a Context passage.                                                                                                                                                                                                                                                                                                                                                    
  - No change in behavior for rows where Context is null or empty.
