### PR TITLE
Deprecate `meta/llama-3.1-405b-instruct-turbo`

### DIFF
--- a/src/helm/benchmark/annotation/helpdesk_call_summarization_annotator.py
+++ b/src/helm/benchmark/annotation/helpdesk_call_summarization_annotator.py
@@ -26,10 +26,13 @@ class HelpdeskCallSummarizationAnnotator(Annotator):
             model_name="openai/gpt-4o-2024-05-13",
             model_deployment="openai/gpt-4o-2024-05-13",
         ),
-        "llama": AnnotatorModelInfo(
-            model_name="meta/llama-3.1-405b-instruct-turbo",
-            model_deployment="together/llama-3.1-405b-instruct-turbo",
-        ),
+        # NOTE: meta/llama-3.1-405b-instruct-turbo was deprecated on March 6, 2026.
+        # See: https://docs.claude.com/en/docs/about-claude/model-deprecations
+        #
+        # "llama": AnnotatorModelInfo(
+        #     model_name="meta/llama-3.1-405b-instruct-turbo",
+        #     model_deployment="together/llama-3.1-405b-instruct-turbo",
+        # ),
         # NOTE: anthropic/claude-3-5-sonnet-20241022 was deprecated on October 28, 2025.
         # See: https://docs.claude.com/en/docs/about-claude/model-deprecations
         #

--- a/src/helm/benchmark/annotation/model_as_judge.py
+++ b/src/helm/benchmark/annotation/model_as_judge.py
@@ -33,9 +33,12 @@ def score_with_reasoning_with_gpt_and_llama(
     # TODO: Make this configurable
     SHORT_NAME_TO_MODEL_INFO: Dict[str, AnnotatorModelInfo] = {
         "gpt": AnnotatorModelInfo(model_name="openai/gpt-4o-2024-05-13", model_deployment="openai/gpt-4o-2024-05-13"),
-        "llama": AnnotatorModelInfo(
-            model_name="meta/llama-3.1-405b-instruct-turbo", model_deployment="together/llama-3.1-405b-instruct-turbo"
-        ),
+        # NOTE: meta/llama-3.1-405b-instruct-turbo was deprecated on March 6, 2026.
+        # See: https://docs.claude.com/en/docs/about-claude/model-deprecations
+        #
+        # "llama": AnnotatorModelInfo(
+        #     model_name="meta/llama-3.1-405b-instruct-turbo", model_deployment="together/llama-3.1-405b-instruct-turbo"
+        # ),
     }
     result: Dict[str, Optional[Union[str, float]]] = {"prompt_text": annotator_prompt}
     for short_name, model_info in SHORT_NAME_TO_MODEL_INFO.items():

--- a/src/helm/benchmark/annotation/omni_math_annotator.py
+++ b/src/helm/benchmark/annotation/omni_math_annotator.py
@@ -60,10 +60,14 @@ class OmniMATHAnnotator(Annotator):
                 model_name="openai/gpt-4o-2024-05-13",
                 model_deployment="openai/gpt-4o-2024-05-13",
             ),
-            "llama": AnnotatorModelInfo(
-                model_name="meta/llama-3.1-405b-instruct-turbo",
-                model_deployment="together/llama-3.1-405b-instruct-turbo",
-            ),
+            # NOTE: meta/llama-3.1-405b-instruct-turbo was deprecated on March 6, 2026.
+            # See: https://docs.claude.com/en/docs/about-claude/model-deprecations
+            #
+            # "llama": AnnotatorModelInfo(
+            #     model_name="meta/llama-3.1-405b-instruct-turbo",
+            #     model_deployment="together/llama-3.1-405b-instruct-turbo",
+            # ),
+            #
             # NOTE: anthropic/claude-3-5-sonnet-20241022 was deprecated on October 28, 2025.
             # See: https://docs.claude.com/en/docs/about-claude/model-deprecations
             #

--- a/src/helm/benchmark/annotation/wildbench_annotator.py
+++ b/src/helm/benchmark/annotation/wildbench_annotator.py
@@ -64,10 +64,13 @@ class WildBenchAnnotator(Annotator):
                 model_name="openai/gpt-4o-2024-05-13",
                 model_deployment="openai/gpt-4o-2024-05-13",
             ),
-            "llama": AnnotatorModelInfo(
-                model_name="meta/llama-3.1-405b-instruct-turbo",
-                model_deployment="together/llama-3.1-405b-instruct-turbo",
-            ),
+            # NOTE: meta/llama-3.1-405b-instruct-turbo was deprecated on March 6, 2026.
+            # See: https://docs.claude.com/en/docs/about-claude/model-deprecations
+            #
+            # "llama": AnnotatorModelInfo(
+            #     model_name="meta/llama-3.1-405b-instruct-turbo",
+            #     model_deployment="together/llama-3.1-405b-instruct-turbo",
+            # ),
             # NOTE: anthropic/claude-3-5-sonnet-20241022 was deprecated on October 28, 2025.
             # See: https://docs.claude.com/en/docs/about-claude/model-deprecations
             #

--- a/src/helm/config/model_metadata.yaml
+++ b/src/helm/config/model_metadata.yaml
@@ -2210,7 +2210,7 @@ models:
     access: open
     num_parameters: 405000000000
     release_date: 2024-07-23
-    tags: [TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
+    tags: [DEPRECATED_MODEL_TAG, TEXT_MODEL_TAG, LIMITED_FUNCTIONALITY_TEXT_MODEL_TAG, INSTRUCTION_FOLLOWING_MODEL_TAG]
 
   - name: meta/llama-3.2-1b-instruct
     display_name: Llama 3.2 Instruct (1.23B)


### PR DESCRIPTION
This model is used as a judge by various scenarios, so this change removes it from those scenarios.