### PR TITLE
Widen the version range for openai-whisper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -348,7 +348,7 @@ audiolm = [
     "einops~=0.7.0",
 
     # For LLaMA-Omni
-    "openai-whisper==20240930",
+    "openai-whisper>=20240930",
 
     # For Qwen2.5-Omni
     "transformers_stream_generator~=0.0.4",

--- a/uv.lock
+++ b/uv.lock
@@ -1748,7 +1748,7 @@ requires-dist = [
     { name = "omegaconf", marker = "extra == 'heim'", specifier = "~=2.3" },
     { name = "open-clip-torch", marker = "extra == 'vlm'", specifier = "~=2.24" },
     { name = "openai", marker = "extra == 'openai'", specifier = "~=2.8" },
-    { name = "openai-whisper", marker = "extra == 'audiolm'", specifier = "==20240930" },
+    { name = "openai-whisper", marker = "extra == 'audiolm'", specifier = ">=20240930" },
     { name = "opencc", marker = "extra == 'cleva'", specifier = "~=1.1" },
     { name = "opencv-python", marker = "python_full_version >= '3.10' and extra == 'heim'", specifier = ">=4.7.0.68,<4.8.2.0" },
     { name = "opencv-python-headless", marker = "python_full_version < '3.10' and extra == 'heim'", specifier = ">=4.7.0.68,<=4.11.0.86" },


### PR DESCRIPTION
We originally pinned the version to `20240930` because this was used for the HELM leaderboard evaluations. However, this version has a build-time dependency on specific versions of `setuptools`, which is very annoying for users. As such, we widen the allowed versions to allow more recent versions that do not have this build-time dependency.

Fixes #4235