### PR TITLE
Remove python_version specifiers from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -273,10 +273,8 @@ heim = [
     # HEIM models
     "diffusers~=0.34.0",
     "icetk~=0.0.4",
-    "jax~=0.6.2; python_version >= '3.10'",
-    "jax~=0.4.30; python_version < '3.10'",
-    "jaxlib~=0.6.2; python_version >= '3.10'",
-    "jaxlib~=0.4.30; python_version < '3.10'",
+    "jax~=0.6.2",
+    "jaxlib~=0.6.2",
     "crfm-helm[openai]",
 
     # For model, kakaobrain/mindall-e
@@ -285,8 +283,7 @@ heim = [
     "pytorch-lightning~=2.0",
 
     # For model, craiyon/dalle-mini and craiyon/dalle-mega
-    "flax~=0.10.7; python_version >= '3.10'",
-    "flax~=0.8.5; python_version < '3.10'",
+    "flax~=0.10.7",
     "ftfy~=6.1",
     "Unidecode~=1.3",
     "wandb~=0.25",
@@ -302,8 +299,7 @@ heim = [
     "multilingual-clip~=1.0",
     "NudeNet~=2.0",
     "numpy>=1.26",
-    "opencv-python>=4.7.0.68,<4.8.2.0; python_version >= '3.10'",
-    "opencv-python-headless>=4.7.0.68,<=4.11.0.86; python_version < '3.10'",
+    "opencv-python>=4.7.0.68,<4.8.2.0",
     "pytorch-fid~=0.3.0",
     "tensorflow~=2.11",
     "timm~=0.6.12",


### PR DESCRIPTION
These `python_version` specifiers are no longer needed since only Python 3.10 or later is supported