### PR TITLE
Fix GenderPerturbation missing words at text boundaries and consecutive matches

### DIFF
--- a/src/helm/benchmark/augmentations/gender_perturbation.py
+++ b/src/helm/benchmark/augmentations/gender_perturbation.py
@@ -194,8 +194,10 @@ class GenderPerturbation(TextPerturbation):
 
     def substitute_word(self, text: str, word: str, synonym: str, rng: Random) -> str:
         """Substitute the occurences of word in text with its synonym with self.probability"""
-        # Pattern capturing any occurence of given word in the text, surrounded by non-alphanumeric characters
-        pattern = f"[^\\w]({word})[^\\w]"
+        # Pattern capturing any occurence of given word in the text at word boundaries.
+        # Using \b (rather than requiring non-word chars on both sides) ensures the word
+        # is matched at text boundaries and when separated from neighbors by a single char.
+        pattern = rf"\b({word})\b"
 
         # Substitution function
         def sub_func(m: re.Match):

--- a/src/helm/benchmark/augmentations/test_perturbation.py
+++ b/src/helm/benchmark/augmentations/test_perturbation.py
@@ -273,8 +273,6 @@ def test_suffix_perturbation():
     assert instances[1].input.text == "A blue dog, pixel art"
 
 
-# TODO(#1958) Fix the logic to renable this test
-@unittest.skip("Currently cannot replace words at either text boundary.")
 def test_gender_term_perturbation_edge_word():
     data_augmenter = DataAugmenter(
         perturbations=[GenderPerturbation(prob=1.0, mode="terms", source_class="male", target_class="female")],
@@ -291,8 +289,6 @@ def test_gender_term_perturbation_edge_word():
     assert instances[0].references[0].output.text == "Sure he did daughter"
 
 
-# TODO(#1958) Fix the logic to renable this test
-@unittest.skip("Currently cannot replace words separated by 1 character.")
 def test_gender_term_perturbation_consequtive_words():
     data_augmenter = DataAugmenter(
         perturbations=[GenderPerturbation(prob=1.0, mode="terms", source_class="male", target_class="female")],


### PR DESCRIPTION
Closes #1732 and #1958.

## Bug

`GenderPerturbation.substitute_word` fails to perturb:

1. A target word at the start or end of the text, e.g. `\"he went to the market, and there he had a soup.\"` rewrites the second `he` but leaves the initial `he` untouched.
2. Two adjacent target words separated by a single non-word character, e.g. `\"I'm a dad dad: my son has a son.\"` only rewrites one of each pair.

Two tests in `test_perturbation.py` (`test_gender_term_perturbation_edge_word`, `test_gender_term_perturbation_consequtive_words`) already encode these cases and are marked `@unittest.skip` with a `TODO(#1958)` pointing at this exact bug.

## Root cause

The pattern is a literal character class rather than a zero-width assertion:

```python
pattern = f\"[^\\\\w]({word})[^\\\\w]\"
```

`[^\\w]` consumes one character of actual input on each side. That has two consequences:

- At the start/end of the text there is no non-word character to consume, so the match simply fails.
- Between two adjacent target words separated by a single char (space, colon, etc.), the first match consumes that separator, leaving the second word with only a word character before it, so it no longer matches.

## Fix

Use Python's word-boundary anchor, which is zero-width and matches at true word boundaries including the start/end of the text:

```python
pattern = rf\"\\b({word})\\b\"
```

The existing `sub_func` keeps working unchanged: with `\\b` the full match equals the captured group, so `match_str.replace(match_word, syn)` reduces to emitting the case-matched synonym via `match_case`, which preserves the existing capitalization behavior covered by the pronoun/term tests.

## Why the fix is correct

- Passing cases: `\\b` still requires a transition between a word char and a non-word char (or text boundary), so it does not match inside larger words — e.g. `dad` inside `daddy` still does not match, matching the previous intent of the character-class guard.
- Previously failing cases now work: `\\b` matches at the start of the string and between two consecutive matches because it is zero-width (no character is consumed).
- Verified by running `test_gender_pronoun_perturbation`, `test_gender_term_perturbation`, and both previously skipped tests — all four pass locally after this change, and the skip decorators on the two boundary tests are removed now that the bug they guarded is fixed.