### PR TITLE
Fix final_number_exact_match matching non-digits as the decimal part

### DIFF
--- a/src/helm/benchmark/metrics/evaluate_reference_metrics.py
+++ b/src/helm/benchmark/metrics/evaluate_reference_metrics.py
@@ -153,7 +153,7 @@ def final_number_exact_match(gold: str, pred: str) -> float:
     """
 
     def get_final_number(x: str) -> str:
-        matches = re.findall(r"-?[\d,]+(?:.\d+)?", x)
+        matches = re.findall(r"-?[\d,]+(?:\.\d+)?", x)
         if not matches:
             return ""
         return matches[-1].replace(",", "")


### PR DESCRIPTION
## Bug

`final_number_exact_match` extracts the final number from `gold` and `pred` using:

```python
matches = re.findall(r"-?[\d,]+(?:.\d+)?", x)
```

The `.` before `\d+` is meant to be a literal decimal point, but it is unescaped, so it matches *any* character. As a result the optional group greedily swallows a separator plus following digits, and two distinct numbers separated by a space (or any non-digit) are extracted as a single token:

```python
get_final_number("answer is 3 5")  # -> "3 5"  (should be "5")
get_final_number("3a5")            # -> "3a5"  (should be "5")
```

## Root cause

In a regex, `.` is the any-character metacharacter. `(?:.\d+)?` therefore matches "some character followed by digits", not "a decimal point followed by digits". When the final number is preceded by another number and a non-digit separator, `get_final_number` returns the wrong string, so the subsequent `exact_match` against the gold answer fails even when the true final number is correct. This metric is the main metric for GSM (`gsm_scenario.py`), so the bug produces false negatives on grade-school-math scoring.

## Fix

Escape the dot so it matches a literal decimal point:

```python
matches = re.findall(r"-?[\d,]+(?:\.\d+)?", x)
```

This is the clearly intended behavior (match an integer part with an optional `.<digits>` fractional part). All existing assertions in `test_final_number_exact_match` — including the decimal cases `"34.2"` and `"342."` and the comma case `"3,420"` — still pass, and `"answer is 3 5"` now correctly yields `"5"`.