### PR TITLE
Upgrade openai-whisper dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -461,9 +461,6 @@ override-dependencies = [
     "numpy>=1.26,<3",
 ]
 
-[tool.uv.extra-build-dependencies]
-openai-whisper = ["setuptools==80.10.2"]
-
 [tool.setuptools]
 package-dir = { "" = "src" }
 zip-safe = false

--- a/uv.lock
+++ b/uv.lock
@@ -5884,7 +5884,7 @@ wheels = [
 
 [[package]]
 name = "openai-whisper"
-version = "20240930"
+version = "20250625"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "more-itertools" },
@@ -5896,7 +5896,7 @@ dependencies = [
     { name = "tqdm" },
     { name = "triton", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'linux2'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/77/952ca71515f81919bd8a6a4a3f89a27b09e73880cebf90957eda8f2f8545/openai-whisper-20240930.tar.gz", hash = "sha256:b7178e9c1615576807a300024f4daa6353f7e1a815dac5e38c33f1ef055dd2d2", size = 800544, upload-time = "2024-09-30T18:21:22.596Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/8e/d36f8880bcf18ec026a55807d02fe4c7357da9f25aebd92f85178000c0dc/openai_whisper-20250625.tar.gz", hash = "sha256:37a91a3921809d9f44748ffc73c0a55c9f366c85a3ef5c2ae0cc09540432eb96", size = 803191, upload-time = "2025-06-26T01:06:13.34Z" }
 
 [[package]]
 name = "opencc"


### PR DESCRIPTION
Remove `extra-build-dependencies` because it is not needed for the latest version of `openai-whisper`.

Stops uv from printing: `warning: The `extra-build-dependencies` option is experimental and may change without warning. Pass `--preview-features extra-build-dependencies` to disable this warning.`

Reverts #4159