### PR TITLE
docs: fix incorrect command name in helm-server tutorial description

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -57,7 +57,7 @@ Additionally, for each group and group-relavent metric, it will output a pair of
 
 ## Using `helm-server`
 
-Finally, the `helm-server` command launches a web server to visualize the output files of `helm-run` and `helm-benchmark`. Run:
+Finally, the `helm-server` command launches a web server to visualize the output files of `helm-run` and `helm-summarize`. Run:
 
 ```sh
 helm-server --suite my-suite


### PR DESCRIPTION
## Summary

Fixes #4306.

The `helm-server` section in `docs/tutorial.md` stated:

> Finally, the `helm-server` command launches a web server to visualize the output files of `helm-run` and `helm-benchmark`.

`helm-benchmark` does not exist as a CLI entry point. Per `pyproject.toml`, the correct commands are `helm-run`, `helm-summarize`, and `helm-server`. The command that reads `helm-run` output and prepares summary files (described in the preceding section) is `helm-summarize`.

## Change

- `docs/tutorial.md` line 60: `helm-benchmark` → `helm-summarize`

## Test plan

- [ ] Grep confirms no remaining `helm-benchmark` references in the repo
- [ ] Tutorial workflow is now internally consistent: `helm-run` → `helm-summarize` → `helm-server`