### PR TITLE
Fix JSON serialization round trip for ModelMetadata dates

### DIFF
--- a/src/helm/benchmark/model_metadata_registry.py
+++ b/src/helm/benchmark/model_metadata_registry.py
@@ -6,6 +6,12 @@ import dacite
 import yaml
 
 
+# dacite cannot reconstruct a `date` from an ISO format string on its own, so
+# provide a type hook that parses the string back into a `date`. Use this config
+# whenever deserializing a dataclass that contains a `ModelMetadata`.
+DACITE_CONFIG = dacite.Config(type_hooks={date: date.fromisoformat})
+
+
 # Different modalities
 TEXT_MODEL_TAG: str = "TEXT_MODEL_TAG"
 IMAGE_MODEL_TAG: str = "IMAGE_MODEL_TAG"

--- a/src/helm/benchmark/test_model_metadata_registry.py
+++ b/src/helm/benchmark/test_model_metadata_registry.py
@@ -1,0 +1,33 @@
+import json
+from dataclasses import asdict
+from datetime import date
+
+from dacite import from_dict
+
+from helm.benchmark.model_metadata_registry import (
+    DACITE_CONFIG,
+    ModelMetadata,
+    TEXT_MODEL_TAG,
+)
+from helm.common.general import serialize_dates
+
+
+def test_model_metadata_json_round_trip():
+    """ModelMetadata has a `release_date` date field that the json standard
+    library cannot round-trip on its own. Check that serialize_dates and the
+    dacite type hook in DACITE_CONFIG together preserve the value."""
+    model_metadata = ModelMetadata(
+        name="openai/davinci",
+        creator_organization_name="OpenAI",
+        display_name="davinci",
+        description="A model.",
+        access="limited",
+        release_date=date(2021, 8, 11),
+        tags=[TEXT_MODEL_TAG],
+    )
+
+    serialized = json.dumps(asdict(model_metadata), default=serialize_dates)
+    deserialized = from_dict(ModelMetadata, json.loads(serialized), config=DACITE_CONFIG)
+
+    assert deserialized == model_metadata
+    assert deserialized.release_date == date(2021, 8, 11)

--- a/src/helm/proxy/server.py
+++ b/src/helm/proxy/server.py
@@ -22,7 +22,7 @@ from helm.benchmark.config_registry import (
 from helm.benchmark.model_deployment_registry import get_default_model_deployment_for_model
 from helm.common.authentication import Authentication
 from helm.common.cache_backend_config import CacheBackendConfig, MongoCacheBackendConfig, SqliteCacheBackendConfig
-from helm.common.general import ensure_directory_exists
+from helm.common.general import ensure_directory_exists, serialize_dates
 from helm.common.hierarchical_logger import hlog, setup_default_logging
 from helm.common.optional_dependencies import handle_module_not_found_error
 from helm.common.request import Request
@@ -67,7 +67,9 @@ def safe_call(func, to_json=True):
         start_time = time.time()
         result = func(params)
         end_time = time.time()
-        result = json.dumps(result) if to_json else result
+        # `result` may contain dates (e.g. ModelMetadata.release_date), which the
+        # json standard library cannot serialize without a custom default.
+        result = json.dumps(result, default=serialize_dates) if to_json else result
         hlog("REQUEST {}: {} seconds, {} bytes".format(bottle.request, end_time - start_time, len(result)))
         return result
     except Exception as e:

--- a/src/helm/proxy/services/remote_service.py
+++ b/src/helm/proxy/services/remote_service.py
@@ -22,6 +22,7 @@ from helm.common.tokenization_request import (
 )
 from helm.common.request import Request, RequestResult
 from dacite import from_dict
+from helm.benchmark.model_metadata_registry import DACITE_CONFIG
 from helm.proxy.accounts import Account
 from helm.proxy.query import Query, QueryResult
 from helm.proxy.services.service import Service, GeneralInfo
@@ -48,7 +49,9 @@ class RemoteService(Service):
 
     def get_general_info(self) -> GeneralInfo:
         response = requests.get(f"{self.base_url}/api/general_info").json()
-        return from_dict(GeneralInfo, response)
+        # GeneralInfo contains ModelMetadata, which has a `release_date` date field
+        # that dacite needs the DACITE_CONFIG type hook to reconstruct from a string.
+        return from_dict(GeneralInfo, response, config=DACITE_CONFIG)
 
     def expand_query(self, query: Query) -> QueryResult:
         params = asdict(query)


### PR DESCRIPTION
Fixes #2158.

ModelMetadata carries an Optional[date] release_date field, and the json standard library cannot round trip a date. The proxy server serialized every response with json.dumps, which raised the moment a result contained a date, and the remote service rebuilt dataclasses with dacite from_dict, which left the date as a plain string. This broke GeneralInfo and any other dataclass that contains ModelMetadata transitively.

This change fixes both sides of the trip.

On the serialize side, the proxy server safe_call now passes the existing serialize_dates helper from helm.common.general as the json.dumps default, so a date is written as an ISO format string. This is the same helper the codebase already uses for date serialization, so the proxy now matches the rest of the project.

On the deserialize side, model_metadata_registry defines a shared DACITE_CONFIG that adds a dacite type hook parsing the string back with date.fromisoformat. The remote service imports that config and passes it to from_dict when it reconstructs GeneralInfo, so the release_date string becomes a real date again. The hook only fires for actual date values, so a None release_date passes through untouched.

A new unit test serializes a ModelMetadata with a release_date, deserializes it, and asserts the result equals the original, which is the round trip the issue asked for.

The issue also mentions ModelField. There is no ModelField dataclass in the current tree, so this change targets the ModelMetadata and GeneralInfo path that exists today.

Verification. I ran the single new test in an isolated venv under the repo's own pytest configuration and it passes. I also confirmed the bug repro directly, that plain json.dumps on a date raises and that from_dict without the type hook raises a dacite WrongTypeError, and that both go away with the fix. black, flake8, and mypy all pass on the changed files.
