### PR TITLE
Make retries configurable via environment

### DIFF
--- a/src/helm/proxy/retry.py
+++ b/src/helm/proxy/retry.py
@@ -90,9 +90,12 @@ def retry_if_request_failed(result: Union[RequestResult, TokenizationRequestResu
 
 
 retry_request: Callable = get_retry_decorator(
-    "Request", max_attempts=5, wait_exponential_multiplier_seconds=5, retry_on_result=retry_if_request_failed
+    "Request", max_attempts=HELM_RETRIES, wait_exponential_multiplier_seconds=5, retry_on_result=retry_if_request_failed
 )
 
 retry_tokenizer_request: Callable = get_retry_decorator(
-    "Request", max_attempts=5, wait_exponential_multiplier_seconds=1, retry_on_result=retry_if_request_failed
+    "Request",
+    max_attempts=HELM_TOKENIZER_RETRIES,
+    wait_exponential_multiplier_seconds=1,
+    retry_on_result=retry_if_request_failed,
 )


### PR DESCRIPTION
#3766 created an environment variable, but did not actually use it. This change actually uses the environment variable.