### PR TITLE
Remove stray debug print in TogetherClient

### DIFF
--- a/src/helm/clients/together_client.py
+++ b/src/helm/clients/together_client.py
@@ -286,7 +286,6 @@ class TogetherClient(CachingClient):
         completions: List[GeneratedOutput] = []
 
         for raw_completion in response["choices"]:
-            print(raw_completion)
             sequence_logprob = 0
             tokens: List[Token] = []
 


### PR DESCRIPTION
## Bug

`src/helm/clients/together_client.py` contains a stray `print(raw_completion)` (line 289) inside the response-handling loop. It was introduced in #4274 alongside the reasoning-handling fix and appears to be leftover debug output.

Every Together completion now prints the full raw response to stdout, polluting logs without serving any functional purpose.

## Fix

Remove the `print(raw_completion)` line.