### PR TITLE
Robustly parse predicted multiple-choice options containing punctuation or whitespace

### DIFF
--- a/src/helm/benchmark/metrics/evaluate_reference_metrics.py
+++ b/src/helm/benchmark/metrics/evaluate_reference_metrics.py
@@ -510,7 +510,19 @@ def compute_reference_metrics(
     if request_state.output_mapping is not None:
         if adapter_spec.output_mapping_pattern:
             preds = [_apply_output_mapping_pattern(adapter_spec.output_mapping_pattern, pred) for pred in preds]
-        preds = [request_state.output_mapping.get(pred) for pred in preds]  # type: ignore
+        
+        def clean_and_get(pred: str) -> Optional[str]:
+            if pred in request_state.output_mapping:
+                return request_state.output_mapping[pred]
+            cleaned = "".join(char for char in pred if char.isalnum())
+            if cleaned in request_state.output_mapping:
+                return request_state.output_mapping[cleaned]
+            for char in pred:
+                if char.isalnum() and char in request_state.output_mapping:
+                    return request_state.output_mapping[char]
+            return None
+
+        preds = [clean_and_get(pred) for pred in preds]  # type: ignore
 
     # Compute max_prob, the probability that the model assigns to its generated text.
     # Use the log prob of sorted_completions[0], which is the completion with the highest


### PR DESCRIPTION
### Bug
When running multiple-choice scenarios like PubMedQA, a correct LLM response is sometimes marked as incorrect simply because it contains a period or extra whitespace after the option letter (e.g., predicted "A." or "A " instead of just "A").

### Root Cause
In `evaluate_reference_metrics.py`, `preds` are mapped back to their original reference texts using `request_state.output_mapping.get(pred)`. Since `output_mapping` only contains pure option letters as keys (e.g. "A", "B", "C"), any predicted option with trailing punctuation or whitespace like "A." will fail the lookup, returning `None` and resulting in an incorrect evaluation.

### Why Fix is Correct
The fix wraps the lookup in a helper function that checks if the prediction is in the mapping directly. If not, it strips non-alphanumeric characters (reducing "A." to "A") and maps the result. As a final fallback, it checks characters in the prediction to extract any matching single alphanumeric choice. This cleanly handles periods, trailing spaces, or line breaks, ensuring accurate correctness evaluations.