### PR TITLE
fix(metrics): f1_score silently returns 0 when gold/pred is a single article word (#2298)

### DIFF
--- a/src/helm/benchmark/metrics/evaluate_reference_metrics.py
+++ b/src/helm/benchmark/metrics/evaluate_reference_metrics.py
@@ -121,7 +121,22 @@ def quasi_prefix_exact_match(gold: str, pred: str) -> float:
 
 
 def f1_score(gold: str, pred: str) -> float:
-    ret = f_measure(set(normalize_text(gold).split()), set(normalize_text(pred).split()))
+    gold_tokens = set(normalize_text(gold).split())
+    pred_tokens = set(normalize_text(pred).split())
+
+    # normalize_text removes English articles ("a", "an", "the").  When the
+    # entire gold or pred string consists of one of those words (e.g. the gold
+    # answer is the letter "A" in a multiple-choice benchmark, or a short
+    # phrase like "An apple"), article removal empties the token set and
+    # f_measure returns None, producing a silently wrong score of 0.0 for a
+    # correct prediction.  Fall back to article-preserving normalization
+    # whenever either token set would otherwise be empty.
+    if not gold_tokens:
+        gold_tokens = set(normalize_text(gold, should_remove_articles=False).split())
+    if not pred_tokens:
+        pred_tokens = set(normalize_text(pred, should_remove_articles=False).split())
+
+    ret = f_measure(gold_tokens, pred_tokens)
     if ret is None:  # answer is the empty string after normalizing
         return 0.0
 

--- a/src/helm/benchmark/metrics/test_evaluate_reference_metrics.py
+++ b/src/helm/benchmark/metrics/test_evaluate_reference_metrics.py
@@ -4,6 +4,7 @@ from helm.benchmark.metrics.evaluate_reference_metrics import (
     chinese_bleu_1,
     exact_match,
     exact_match_indicator,
+    f1_score,
     final_number_exact_match,
 )
 
@@ -43,3 +44,38 @@ def test_chinese_bleu_1():
     assert chinese_bleu_1(
         "太祖武皇帝，沛國譙人也，姓曹，諱操，字孟德，漢相國參之後。", "太祖武皇帝，沛國譙人也，漢相國參之後。"
     ) == pytest.approx(0.5907775139012316)
+
+
+def test_f1_score_normal():
+    # Standard QA: partial overlap
+    assert f1_score("the cat sat on the mat", "the cat sat") == pytest.approx(2 / 3)
+    # Identical strings
+    assert f1_score("quick brown fox", "quick brown fox") == pytest.approx(1.0)
+    # No overlap
+    assert f1_score("cat", "dog") == pytest.approx(0.0)
+
+
+def test_f1_score_article_gold():
+    # Regression for issue #2298: gold is a single English article letter.
+    # Before the fix, normalize_text("A") → "" and f1_score returned 0.0 even
+    # when the prediction was also "A".
+    assert f1_score("A", "A") == pytest.approx(1.0)
+    assert f1_score("A", "B") == pytest.approx(0.0)
+    assert f1_score("An", "An") == pytest.approx(1.0)
+    assert f1_score("The", "The") == pytest.approx(1.0)
+    # Pred is the article, gold is not
+    assert f1_score("cat", "a") == pytest.approx(0.0)
+
+
+def test_f1_score_article_in_longer_string():
+    # Article removal in a multi-word string should still apply (existing behavior).
+    # "a cat" → "cat" after normalization; "the cat" → "cat"; both match.
+    assert f1_score("a cat", "the cat") == pytest.approx(1.0)
+    # Extra non-article words lower the score.
+    assert f1_score("a cat sat", "a cat") == pytest.approx(2 / 3)
+
+
+def test_f1_score_empty_pred():
+    # Empty prediction always yields 0.
+    assert f1_score("cat", "") == pytest.approx(0.0)
+    assert f1_score("A", "") == pytest.approx(0.0)


### PR DESCRIPTION
## What

`f1_score` calls `normalize_text()` on both gold and pred before computing
token overlap. `normalize_text` strips English articles (`a`, `an`, `the`)
via `re.sub(r"\b(a|an|the)\b", ...)`.

When the gold (or pred) string is *entirely* one of those words — for
example, the letter **`"A"`** in a multiple-choice benchmark like MMLU —
article removal produces an empty string. `set("".split()) == set()`, and
`nltk.metrics.scores.f_measure(set(), ...)` returns `None`, which
`f1_score` silently maps to `0.0`.

**Concrete failure** (pre-fix):
```python
>>> f1_score("A", "A")
0.0   # should be 1.0
>>> f1_score("An", "An")
0.0   # should be 1.0
```

Any benchmark that reports `f1_score` alongside single-letter gold answers
(MMLU, ARC, HellaSwag …) will show 0.0 for correct predictions.  The same
bug applies to the pred side, and to non-English benchmarks where `"a"` is
a meaningful token rather than an English article.

## Fix

`src/helm/benchmark/metrics/evaluate_reference_metrics.py`

After computing the normalised token sets, if either set is empty, retry
with `should_remove_articles=False` before calling `f_measure`.  Strings
that contain articles alongside other tokens are unaffected — article
removal fires as before.

```python
# Before (one line):
ret = f_measure(set(normalize_text(gold).split()), set(normalize_text(pred).split()))

# After:
gold_tokens = set(normalize_text(gold).split())
pred_tokens = set(normalize_text(pred).split())
if not gold_tokens:
    gold_tokens = set(normalize_text(gold, should_remove_articles=False).split())
if not pred_tokens:
    pred_tokens = set(normalize_text(pred, should_remove_articles=False).split())
ret = f_measure(gold_tokens, pred_tokens)
```

## Tests

`src/helm/benchmark/metrics/test_evaluate_reference_metrics.py` — four new
test functions (no prior `f1_score` coverage existed):

| Test | Checks |
|---|---|
| `test_f1_score_normal` | Baseline partial-overlap and no-overlap cases |
| `test_f1_score_article_gold` | Regression: `"A"/"An"/"The"` as gold — now scores 1.0 for a correct pred |
| `test_f1_score_article_in_longer_string` | Multi-word strings: article removal still fires |
| `test_f1_score_empty_pred` | Empty prediction still yields 0 |

Fixes #2298