### PR TITLE
Fix LocalWindowService to respect combined sequence budget

### DIFF
--- a/src/helm/benchmark/window_services/local_window_service.py
+++ b/src/helm/benchmark/window_services/local_window_service.py
@@ -86,12 +86,21 @@ class LocalWindowService(ConfigurableWindowService, ABC):
         """Tokenizes the text and returns the number of tokens."""
         return len(self.encode(text).tokens)
 
+    def _effective_prompt_token_budget(self, expected_completion_token_length: int = 0) -> int:
+        return max(
+            0,
+            min(
+                self.max_request_length,
+                self.max_sequence_and_generated_tokens_length - expected_completion_token_length,
+            ),
+        )
+
     def fits_within_context_window(self, text: str, expected_completion_token_length: int = 0) -> bool:
         """
         Checks if the given text fits within the context window given by `max_request_length`
         taking to account the expected completion length (defaults to 0).
         """
-        return self.get_num_tokens(text) + expected_completion_token_length <= self.max_request_length
+        return self.get_num_tokens(text) <= self._effective_prompt_token_budget(expected_completion_token_length)
 
     def truncate_from_right(self, text: str, expected_completion_token_length: int = 0) -> str:
         """
@@ -104,7 +113,7 @@ class LocalWindowService(ConfigurableWindowService, ABC):
 
         Since we are only passing in a single string, the tokenizer will simply truncate from the right.
         """
-        max_length: int = self.max_request_length - expected_completion_token_length
+        max_length: int = self._effective_prompt_token_budget(expected_completion_token_length)
         result: str = self.decode(self.encode(text, truncation=True, max_length=max_length).tokens)
 
         # HACK: For the vast majority of cases, the above logic works, but it sometimes doesn't work

--- a/src/helm/benchmark/window_services/test_local_window_service.py
+++ b/src/helm/benchmark/window_services/test_local_window_service.py
@@ -1,0 +1,67 @@
+from helm.benchmark.window_services.default_window_service import DefaultWindowService
+from helm.common.tokenization_request import (
+    DecodeRequest,
+    DecodeRequestResult,
+    TokenizationRequest,
+    TokenizationRequestResult,
+    TokenizationToken,
+)
+
+
+class _CountingTokenizerService:
+    """
+    Test tokenizer where each character counts as one token.
+    Used to test window truncation logic.
+    """
+
+    def tokenize(self, request: TokenizationRequest) -> TokenizationRequestResult:
+        text = request.text[: request.max_length] if request.truncation else request.text
+        tokens = [TokenizationToken(value=i) for i, _ in enumerate(text)]
+        return TokenizationRequestResult(
+            success=True,
+            cached=False,
+            text=text,
+            tokens=tokens,
+        )
+
+    def decode(self, request: DecodeRequest) -> DecodeRequestResult:
+        return DecodeRequestResult(
+            success=True,
+            cached=False,
+            text="x" * len(request.tokens),
+        )
+
+
+def test_local_window_service_uses_combined_prompt_completion_budget():
+    """
+    MWE for a bug in prompt budgeting.
+
+    Given:
+      max_request_length = 2048
+      max_sequence_and_generated_tokens_length = 2040
+      expected_completion_token_length = 5
+
+    The real prompt budget is:
+      min(2048, 2040 - 5) = 2035
+
+    So:
+      2035-token prompt -> fits
+      2036-token prompt -> does not fit
+      truncation target -> 2035
+    """
+    ws = DefaultWindowService(
+        service=_CountingTokenizerService(),
+        tokenizer_name="huggingface/gpt2",
+        max_sequence_length=2048,
+        max_request_length=2048,
+        max_sequence_and_generated_tokens_length=2040,
+    )
+
+    completion = 5
+    got_fit_2035 = ws.fits_within_context_window("x" * 2035, completion)
+    got_fit_2036 = ws.fits_within_context_window("x" * 2036, completion)
+    got_trunc_len = len(ws.truncate_from_right("x" * 3000, completion))
+
+    assert got_fit_2035, "fits(2035, completion=5) == {got_fit_2035}  expected=True"
+    assert not got_fit_2036, "fits(2036, completion=5) == {got_fit_2036}  expected=False"
+    assert got_trunc_len == 2035, "truncate_len == {got_trunc_len}  expected=2035"


### PR DESCRIPTION
I ran into an issue when running Vicuna7B on my vLLM server, and the issue looks like a bug. Not sure exactly why it wasn't hit outside vLLM, perhaps my configuration is having it produce results that are pathologically long, but in any case, the existing check for fits within context window seems incorrect. The old code assumed the usable prompt budget was `max_request_length - expected_completion_tokens`, but it should be the smaller of that and `max_sequence_and_generated_tokens_length - expected_completion_tokens` to have consistent semantics. 

Here's the visual reasoning:

```
Example:
  max_request_length = 10
  max_sequence_and_generated_tokens_length = 8
  expected_completion_tokens = 2

Old code:
  usable prompt budget = 10 - 2 = 8

Correct:
  usable prompt budget = min(10, 8 - 2) = 6

Diagram:

  old view:
    |<----------- 10 ----------->|
    |<------ prompt = 8 ------>|<-2->|

  real combined limit:
    |<------- total = 8 ------->|
    |<--- prompt = 6 --->|<-2->|

So a 7-token prompt was incorrectly accepted before:
  old check: 7 + 2 <= 10   -> pass
  real budget: 7 > 6       -> fail
```