### PR TITLE
Fix Cache.get treating falsy cached responses as cache misses

### DIFF
--- a/src/helm/common/cache.py
+++ b/src/helm/common/cache.py
@@ -189,7 +189,7 @@ class Cache(object):
         # TODO: Initialize key_value_store in constructor
         with create_key_value_store(self.config) as key_value_store:
             response = key_value_store.get(request)
-            if response:
+            if response is not None:
                 cached = True
             else:
                 cached = False


### PR DESCRIPTION
## Bug

`Cache.get` checks whether the key-value store returned a cached entry using a truthiness test:

```python
response = key_value_store.get(request)
if response:
    cached = True
```

`key_value_store.get()` is declared `-> Optional[Dict]`: it returns `None` on a cache miss and a `Dict` on a hit. The correct sentinel for "value not present" is `None`, not falsiness.

## Root cause

Any falsy-but-non-None value stored in the cache (e.g. an empty dict `{}` returned by a model client that produces no completions) will evaluate as `False`, causing `Cache.get` to treat the hit as a miss, re-call `compute()`, and overwrite the cached entry — repeating on every subsequent call.

## Fix

Replace the truthiness check with an explicit `None` test:

```python
if response is not None:
```

This matches the semantics of `Optional[Dict]` and is consistent with how `SqliteKeyValueStore.get` itself checks for hits (`if result is not None`).