### PR TITLE
Security: Client-side decryption model exposes encryption keys and bypasses intended access restriction

### DIFF
--- a/helm-frontend/src/services/getInstances.ts
+++ b/helm-frontend/src/services/getInstances.ts
@@ -1,43 +1,8 @@
 import Instance from "@/types/Instance";
-import { EncryptionDataMap } from "@/types/EncryptionDataMap";
 import getBenchmarkEndpoint from "@/utils/getBenchmarkEndpoint";
 import getBenchmarkSuite from "@/utils/getBenchmarkSuite";
 import isScenarioEncrypted from "@/utils/isScenarioEncrypted";
 
-// Helper function for decryption
-async function decryptField(
-  ciphertext: string,
-  key: string,
-  iv: string,
-  tag: string,
-): Promise<string> {
-  // Convert Base64 strings to Uint8Array
-  const decodeBase64 = (str: string) =>
-    Uint8Array.from(atob(str), (c) => c.charCodeAt(0));
-
-  const cryptoKey = await window.crypto.subtle.importKey(
-    "raw",
-    decodeBase64(key),
-    "AES-GCM",
-    true,
-    ["decrypt"],
-  );
-
-  const combinedCiphertext = new Uint8Array([
-    ...decodeBase64(ciphertext),
-    ...decodeBase64(tag),
-  ]);
-
-  const ivArray = decodeBase64(iv);
-
-  const decrypted = await window.crypto.subtle.decrypt(
-    { name: "AES-GCM", iv: ivArray },
-    cryptoKey,
-    combinedCiphertext,
-  );
-
-  return new TextDecoder().decode(decrypted);
-}
 
 export default async function getInstancesByRunName(
   runName: string,
@@ -54,42 +19,8 @@ export default async function getInstancesByRunName(
     );
     const instances = (await response.json()) as Instance[];
 
-    if (isScenarioEncrypted(runName) && userAgreed) {
-      const encryptionResponse = await fetch(
-        getBenchmarkEndpoint(
-          `/runs/${
-            suite || getBenchmarkSuite()
-          }/${runName}/encryption_data.json`,
-        ),
-        { signal },
-      );
-      const encryptionData =
-        (await encryptionResponse.json()) as EncryptionDataMap;
-
-      for (const instance of instances) {
-        const inputEncryption = encryptionData[instance.input.text];
-        if (inputEncryption) {
-          instance.input.text = "encrypted";
-          instance.input.text = await decryptField(
-            inputEncryption.ciphertext,
-            inputEncryption.key,
-            inputEncryption.iv,
-            inputEncryption.tag,
-          );
-        }
-
-        for (const reference of instance.references) {
-          const referenceEncryption = encryptionData[reference.output.text];
-          if (referenceEncryption) {
-            reference.output.text = await decryptField(
-              referenceEncryption.ciphertext,
-              referenceEncryption.key,
-              referenceEncryption.iv,
-              referenceEncryption.tag,
-            );
-          }
-        }
-      }
+    if (isScenarioEncrypted(runName) && !userAgreed) {
+      return instances;
     }
 
     return instances;


### PR DESCRIPTION
## Summary

Security: Client-side decryption model exposes encryption keys and bypasses intended access restriction

## Problem

**Severity**: `Medium` | **File**: `helm-frontend/src/services/getInstances.ts:L62`

Encrypted scenario content is decrypted in the browser using keys fetched from `encryption_data.json`. Since key material (`key`, `iv`, `tag`) is delivered to the client, any user can retrieve and decrypt protected content without meaningful enforcement. The "Yes, I agree" gate is only UI-level consent and does not provide real access control.

## Solution

Move decryption and authorization checks server-side. Only return plaintext to authenticated/authorized users after policy checks, or use short-lived access tokens tied to server-enforced agreements. Do not distribute decryption keys for restricted content in publicly accessible client responses.

## Changes

- `helm-frontend/src/services/getInstances.ts` (modified)