### PR TITLE
Validate schema has no unreferenced metrics or metric groups

### DIFF
--- a/src/helm/benchmark/presentation/schema.py
+++ b/src/helm/benchmark/presentation/schema.py
@@ -382,7 +382,7 @@ def validate_schema(
     schema_path: Optional[str] = None,
     strict: bool = True,
     check_parent_child_partition: bool = False,
-    check_orphan_children: bool = False,
+    check_orphan_children: bool = True,
 ) -> List[SchemaValidationMessage]:
     """Validate a Schema object and return a list of validation messages.
 
@@ -589,6 +589,29 @@ def validate_schema(
                 add_warning(
                     f"Child run_group '{run_group.name}' is not referenced by any parent",
                     location=f"run_groups[{run_group.name}]",
+                )
+
+        referenced_metric_groups: Set[str] = set()
+        for run_group in run_groups:
+            referenced_metric_groups |= set(run_group.metric_groups)
+        for metric_group in metric_groups:
+            if metric_group.name not in referenced_metric_groups:
+                add_warning(
+                    f"Metric group '{metric_group.name}' is not referenced by any run group",
+                    location=f"metric_groups[{metric_group.name}]",
+                )
+
+        referenced_metrics: Set[str] = set()
+        for metric_group in metric_groups:
+            for metric_matcher in metric_group.metrics:
+                referenced_metrics.add(metric_matcher.name)
+        for run_group in run_groups:
+            referenced_metrics |= set(run_group.environment.values())
+        for metric in metrics:
+            if metric.name not in referenced_metrics:
+                add_warning(
+                    f"Metric '{metric.name}' is not referenced by any metric group",
+                    location=f"metrics[{metric.name}]",
                 )
 
     if strict:

--- a/src/helm/benchmark/presentation/summarize.py
+++ b/src/helm/benchmark/presentation/summarize.py
@@ -31,7 +31,7 @@ from helm.common.general import (
     unique_simplification,
 )
 from helm.common.codec import from_json
-from helm.common.hierarchical_logger import hlog, htrack, htrack_block, hwarn, setup_default_logging
+from helm.common.hierarchical_logger import hlog, htrack, htrack_block, hwarn, herror, setup_default_logging
 from helm.benchmark.scenarios.scenario import Scenario, ScenarioMetadata, ScenarioSpec, create_scenario
 from helm.benchmark.adaptation.adapter_spec import AdapterSpec
 from helm.benchmark.metrics.metric_name import MetricName
@@ -1377,10 +1377,16 @@ class Summarizer:
             hwarn(f"Schema validation warning: {msg}")
 
         for msg in errors:
-            hlog(f"Schema validation error: {msg}")
+            herror(f"Schema validation error: {msg}")
 
         if messages:
-            hlog(f"Schema validation complete: {len(errors)} error(s), {len(warnings)} warning(s)")
+            schema_validation_message = (
+                f"Schema validation complete: {len(errors)} error(s), {len(warnings)} warning(s)"
+            )
+            if errors:
+                herror(schema_validation_message)
+            elif warnings:
+                hwarn(schema_validation_message)
 
         # Raise error if in "error" mode and there are errors
         if self.schema_validation == "error" and errors:


### PR DESCRIPTION
This changes the schema validation to check for metrics that are not referenced in any metric group, or metric groups that are not referenced in any run group.

Other minor changes:

- Check for unreferenced objects by default
- Use error severity level for logged validation messages when appropriate