### PR TITLE
Fix codeinsights ast_distance / asm_distance returning similarity not distance

### DIFF
--- a/src/helm/benchmark/metrics/codeinsights_code_evaluation_metrics.py
+++ b/src/helm/benchmark/metrics/codeinsights_code_evaluation_metrics.py
@@ -88,7 +88,11 @@ class ASTAnalyzer:
             nodes1: List[str] = self._extract_ast_features(tu1.cursor)
             nodes2: List[str] = self._extract_ast_features(tu2.cursor)
 
-            return levenshtein_distance_ratio(nodes1, nodes2)
+            # `Levenshtein.ratio` is a similarity in [0, 1] (1.0 = identical),
+            # while the docstring, the public stat name "ast_distance", and the
+            # error-fallback `return 1.0` below all assume *distance* semantics
+            # (0 = identical, 1 = completely different). Convert to a distance.
+            return 1.0 - levenshtein_distance_ratio(nodes1, nodes2)
 
         except Exception:
             # any parse error or clang error → max distance
@@ -232,7 +236,10 @@ class CodeInsightsCodeEvaluationMetric(Metric):
         if gen_asm == "" or truth_asm == "":
             asm_distance = 1.0
         else:
-            asm_distance = levenshtein_distance_ratio(gen_asm, truth_asm)
+            # `Levenshtein.ratio` returns a similarity in [0, 1]; convert to
+            # distance so the value matches the "asm_distance" stat name and
+            # the compile-failure fallback above (1.0 = max distance).
+            asm_distance = 1.0 - levenshtein_distance_ratio(gen_asm, truth_asm)
 
         # Create assembly-based statistics
         stats.extend(self._create_asm_stats(asm_distance))

--- a/src/helm/benchmark/metrics/test_codeinsights_code_evaluation_metrics.py
+++ b/src/helm/benchmark/metrics/test_codeinsights_code_evaluation_metrics.py
@@ -1,0 +1,64 @@
+"""Tests for codeinsights_code_evaluation_metrics distance semantics.
+
+`Levenshtein.ratio` returns a *similarity* in [0, 1] (1.0 = identical), but the
+metric is reported as ``ast_distance`` / ``asm_distance`` and its error
+fallback returns 1.0 for "max distance". Computing similarity directly meant a
+perfect match was reported as 1.0 — indistinguishable from a parse failure.
+These tests pin the distance semantics: identical inputs return 0.0 and a
+totally-different input returns 1.0.
+"""
+
+import pytest
+
+
+# The module imports clang.cindex and Levenshtein at top level (both ship in
+# the codeinsights extras). Skip cleanly when they're absent.
+clang_cindex = pytest.importorskip("clang.cindex")
+pytest.importorskip("Levenshtein")
+
+
+def _patch_clang_index(monkeypatch):
+    """Replace clang.cindex.Index.create so ASTAnalyzer.__init__ doesn't need
+    libclang installed; ``parse`` round-trips the source text through .cursor
+    so the stubbed _extract_ast_features can read it back."""
+
+    class _DummyTU:
+        def __init__(self, code: str) -> None:
+            self.cursor = code
+
+    class _DummyIndex:
+        def parse(self, path, args, unsaved_files):
+            return _DummyTU(unsaved_files[0][1])
+
+    monkeypatch.setattr(clang_cindex.Index, "create", staticmethod(lambda: _DummyIndex()))
+
+
+def test_calculate_ast_distance_identical_returns_zero(monkeypatch):
+    _patch_clang_index(monkeypatch)
+    from helm.benchmark.metrics.codeinsights_code_evaluation_metrics import ASTAnalyzer
+
+    analyzer = ASTAnalyzer()
+    analyzer._extract_ast_features = lambda cursor: list(cursor)
+
+    assert analyzer.calculate_ast_distance("int x = 1;", "int x = 1;") == 0.0
+
+
+def test_calculate_ast_distance_completely_different_returns_one(monkeypatch):
+    _patch_clang_index(monkeypatch)
+    from helm.benchmark.metrics.codeinsights_code_evaluation_metrics import ASTAnalyzer
+
+    analyzer = ASTAnalyzer()
+    analyzer._extract_ast_features = lambda cursor: list(cursor)
+
+    assert analyzer.calculate_ast_distance("aaaa", "zzzz") == 1.0
+
+
+def test_calculate_ast_distance_partial_overlap_is_small_positive(monkeypatch):
+    _patch_clang_index(monkeypatch)
+    from helm.benchmark.metrics.codeinsights_code_evaluation_metrics import ASTAnalyzer
+
+    analyzer = ASTAnalyzer()
+    analyzer._extract_ast_features = lambda cursor: list(cursor)
+
+    distance = analyzer.calculate_ast_distance("int x = 1;", "int y = 2;")
+    assert 0.0 < distance < 1.0


### PR DESCRIPTION
## Summary

`codeinsights_code_evaluation_metrics.py` imports

```python
from Levenshtein import ratio as levenshtein_distance_ratio
```

then in `ASTAnalyzer.calculate_ast_distance` (and the assembly path in `CodeInsightsCodeEvaluationMetric.evaluate_generation`) returns it directly:

```python
return levenshtein_distance_ratio(nodes1, nodes2)   # AST
asm_distance = levenshtein_distance_ratio(gen_asm, truth_asm)
```

`Levenshtein.ratio` is a **similarity** in `[0, 1]` (1.0 = identical, 0.0 = completely different), but everything around the call site assumes **distance** semantics:

| signal | says |
| --- | --- |
| function name `calculate_ast_distance` | distance |
| docstring | *"a float in [0,1], where 0 means identical ASTs and 1 means completely different (or a parse failure)"* |
| stat names `MetricName("ast_distance")` / `"asm_distance"` (contrasted with the sibling `"codebert_similarity"` in the same class) | distance |
| error fallbacks (`return 1.0` for parse failure, `asm_distance = 1.0` for compile failure, comment *"max distance for errors"*) | distance |

So a **perfect AST or ASM match was reported as 1.0**, indistinguishable from a parse / compile failure, and the ordering was inverted (higher score looked better than lower).

## Fix

Convert similarity to distance at the two call sites:

```python
return 1.0 - levenshtein_distance_ratio(nodes1, nodes2)
asm_distance = 1.0 - levenshtein_distance_ratio(gen_asm, truth_asm)
```

The legacy batch helper `evaluate_ast_distances_batch` calls `analyzer.calculate_ast_distance(...)` and so picks up the fix transitively.

## Why this isn't a behavior change someone would be relying on

- No other file in the repo references `ast_distance` / `asm_distance` / `normalized_distance` — no presentation/schema, no `higher_is_better`/`lower_is_better` annotation, no test.
- The error fallbacks already use 1.0 as "max distance", so any consumer that read those error values was already assuming distance semantics.

## Test plan

Added `src/helm/benchmark/metrics/test_codeinsights_code_evaluation_metrics.py`. Uses `pytest.importorskip` for the optional `codeinsights` extras (`clang.cindex`, `Levenshtein`) and stubs `clang.cindex.Index.create` + `_extract_ast_features` so the tests don't need a real libclang install:

- identical inputs → `0.0` (matches docstring)
- totally different inputs → `1.0`
- partial overlap → small positive in `(0, 1)`

The first two **fail on `main`** (return `1.0` and `0.0` respectively) and **pass** with this change. `pytest -o addopts=""` on the new file → 3 passed; `black --check` clean on both files.