### PR TITLE
Add metadata for Unitxt scenarios and metrics

### DIFF
--- a/src/helm/benchmark/metrics/unitxt_metrics.py
+++ b/src/helm/benchmark/metrics/unitxt_metrics.py
@@ -1,8 +1,12 @@
 import numbers
 import re
-from typing import Dict, List, Set
+from typing import Any, Dict, List, Optional, Set, Union
+from threading import Lock
 
-from helm.benchmark.metrics.metric import MetricInterface, MetricResult, PerInstanceStats
+from datasets import Dataset, IterableDataset
+
+from helm.benchmark.adaptation.request_state import RequestState
+from helm.benchmark.metrics.metric import MetricInterface, MetricMetadata, MetricResult, PerInstanceStats
 from helm.benchmark.adaptation.scenario_state import ScenarioState
 from helm.benchmark.metrics.metric_name import MetricName
 from helm.benchmark.metrics.metric_service import MetricService
@@ -11,7 +15,11 @@ from helm.common.hierarchical_logger import hwarn
 from helm.common.optional_dependencies import handle_module_not_found_error
 
 try:
-    from unitxt import load_dataset, evaluate
+    from unitxt import evaluate, load_dataset
+    from unitxt.api import load_recipe
+    from unitxt.artifact import fetch_artifact
+    from unitxt.base_metric import Metric
+
 except ModuleNotFoundError as e:
     handle_module_not_found_error(e, suggestions=["unitxt"])
 
@@ -21,95 +29,142 @@ class UnitxtMetric(MetricInterface):
 
     def __init__(self, **kwargs):
         super().__init__()
-        if len(kwargs) == 1 and "recipe" in kwargs:
-            unitxt_dataset = load_dataset(kwargs["recipe"])
-        else:
-            unitxt_dataset = load_dataset(**kwargs)
+        self.kwargs = kwargs
+        self._lock = Lock()
+        self._dataset_dict: Optional[Dict[str, Union[Dataset, IterableDataset]]] = None
 
-        if isinstance(unitxt_dataset, dict):
-            self.dataset = unitxt_dataset
-        else:
-            if "split" in kwargs:
-                self.dataset = {kwargs["split"]: unitxt_dataset}
-            else:
-                raise Exception("Expected Unitxt `load_dataset()` to return a dict because `split` was not specified")
+    def get_dataset_dict(self) -> Dict[str, Union[Dataset, IterableDataset]]:
+        if not self._dataset_dict:
+            with self._lock:
+                if len(self.kwargs) == 1 and "recipe" in self.kwargs:
+                    unitxt_dataset = load_dataset(self.kwargs["recipe"])
+                else:
+                    unitxt_dataset = load_dataset(**self.kwargs)
+
+                if isinstance(unitxt_dataset, dict):
+                    self._dataset_dict = unitxt_dataset
+                else:
+                    if "split" in self.kwargs:
+                        self._dataset_dict = {self.kwargs["split"]: unitxt_dataset}
+                    else:
+                        raise Exception(
+                            "Expected Unitxt `load_dataset()` to return a dict because `split` was not specified"
+                        )
+
+        return self._dataset_dict
+
+    def get_split_to_request_states(self, scenario_state: ScenarioState) -> Dict[str, List[RequestState]]:
+        split_to_request_states: Dict[str, List[RequestState]] = {}
+        for request_state in scenario_state.request_states:
+            split = request_state.instance.split
+            assert split is not None
+            if split not in split_to_request_states:
+                split_to_request_states[split] = []
+            split_to_request_states[split].append(request_state)
+        return split_to_request_states
 
     def evaluate(
         self, scenario_state: ScenarioState, metric_service: MetricService, eval_cache_path: str, parallelism: int
     ) -> MetricResult:
