### PR TITLE
fix(medhelm): score PubMedQA with punctuation-tolerant metric

### DIFF
--- a/src/helm/benchmark/run_specs/medhelm_run_specs.py
+++ b/src/helm/benchmark/run_specs/medhelm_run_specs.py
@@ -1273,7 +1273,9 @@ def get_pubmed_qa_spec() -> RunSpec:
         name="pubmed_qa",
         scenario_spec=scenario_spec,
         adapter_spec=adapter_spec,
-        metric_specs=get_exact_match_metric_specs(),
+        metric_specs=get_basic_metric_specs(
+            ["exact_match", "prefix_exact_match", "quasi_leave_articles_exact_match"]
+        ),
         groups=["pubmed_qa"],
     )
 

--- a/src/helm/benchmark/static/schema_medhelm.yaml
+++ b/src/helm/benchmark/static/schema_medhelm.yaml
@@ -87,6 +87,11 @@ metrics:
     short_display_name: EM
     description: Fraction of instances that the predicted output matches a correct reference up to light processing.
     lower_is_better: false
+  - name: quasi_leave_articles_exact_match
+    display_name: Quasi-exact match
+    short_display_name: EM
+    description: Fraction of instances that the predicted output matches a correct reference up to light processing.
+    lower_is_better: false
   - name: prefix_exact_match
     display_name: Prefix exact match
     short_display_name: PEM
@@ -995,7 +1000,7 @@ run_groups:
       - efficiency
       - general_information
     environment:
-      main_name: exact_match
+      main_name: quasi_leave_articles_exact_match
       main_split: test
     taxonomy:
       task: Question answering


### PR DESCRIPTION
## Summary
- compute quasi_leave_articles_exact_match for the MedHELM PubMedQA run spec
- add the metric to the MedHELM schema
- use it as the PubMedQA main metric so answers like "A." are scored consistently

Fixes #4187.

## Tests
- python3 -m compileall -q src/helm/benchmark/run_specs/medhelm_run_specs.py src/helm/benchmark/metrics/evaluate_reference_metrics.py
- python3 schema assertion for quasi_leave_articles_exact_match and PubMedQA main metric
- git diff --check