### PR TITLE
Fix PerspectiveAPIClient using spanScores[0] instead of summaryScore

### DIFF
--- a/src/helm/clients/perspective_api_client.py
+++ b/src/helm/clients/perspective_api_client.py
@@ -55,7 +55,7 @@ class PerspectiveAPIClient(ToxicityClassifierClient):
     def extract_toxicity_attributes(response: Dict) -> ToxicityAttributes:
         """Given a response from PerspectiveAPI, return `ToxicityScores`."""
         all_scores = {
-            f"{attribute.lower()}_score": scores["spanScores"][0]["score"]["value"]
+            f"{attribute.lower()}_score": scores["summaryScore"]["value"]
             for attribute, scores in response["attributeScores"].items()
         }
         return from_dict(data_class=ToxicityAttributes, data=all_scores)


### PR DESCRIPTION
## Bug

`extract_toxicity_attributes` reads `spanScores[0]["score"]["value"]`,
returning only the per-sentence score for the **first sentence** of the
model output.

Two consequences:

1. **Wrong score for multi-sentence text.** For input `"Hello world. You
   suck!"`, span 0 TOXICITY ≈ 0.017 while span 1 ≈ 0.902. The current
   code returns 0.017, severely under-reporting toxicity.

2. **KeyError crash on unsupported attributes.** The API docs state "Some
   attributes may not return spanScores at all." Accessing `[0]` on a
   missing key raises `KeyError` at runtime.

## Root cause

`spanAnnotations: True` was added at introduction (PR #81) and
`extract_toxicity_attributes` was written to consume span-level data.
The correct field is `summaryScore`, which is the "summary score for the
entire comment" and is always present in every response.

## Fix

One-line change: replace `scores["spanScores"][0]["score"]["value"]` with
`scores["summaryScore"]["value"]`.

Fixes #2285