-        # Fetch references from dataset and make them parallel to predictions
-        predictions: List[str] = []
-        references: List = []
-        for request_state in scenario_state.request_states:
-            assert request_state.instance.id
-            id_match = UnitxtMetric.ID_PATTERN.match(request_state.instance.id)
-            assert id_match
-            unitxt_split_name = id_match.group(1)
-            row_index = int(id_match.group(2))
-            references.append(self.dataset[unitxt_split_name][row_index])
-            assert request_state.result
-            assert len(request_state.result.completions) == 1
-            predictions.append(request_state.result.completions[0].text)
-
-        # Compute metrics
-        evaluate_results: List[Dict] = evaluate(predictions=predictions, dataset=references)
-
-        # Extract instance metrics
-        non_number_instance_metric_names: Set[str] = set()
         per_instance_stats: List[PerInstanceStats] = []
-        for request_state, evaluate_result in zip(scenario_state.request_states, evaluate_results):
-            instance = request_state.instance
-            instance_stats: List[Stat] = []
-            instance_results = evaluate_result["score"]["instance"]
-            for metric_name, metric_score in instance_results.items():
-                if metric_name == "score" or metric_name == "score_name":
-                    continue
-                stat = Stat(
-                    MetricName(
-                        name=metric_name,
-                        split=instance.split,
-                        sub_split=instance.sub_split,
-                        perturbation=instance.perturbation,
+        aggregated_stats: List[Stat] = []
+        non_number_instance_metric_names: Set[str] = set()
+
+        # Fetch references from dataset and make them parallel to predictions
+        dataset_dict = self.get_dataset_dict()
+        split_to_request_states = self.get_split_to_request_states(scenario_state)
+        for helm_split, request_states in split_to_request_states.items():
+            # Fetch references from dataset and make them parallel to predictions
+            predictions: List[str] = []
+            references: List[Any] = []
+            for request_state in request_states:
+                assert request_state.instance.id
+                id_match = UnitxtMetric.ID_PATTERN.match(request_state.instance.id)
+                assert id_match
+                unitxt_split_name = id_match.group(1)
+                row_index = int(id_match.group(2))
+                references.append(dataset_dict[unitxt_split_name][row_index])
+                assert request_state.result
+                assert len(request_state.result.completions) == 1
+                predictions.append(request_state.result.completions[0].text)
+
+            # Compute metrics
+            evaluate_results: List[Dict] = evaluate(predictions=predictions, dataset=references)
+
+            # Extract instance metrics
+            for request_state, evaluate_result in zip(request_states, evaluate_results):
+                instance = request_state.instance
+                instance_stats: List[Stat] = []
+                instance_results = evaluate_result["score"]["instance"]
+                for metric_name, metric_score in instance_results.items():
+                    if metric_name == "score" or metric_name == "score_name":
+                        continue
+                    assert instance.split == helm_split
+                    stat = Stat(
+                        MetricName(
+                            name=metric_name,
+                            split=instance.split,
+                            sub_split=instance.sub_split,
+                            perturbation=instance.perturbation,
+                        )
                     )
-                )
-                if isinstance(metric_score, list):
-                    for metric_score_element in metric_score:
-                        if isinstance(metric_score_element, numbers.Number):
-                            stat = stat.add(metric_score_element)
+                    if isinstance(metric_score, list):
+                        for metric_score_element in metric_score:
+                            if isinstance(metric_score_element, numbers.Number):
+                                stat = stat.add(metric_score_element)
+                            else:
+                                non_number_instance_metric_names.add(metric_name)
+                    else:
+                        if isinstance(metric_score, numbers.Number):
+                            stat = stat.add(metric_score)
                         else:
                             non_number_instance_metric_names.add(metric_name)
-                else:
-                    if isinstance(metric_score, numbers.Number):
-                        stat = stat.add(metric_score)
-                    else:
-                        non_number_instance_metric_names.add(metric_name)
-                instance_stats.append(stat)
-            assert instance.id
-            per_instance_stats.append(
-                PerInstanceStats(
-                    instance_id=instance.id,
-                    perturbation=instance.perturbation,
-                    train_trial_index=request_state.train_trial_index,
-                    stats=instance_stats,
+                    instance_stats.append(stat)
+                assert instance.id
+                per_instance_stats.append(
+                    PerInstanceStats(
+                        instance_id=instance.id,
+                        perturbation=instance.perturbation,
+                        train_trial_index=request_state.train_trial_index,
+                        stats=instance_stats,
+                    )
                 )
-            )
-        if non_number_instance_metric_names:
-            hwarn(
-                "Ignored Unitxt instance metrics because " f"they were not numbers: {non_number_instance_metric_names}"
-            )
 
-        # Extract global metrics
-        aggregated_stats: List[Stat] = []
-        if len(evaluate_results) > 0:
-            global_results = evaluate_results[-1]["score"]["global"]
-            for metric_name, metric_score in global_results.items():
-                if metric_name == "score" or metric_name == "score_name":
-                    continue
-                stat = Stat(MetricName(name=metric_name))
-                if isinstance(metric_score, list):
-                    for metric_score_element in metric_score:
-                        stat = stat.add(metric_score_element)
-                else:
-                    stat = stat.add(metric_score)
-                aggregated_stats.append(stat)
+            # Extract global metrics for this split
+            if len(evaluate_results) > 0:
+                global_results = evaluate_results[-1]["score"]["global"]
+                for metric_name, metric_score in global_results.items():
+                    if metric_name == "score" or metric_name == "score_name":
+                        continue
+                    stat = Stat(MetricName(name=metric_name, split=helm_split))
+                    if isinstance(metric_score, list):
+                        for metric_score_element in metric_score:
+                            stat = stat.add(metric_score_element)
+                    else:
+                        stat = stat.add(metric_score)
+                    aggregated_stats.append(stat)
+        if non_number_instance_metric_names:
+            hwarn(f"Ignored Unitxt instance metrics because they were not numbers: {non_number_instance_metric_names}")
         return MetricResult(aggregated_stats=aggregated_stats, per_instance_stats=per_instance_stats)
+
+    def get_metadata(self):
+        if len(self.kwargs) == 1 and "recipe" in self.kwargs:
+            recipe = load_recipe(self.kwargs["recipe"])
+        else:
+            recipe = load_recipe(**self.kwargs)
+        metric_names = recipe.task.metrics
+        assert metric_names
+        metric_metadata = []
+        for metric_name in metric_names:
+            metric, _ = fetch_artifact(metric_names[0])
+            assert isinstance(metric, Metric)
+            metric_name = metric.main_score
+            metric_metadata.append(
+                MetricMetadata(
+                    name=metric_name,
+                    display_name=metric_name,
+                    description=f"{metric_name} (Unitxt)",
+                    group="unitxt",
+                ),
+            )
+        return metric_metadata

--- a/src/helm/benchmark/metrics/unitxt_metrics.py
+++ b/src/helm/benchmark/metrics/unitxt_metrics.py
@@ -1,8 +1,7 @@
 import inspect
 import numbers
 import re
-from typing import Any, Dict, List, Optional, Set, Union
-from threading import Lock
+from typing import Any, Dict, List, Set, Union
 
 from datasets import Dataset, IterableDataset
 
@@ -31,28 +30,20 @@ class UnitxtMetric(MetricInterface):
     def __init__(self, **kwargs):
         super().__init__()
         self.kwargs = kwargs
-        self._lock = Lock()
-        self._dataset_dict: Optional[Dict[str, Union[Dataset, IterableDataset]]] = None
 
     def get_dataset_dict(self) -> Dict[str, Union[Dataset, IterableDataset]]:
-        if not self._dataset_dict:
-            with self._lock:
-                if len(self.kwargs) == 1 and "recipe" in self.kwargs:
-                    unitxt_dataset = load_dataset(self.kwargs["recipe"])
-                else:
-                    unitxt_dataset = load_dataset(**self.kwargs)
+        if len(self.kwargs) == 1 and "recipe" in self.kwargs:
+            unitxt_dataset = load_dataset(self.kwargs["recipe"])
+        else:
+            unitxt_dataset = load_dataset(**self.kwargs)
 
-                if isinstance(unitxt_dataset, dict):
-                    self._dataset_dict = unitxt_dataset
-                else:
-                    if "split" in self.kwargs:
-                        self._dataset_dict = {self.kwargs["split"]: unitxt_dataset}
-                    else:
-                        raise Exception(
-                            "Expected Unitxt `load_dataset()` to return a dict because `split` was not specified"
-                        )
-
-        return self._dataset_dict
+        if isinstance(unitxt_dataset, dict):
+            return unitxt_dataset
+        else:
+            if "split" in self.kwargs:
+                return {self.kwargs["split"]: unitxt_dataset}
+            else:
+                raise Exception("Expected Unitxt `load_dataset()` to return a dict because `split` was not specified")
 
     def get_split_to_request_states(self, scenario_state: ScenarioState) -> Dict[str, List[RequestState]]:
         split_to_request_states: Dict[str, List[RequestState]] = {}

--- a/src/helm/benchmark/metrics/unitxt_metrics.py
+++ b/src/helm/benchmark/metrics/unitxt_metrics.py
@@ -151,11 +151,12 @@ class UnitxtMetric(MetricInterface):
             metric, _ = fetch_artifact(metric_names[0])
             assert isinstance(metric, Metric)
             metric_name = metric.main_score
+            display_name = metric_name.replace("_", " ").title()
             description = inspect.getdoc(metric) or metric_name
             metric_metadata.append(
                 MetricMetadata(
                     name=metric_name,
-                    display_name=metric_name,
+                    display_name=display_name,
                     description=description,
                     group="unitxt",
                 ),

--- a/src/helm/benchmark/metrics/unitxt_metrics.py
+++ b/src/helm/benchmark/metrics/unitxt_metrics.py
@@ -1,3 +1,4 @@
+import inspect
 import numbers
 import re
 from typing import Any, Dict, List, Optional, Set, Union
@@ -159,11 +160,12 @@ class UnitxtMetric(MetricInterface):
             metric, _ = fetch_artifact(metric_names[0])
             assert isinstance(metric, Metric)
             metric_name = metric.main_score
+            description = inspect.getdoc(metric) or metric_name
             metric_metadata.append(
                 MetricMetadata(
                     name=metric_name,
                     display_name=metric_name,
-                    description=f"{metric_name} (Unitxt)",
+                    description=description,
                     group="unitxt",
                 ),
             )

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -600,14 +600,14 @@ class Summarizer:
         scenario_specs = list(set(scenario_specs))
         scenario_name_to_metadata: Dict[str, ScenarioMetadata] = {}
         for scenario_spec in scenario_specs:
-            # try:
-            scenario: Scenario = create_scenario(scenario_spec)
-            scenario_metadata = scenario.get_metadata()
-            scenario_name_to_metadata[scenario_metadata.name] = scenario_metadata
-            # except NotImplementedError:
-            #     pass
-            # except (ModuleNotFoundError, AttributeError, TypeError):
-            #     pass
+            try:
+                scenario: Scenario = create_scenario(scenario_spec)
+                scenario_metadata = scenario.get_metadata()
+                scenario_name_to_metadata[scenario_metadata.name] = scenario_metadata
+            except NotImplementedError:
+                pass
+            except (ModuleNotFoundError, AttributeError, TypeError):
+                pass
 
         run_groups: Set[str] = set()
         for run in self.runs:

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -600,14 +600,14 @@ class Summarizer:
         scenario_specs = list(set(scenario_specs))
         scenario_name_to_metadata: Dict[str, ScenarioMetadata] = {}
         for scenario_spec in scenario_specs:
-            try:
-                scenario: Scenario = create_scenario(scenario_spec)
-                scenario_metadata = scenario.get_metadata()
-                scenario_name_to_metadata[scenario_metadata.name] = scenario_metadata
-            except NotImplementedError:
-                pass
-            except (ModuleNotFoundError, AttributeError, TypeError):
-                pass
+            # try:
+            scenario: Scenario = create_scenario(scenario_spec)
+            scenario_metadata = scenario.get_metadata()
+            scenario_name_to_metadata[scenario_metadata.name] = scenario_metadata
+            # except NotImplementedError:
+            #     pass
+            # except (ModuleNotFoundError, AttributeError, TypeError):
+            #     pass
 
         run_groups: Set[str] = set()
         for run in self.runs:

--- a/src/helm/benchmark/scenarios/unitxt_scenario.py
+++ b/src/helm/benchmark/scenarios/unitxt_scenario.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from helm.benchmark.presentation.taxonomy_info import TaxonomyInfo
 from helm.benchmark.scenarios.scenario import (
     Output,
     Reference,
@@ -10,11 +11,15 @@ from helm.benchmark.scenarios.scenario import (
     TRAIN_SPLIT,
     TEST_SPLIT,
     VALID_SPLIT,
+    ScenarioMetadata,
 )
 from helm.common.optional_dependencies import handle_module_not_found_error
 
 try:
     from unitxt import load_dataset
+    from unitxt.api import load_recipe
+    from unitxt.artifact import fetch_artifact
+    from unitxt.base_metric import Metric
 except ModuleNotFoundError as e:
     handle_module_not_found_error(e, suggestions=["unitxt"])
 
@@ -74,3 +79,35 @@ class UnitxtScenario(Scenario):
                 )
                 instances.append(instance)
         return instances
+
+    def get_metadata(self):
+        if len(self.kwargs) == 1 and "recipe" in self.kwargs:
+            recipe = load_recipe(self.kwargs["recipe"])
+        else:
+            recipe = load_recipe(**self.kwargs)
+        description = recipe.__description__
+        metric_names = recipe.task.metrics
+        assert metric_names
+        metric, _ = fetch_artifact(metric_names[0])
+        assert isinstance(metric, Metric)
+        main_metric_name = metric.main_score
+        scenario_name = f'unitxt_{self.kwargs.get("card") or self.kwargs.get("recipe")}'
+        if "split" in self.kwargs:
+            self.UNITXT_SPLIT_NAME_TO_HELM_SPLIT_NAME[self.kwargs["split"]]
+        else:
+            split = TEST_SPLIT
+        return ScenarioMetadata(
+            name=scenario_name,
+            display_name=scenario_name,
+            short_display_name=scenario_name,
+            description=description,
+            taxonomy=TaxonomyInfo(
+                task="?",
+                what="?",
+                when="?",
+                who="?",
+                language="?",
+            ),
+            main_metric=main_metric_name,
+            main_split=split,
+        )

--- a/src/helm/benchmark/scenarios/unitxt_scenario.py
+++ b/src/helm/benchmark/scenarios/unitxt_scenario.py
@@ -85,28 +85,31 @@ class UnitxtScenario(Scenario):
             recipe = load_recipe(self.kwargs["recipe"])
         else:
             recipe = load_recipe(**self.kwargs)
-        description = recipe.__description__
+        card = recipe.card
+        description = card.__description__
+        task = card.__tags__.get("task_categories", "?").replace("-", " ")
+        language = card.__tags__.get("language", "?")
         metric_names = recipe.task.metrics
         assert metric_names
         metric, _ = fetch_artifact(metric_names[0])
         assert isinstance(metric, Metric)
         main_metric_name = metric.main_score
         scenario_name = f'unitxt_{self.kwargs.get("card") or self.kwargs.get("recipe")}'
+        display_name = " ".join(scenario_name.split(".")[1:]).replace("_", " ").title()
         if "split" in self.kwargs:
             self.UNITXT_SPLIT_NAME_TO_HELM_SPLIT_NAME[self.kwargs["split"]]
         else:
             split = TEST_SPLIT
         return ScenarioMetadata(
             name=scenario_name,
-            display_name=scenario_name,
-            short_display_name=scenario_name,
+            display_name=display_name,
             description=description,
             taxonomy=TaxonomyInfo(
-                task="?",
+                task=task,
                 what="?",
                 when="?",
                 who="?",
-                language="?",
+                language=language,
             ),
             main_metric=main_metric_name,
             main_split=split,


### PR DESCRIPTION
- Populates metadata by introspecting on Unitxt objects
- Load the dataset inside `evaluate()` instead of `__init__()` so that the metadata can be obtained without loading the dataset
- Minor fix to `UnitxtMetric`. Previously, global Unitxt metrics were computed across all instances and presented with a `MetricName` with `split` as `None`. Now, the metrics are computed per-split, and presented with a `MetricName` with `split` set correctly.

Addresses #4291